### PR TITLE
Add support of MySQL tests

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -34,7 +34,7 @@ class AppKernel extends Kernel
             new AppBundle\AppBundle(),
         ];
 
-        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
+        if (in_array($this->getEnvironment(), ['dev', 'test', 'test_sqlite', 'test_mysql'], true)) {
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -41,15 +41,6 @@ parameters:
         securite: Sécurité
         territoire: Territoire
 
-liip_functional_test:
-    cache_sqlite_db: true
-
-doctrine:
-    dbal:
-        driver:      pdo_sqlite
-        charset:     UTF8
-        path:        "%kernel.root_dir%/../var/cache/test/data.db"
-
 framework:
     test: ~
     session:

--- a/app/config/config_test_mysql.yml
+++ b/app/config/config_test_mysql.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: config_test.yml }
+
+parameters:
+    env(DATABASE_HOST): "testdb"
+    env(DATABASE_NAME): "enmarche_test"
+    env(DATABASE_USER): "enmarche_test"
+    env(DATABASE_PASSWORD): "enmarche_test"

--- a/app/config/config_test_sqlite.yml
+++ b/app/config/config_test_sqlite.yml
@@ -1,0 +1,10 @@
+imports:
+    - { resource: config_test.yml }
+
+liip_functional_test:
+    cache_sqlite_db: true
+
+doctrine:
+    dbal:
+        driver:      pdo_sqlite
+        path:        "/tmp/data.db"

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,10 @@ machine:
     environment:
         YARN_VERSION: 0.18.1
         PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+        DATABASE_HOST: 127.0.0.1
+        DATABASE_USER: ubuntu
+        DATABASE_PASSWORD: ''
+        DATABASE_NAME: circle_test
     services:
         - docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,14 @@ services:
             MYSQL_USER: enmarche
             MYSQL_PASSWORD: enmarche
 
+    testdb:
+        image: mysql:5.7
+        environment:
+            MYSQL_ROOT_PASSWORD: enmarche_test
+            MYSQL_DATABASE: enmarche_test
+            MYSQL_USER: enmarche_test
+            MYSQL_PASSWORD: enmarche_test
+
     redis:
         image: redis:3.2
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
 
     <testsuites>

--- a/src/AppBundle/Donation/PayboxFormFactory.php
+++ b/src/AppBundle/Donation/PayboxFormFactory.php
@@ -37,7 +37,7 @@ class PayboxFormFactory
             'PBX_REPONDRE_A' => $this->router->generate('lexik_paybox_ipn', ['time' => time()], UrlGeneratorInterface::ABSOLUTE_URL),
         ];
 
