### PR TITLE
Added a Makefile and better docker support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+TOOLS = docker-compose run --rm tools
+CONSOLE = ./bin/console
+
+all: boot install assets run
+
+boot:
+	docker-compose up -d
+
+install:
+	$(TOOLS) sh -c "composer install && yarn install"
+
+assets:
+	$(TOOLS) sh -c "npm run build-dev"
+
+run:
+	$(CONSOLE) server:run
+
+watch:
+	$(TOOLS) npm run watch
+
+test:
+	$(TOOLS) ./vendor/bin/simple-phpunit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,10 @@ services:
         ports:
             - "9025:1025"
             - "9080:1080"
+
+    tools:
+        build: ./docker/tools
+        depends_on:
+            - mysql
+        volumes:
+            - .:/www

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,0 +1,53 @@
+FROM php:7.1-cli
+
+ENV NODE_VERSION 6.0.0
+
+RUN buildDeps=" \
+        build-essential \
+        libmcrypt-dev \
+        libgcrypt11-dev \
+        libpng12-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libgmp-dev \
+        libicu-dev \
+        zlib1g-dev \
+    " \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        $buildDeps \
+        vim \
+        libicu52 \
+        libmcrypt4 \
+        libjpeg62-turbo \
+        libfreetype6 \
+        ssl-cert \
+        graphviz \
+    && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-configure gmp --with-gmp=/usr/include/x86_64-linux-gnu/ \
+    && docker-php-ext-install gmp mcrypt mbstring intl pdo_mysql zip opcache \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd bcmath \
+    && pecl install -f xdebug \
+    && echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so' > $PHP_INI_DIR/conf.d/xdebug.ini \
+    && pecl install apcu-5.1.7 && docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini \
+    && pecl install apcu_bc-1.0.3 && docker-php-ext-enable apc --ini-name 20-docker-php-ext-apcu.ini \
+    && rm /usr/include/gmp.h \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# PHP conf
+COPY php.ini $PHP_INI_DIR/conf.d/z_docker.ini
+
+RUN curl -k -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Directory of the application
+WORKDIR /www
+
+# NodeJS
+RUN curl -L -o /tmp/nodejs.tar.gz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \
+    && tar xfvz /tmp/nodejs.tar.gz -C /usr/local --strip-components=1 \
+    && rm -r /tmp/nodejs.tar.gz \
+    && npm install yarn -g

--- a/docker/tools/php.ini
+++ b/docker/tools/php.ini
@@ -1,0 +1,4 @@
+; Add here the parameter that you want to override
+short_open_tag=Off
+date.timezone='Europe/Paris'
+error_log='/proc/self/fd/2'

--- a/docs/1. Installer le projet en local.md
+++ b/docs/1. Installer le projet en local.md
@@ -19,10 +19,18 @@ n'hésitez pas à nous poser la question [sur Slack](https://slack.en-marche.fr)
 
 Les services/outils suivants sont nécessaires pour développer :
  
-- MariaDB 5.5+
 - PHP 7.0+
-- Composer
-- nodeJS/npm/yarn
+- MariaDB 5.5+ (ou Docker/Docker compose)
+- Composer (ou Docker/Docker compose)
+- nodeJS/npm/yarn (ou Docker/Docker Compose)
+
+Si vous avez Docker, installez et lancez le projet simplement avec :
+```bash
+$ cd /chemin/vers/le/projet
+$ make
+
+...
+```
 
 ### a. MariaDB
 
@@ -31,10 +39,10 @@ Deux méthodes de mise en place sont disponibles : en utilisant Docker ou à la 
 
 #### Docker et docker-compose
 