-        if ($this->environment === 'test') {
+        if ('test_sqlite' === $this->environment || 'test_mysql' === $this->environment) {
             $parameters = array_merge($parameters, [
                 'PBX_EFFECTUE' => 'https://httpbin.org/status/200',
                 'PBX_REFUSE' => 'https://httpbin.org/status/200',

--- a/tests/AppBundle/Committee/CommitteeManagerTest.php
+++ b/tests/AppBundle/Committee/CommitteeManagerTest.php
@@ -5,11 +5,11 @@ namespace Tests\AppBundle\Committee;
 use AppBundle\Committee\CommitteeManager;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Entity\Committee;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Ramsey\Uuid\Uuid;
+use Tests\AppBundle\SqliteWebTestCase;
 use Tests\AppBundle\TestHelperTrait;
 
-class CommitteeManagerTest extends WebTestCase
+class CommitteeManagerTest extends SqliteWebTestCase
 {
     use TestHelperTrait;
 

--- a/tests/AppBundle/Controller/AdherentControllerTest.php
+++ b/tests/AppBundle/Controller/AdherentControllerTest.php
@@ -9,11 +9,11 @@ use AppBundle\Mailjet\Message\CommitteeCreationConfirmationMessage;
 use AppBundle\Membership\AdherentEmailSubscription;
 use AppBundle\Repository\CommitteeRepository;
 use AppBundle\Repository\MailjetEmailRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class AdherentControllerTest extends WebTestCase
+class AdherentControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -434,7 +434,7 @@ class AdherentControllerTest extends WebTestCase
             LoadAdherentData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
         $this->container = $this->client->getContainer();
         $this->committeeRepository = $this->getCommitteeRepository();
         $this->emailRepository = $this->getMailjetEmailRepository();

--- a/tests/AppBundle/Controller/Api/IntlControllerTest.php
+++ b/tests/AppBundle/Controller/Api/IntlControllerTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\AppBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class IntlControllerTest extends WebTestCase
+class IntlControllerTest extends SqliteWebTestCase
 {
     public function testGetPostalCode()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
         $client->request(Request::METHOD_GET, '/api/postal-code/35420');
 
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -5,11 +5,11 @@ namespace Tests\AppBundle\Controller;
 use AppBundle\DataFixtures\ORM\LoadArticleData;
 use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class ArticleControllerTest extends WebTestCase
+class ArticleControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -47,7 +47,7 @@ class ArticleControllerTest extends WebTestCase
             LoadLiveLinkData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
     }
 
     protected function tearDown()

--- a/tests/AppBundle/Controller/ControllerTestTrait.php
+++ b/tests/AppBundle/Controller/ControllerTestTrait.php
@@ -56,7 +56,7 @@ trait ControllerTestTrait
 
     protected function init(array $fixtures = [])
     {
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
         $this->container = $this->client->getContainer();
         $this->manager = $this->container->get('doctrine.orm.entity_manager');
     }

--- a/tests/AppBundle/Controller/DonationControllerTest.php
+++ b/tests/AppBundle/Controller/DonationControllerTest.php
@@ -6,11 +6,11 @@ use AppBundle\Entity\Donation;
 use AppBundle\Repository\DonationRepository;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Goutte\Client as PayboxClient;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class DonationControllerTest extends WebTestCase
+class DonationControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -120,21 +120,13 @@ class DonationControllerTest extends WebTestCase
         $this->assertNotNull($donation->getDonatedAt());
         $this->assertSame('00000', $donation->getPayboxResultCode());
         $this->assertSame('XXXXXX', $donation->getPayboxAuthorizationCode());
-
-        /*
-         * Check callback redirect to success page
-         */
-        $callbackUrl = str_replace('https://httpbin.org/status/200', '/don/callback', $mockUrl);
-
-        // $symfonyClient->request('GET', $callbackUrl);
-        // $this->assertEquals(302, $symfonyClient->getResponse()->getStatusCode());
     }
 
     protected function setUp()
     {
         parent::setUp();
 
-        $this->appClient = static::createClient();
+        $this->appClient = $this->makeClient();
         $this->payboxClient = new PayboxClient();
         $this->container = $this->appClient->getContainer();
         $this->donationRepository = $this->getDonationRepository();

--- a/tests/AppBundle/Controller/EventsControllerTest.php
+++ b/tests/AppBundle/Controller/EventsControllerTest.php
@@ -2,17 +2,17 @@
 
 namespace Tests\AppBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class EventsControllerTest extends WebTestCase
+class EventsControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
     public function testIndexActionIsSecured()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
         $client->request(Request::METHOD_GET, '/evenements');
 
         $this->assertResponseStatusCode(Response::HTTP_OK, $client->getResponse());

--- a/tests/AppBundle/Controller/HomeControllerTest.php
+++ b/tests/AppBundle/Controller/HomeControllerTest.php
@@ -4,11 +4,11 @@ namespace Tests\AppBundle\Controller;
 
 use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class HomeControllerTest extends WebTestCase
+class HomeControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -43,7 +43,7 @@ class HomeControllerTest extends WebTestCase
             LoadLiveLinkData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
     }
 
     protected function tearDown()

--- a/tests/AppBundle/Controller/InvitationControllerTest.php
+++ b/tests/AppBundle/Controller/InvitationControllerTest.php
@@ -3,13 +3,13 @@
 namespace Tests\AppBundle\Controller;
 
 use AppBundle\Entity\Invite;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use AppBundle\Repository\InvitationRepository;
 use Symfony\Bundle\FrameworkBundle\Client;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class InvitationControllerTest extends WebTestCase
+class InvitationControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -69,7 +69,7 @@ class InvitationControllerTest extends WebTestCase
 
         $this->loadFixtures([]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
         $this->container = $this->client->getContainer();
         $this->invitationRepository = $this->getInvitationRepository();
     }

--- a/tests/AppBundle/Controller/MembershipControllerTest.php
+++ b/tests/AppBundle/Controller/MembershipControllerTest.php
@@ -13,11 +13,11 @@ use AppBundle\Repository\AdherentRepository;
 use AppBundle\Repository\MailjetEmailRepository;
 use AppBundle\Entity\Donation;
 use AppBundle\Membership\MembershipUtils;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class MembershipControllerTest extends WebTestCase
+class MembershipControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/AppBundle/Controller/NewsletterControllerTest.php
+++ b/tests/AppBundle/Controller/NewsletterControllerTest.php
@@ -4,13 +4,13 @@ namespace Tests\AppBundle\Controller;
 
 use AppBundle\Entity\NewsletterSubscription;
 use AppBundle\Repository\NewsletterSubscriptionRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class NewsletterControllerTest extends WebTestCase
+class NewsletterControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -88,7 +88,7 @@ class NewsletterControllerTest extends WebTestCase
             LoadHomeBlockData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
         $this->container = $this->client->getContainer();
         $this->subscriptionsRepository = $this->getNewsletterSubscriptionRepository();
     }

--- a/tests/AppBundle/Controller/PageControllerTest.php
+++ b/tests/AppBundle/Controller/PageControllerTest.php
@@ -4,11 +4,11 @@ namespace Tests\AppBundle\Controller;
 
 use AppBundle\DataFixtures\ORM\LoadPageData;
 use AppBundle\DataFixtures\ORM\LoadProposalData;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class PageControllerTest extends WebTestCase
+class PageControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -54,7 +54,7 @@ class PageControllerTest extends WebTestCase
             LoadProposalData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
     }
 
     protected function tearDown()

--- a/tests/AppBundle/Controller/Security/AdherentSecurityControllerTest.php
+++ b/tests/AppBundle/Controller/Security/AdherentSecurityControllerTest.php
@@ -7,12 +7,12 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Mailjet\Message\AdherentResetPasswordMessage;
 use AppBundle\Repository\AdherentRepository;
 use AppBundle\Repository\MailjetEmailRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class AdherentSecurityControllerTest extends WebTestCase
+class AdherentSecurityControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
@@ -99,7 +99,7 @@ class AdherentSecurityControllerTest extends WebTestCase
 
     public function testRetrieveForgotPasswordAction()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
 
         $crawler = $client->request(Request::METHOD_GET, '/espace-adherent/mot-de-passe-oublie');
 
@@ -111,7 +111,7 @@ class AdherentSecurityControllerTest extends WebTestCase
 
     public function testRetrieveForgotPasswordActionWithEmptyEmail()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
 
         $crawler = $client->request(Request::METHOD_GET, '/espace-adherent/mot-de-passe-oublie');
 
@@ -128,7 +128,7 @@ class AdherentSecurityControllerTest extends WebTestCase
 
     public function testRetrieveForgotPasswordActionWithUnknownEmail()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
 
         $crawler = $client->request(Request::METHOD_GET, '/espace-adherent/mot-de-passe-oublie');
 
@@ -150,7 +150,7 @@ class AdherentSecurityControllerTest extends WebTestCase
 
     public function testRetrieveForgotPasswordActionWithKnownEmailSendEmail()
     {
-        $client = static::createClient();
+        $client = $this->makeClient();
 
         $crawler = $client->request(Request::METHOD_GET, '/espace-adherent/mot-de-passe-oublie');
 
@@ -173,7 +173,7 @@ class AdherentSecurityControllerTest extends WebTestCase
 
     public function testResetPasswordAction()
     {
-        $client = $this->client = static::createClient();
+        $client = $this->client = $this->makeClient();
         $adherent = $this->getAdherentRepository()->findByEmail('michelle.dufour@example.ch');
         $token = $this->getFirstAdherentResetPasswordToken();
         $oldPassword = $adherent->getPassword();

--- a/tests/AppBundle/Controller/Security/AdminSecurityControllerTest.php
+++ b/tests/AppBundle/Controller/Security/AdminSecurityControllerTest.php
@@ -3,13 +3,13 @@
 namespace Tests\AppBundle\Controller\Security;
 
 use AppBundle\DataFixtures\ORM\LoadAdminData;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class AdminSecurityControllerTest extends WebTestCase
+class AdminSecurityControllerTest extends SqliteWebTestCase
 {
     /* @var Client */
     private $client;
@@ -88,7 +88,7 @@ class AdminSecurityControllerTest extends WebTestCase
             LoadAdminData::class,
         ]);
 
-        $this->client = static::createClient();
+        $this->client = $this->makeClient();
         $this->container = $this->client->getContainer();
     }
 

--- a/tests/AppBundle/MysqlWebTestCase.php
+++ b/tests/AppBundle/MysqlWebTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\AppBundle;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+abstract class MysqlWebTestCase extends WebTestCase
+{
+    protected $environment = 'test_mysql';
+}

--- a/tests/AppBundle/Repository/AdherentRepositoryTest.php
+++ b/tests/AppBundle/Repository/AdherentRepositoryTest.php
@@ -5,10 +5,10 @@ namespace Tests\AppBundle\Repository;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Repository\AdherentRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class AdherentRepositoryTest extends WebTestCase
+class AdherentRepositoryTest extends SqliteWebTestCase
 {
     /**
      * @var AdherentRepository

--- a/tests/AppBundle/Repository/CommitteeMembershipRepositoryTest.php
+++ b/tests/AppBundle/Repository/CommitteeMembershipRepositoryTest.php
@@ -5,10 +5,10 @@ namespace Tests\AppBundle\Repository;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Entity\CommitteeMembership;
 use AppBundle\Repository\CommitteeMembershipRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class CommitteeMembershipRepositoryTest extends WebTestCase
+class CommitteeMembershipRepositoryTest extends SqliteWebTestCase
 {
     /**
      * @var CommitteeMembershipRepository

--- a/tests/AppBundle/Repository/CommitteeRepositoryTest.php
+++ b/tests/AppBundle/Repository/CommitteeRepositoryTest.php
@@ -4,10 +4,10 @@ namespace Tests\AppBundle\Repository;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Repository\CommitteeRepository;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
+use Tests\AppBundle\SqliteWebTestCase;
 
-class CommitteeRepositoryTest extends WebTestCase
+class CommitteeRepositoryTest extends SqliteWebTestCase
 {
     /**
      * @var CommitteeRepository

--- a/tests/AppBundle/SqliteWebTestCase.php
+++ b/tests/AppBundle/SqliteWebTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\AppBundle;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+abstract class SqliteWebTestCase extends WebTestCase
+{
+    protected $environment = 'test_sqlite';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,5 +2,8 @@
 
 require __DIR__.'/../app/autoload.php';
 
+echo 'Preparing database...';
 passthru('rm -rf var/cache/test');
-passthru('php bin/console doctrine:schema:create --quiet --env=test');
+passthru('php bin/console doctrine:schema:drop --quiet -f --env=test_mysql');
+passthru('php bin/console doctrine:schema:create --quiet --env=test_mysql');
+echo " Done\n";


### PR DESCRIPTION
This PR introduces two types of WebTestCase: one for SQLite and another for MySQL.

Usage: extends SqliteWebTestCase or MysqlWebTestCase. **Be careful** to use `makeClient` instead of `createClient`.

Example for MySQL:
``` php
<?php

namespace Tests\AppBundle\Controller;

use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
use Symfony\Component\HttpFoundation\Request;
use Tests\AppBundle\MysqlWebTestCase;

class MysqlControllerTest extends MysqlWebTestCase
{
    use ControllerTestTrait;

    public function testHome()
    {
        $this->client->request(Request::METHOD_GET, '/');
    }

    protected function setUp()
    {
        parent::setUp();

        $this->loadFixtures([
            LoadHomeBlockData::class,
            LoadLiveLinkData::class,
        ]);

        $this->client = $this->makeClient();
    }

    protected function tearDown()
    {
        $this->client = null;

        parent::tearDown();
    }
}
```