-Si vous utilisez Docker et docker-compose, il est aisé de démarrer un serveur MariaDB : lancez simplement
-à la racine du projet la commande `docker-compose up -d`. Cela créera un serveur MariaDB accessible sur
-le port 3306 de votre machine (si vous êtes sous Mac OS ou Windows, vous aurez besoin de travailler
-avec l'IP de votre machine virtuelle).
+Si vous utilisez Docker et docker-compose, il est aisé de démarrer un serveur MariaDB :
+lancez simplement ``make boot`` à la racine du projet ou la commande `docker-compose up -d`.
+Cela créera un serveur MariaDB accessible sur le port 3306 de votre machine (si vous êtes sous Mac OS ou Windows,
+vous aurez besoin de travailler avec l'IP de votre machine virtuelle).
 
 Si vous utilisez Docker, la base de donnée sera configurée automatiquement.
 
@@ -72,6 +80,8 @@ Composer version 1.2.1 2016-09-12 11:27:19
 
 ### d. nodeJS/npm/yarn
 
+** Cette étape est optionnelle si vous avez Docker **
+
 nodeJS est requis pour compiler le SASS et le JSX en des fichiers utilisables par la plupart des navigateurs.
 
 Installez nodeJS pour votre plateforme sur https://nodejs.org/en/download/ ou en utilisant votre gestionnaire de
@@ -79,7 +89,7 @@ paquets préféré.
 
 Pour vérifier que vous avez bien nodejs et npm installés, lancez les commandes suivantes :
 
-```
+```bash
 $ node --version
 v6.9.1
 
@@ -90,7 +100,7 @@ $ npm --version
 Une fois npm disponible, utilisez le pour installer yarn (le gestionnaire de dépendance utilisé par le projet,
 vous aurez peut-être besoin d'exécuter cette commande en root) :
 
-```
+```bash
 $ npm install -g yarn
 
 # Pour vérifier l'installation
@@ -104,14 +114,17 @@ Une fois que vous avez PHP, MySQL/MariaDB, Composer et nodeJS/yarn installés, v
 
 ### a. Installer les dépendances PHP du projet
 
-Allez dans le dossier du projet et lancez Composer comme suis :
+Si vous avez Docker, lancez simplement ``make install`` à la racine du projet.
 
-```
+Sinon, allez dans le dossier du projet et lancez Composer comme suis :
+
+```bash
 $ cd /chemin/vers/le/projet
 $ composer install
 
 ...
 ```
+
 
 Composer vous demandera des informations sur la base de donnée, le mailer et autre. A moins que vous ayez modifié les
 valeurs de configuration lors de l'étape d'installation, vous pouvez appuyer sur Entrée pour choisir la valeur proposée par
@@ -162,18 +175,22 @@ venir [sur Slack](https://slack.en-marche.fr) pour nous poser vos questions.
 
 ### b. Installer les dépendances Javascript du projet
 
-Allez dans le dossier du projet et lancez Yarn comme suis :
+Si vous avez Docker, lancez simplement ``make install`` à la racine du projet.
 
-```
+Sinon, allez dans le dossier du projet et lancez Yarn comme suis :
+
+```bash
 $ cd /chemin/vers/le/projet
 $ yarn install
 ```
 
 ### c. Compiler le CSS et le Javascript de développement
 
+Si vous avez Docker, lancez simplement ``make assets`` à la racine du projet.
+
 Allez dans le dossier du projet et lancez le script de build comme suis :
 
-```
+```bash
 $ cd /chemin/vers/le/projet
 $ npm run build-dev
 ```
@@ -186,7 +203,7 @@ de la plateforme dans le dossier `web/built`.
 Une fois les dépendances du projet installées et prêtes (vous devriez désormais voir un dossier `vendor` dans le
 dossier du projet), vous pouvez lancer le serveur de développement :
 
-```
+```bash
 $ cd /chemin/vers/le/projet
 $ php bin/console server:run
 
@@ -211,7 +228,9 @@ sûrement que vos changements soient pris en compte en temps réel. Cela vous
 permettra de ne pas avoir à relancer la compilation du CSS et du Javascript 
 après chaque modification de code.
 
-```
+Si vous avez Docker, lancer simplement ``make watch`` à la racine du projet, sinon :
+
+```bash
 $ cd /chemin/vers/le/projet
 $ npm run watch
 ```


### PR DESCRIPTION
Démarrer le projet :
```bash
make
```

La commande au-dessus execute toutes celles en-dessous (hormis "watch" et "test").

Builder et lancer docker :
```bash
make boot
```

Installer les dépendances PHP et JS :
```bash
make install
```

Générer les assets :
```bash
make assets
```

Générer les assets en temps réel :
```bash
make watch
```

Lancer le serveur PHP :
```bash
make run
```

Lancer les tests :
```bash
make test
```