### PR TITLE
Fix layout issue on articles + keep fullscreen option for EM pages

### DIFF
--- a/app/Resources/views/article/article.html.twig
+++ b/app/Resources/views/article/article.html.twig
@@ -18,7 +18,7 @@
 
 {% block content %}
 <main>
-    <section class="content articles">
+    <section class="content">
         <header class="space--60-0 l__wrapper--slim">
             <h1 class="text--large b__nudge--bottom-small">
                 {{ article.title }}
@@ -49,7 +49,7 @@
         </figure>
         {% endif %}
 
-        <article>
+        <article class="l__wrapper--slim">
             {{ article.content|markdown }}
         </article>
 

--- a/app/Resources/views/page/emmanuel-macron/layout.html.twig
+++ b/app/Resources/views/page/emmanuel-macron/layout.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <main>
-        <section class="content emmanuel-macron articles">
+        <section class="content emmanuel-macron">
             <header class="filtered-image progressive-background"
                     data-sd="{{ static_asset('emmanuel-macron.jpg', {'w': 300, 'q': 20}) }}"
                     data-hd="{{ static_asset('emmanuel-macron.jpg', {'q': 70}) }}">

--- a/docs/content-styleguide.md
+++ b/docs/content-styleguide.md
@@ -29,26 +29,6 @@ Image aussi large que le reste de l'article (sa largeur doit être > 725px):
 </figure>
 ```
 
-Image fullscreen, aussi large que la page:
-```
-<figure class="fullscreen">
-    <img src="http://i.f1g.fr/media/figaro/1280x580_crop/2016/04/08/XVMe0a5d610-fd5d-11e5-bf72-58d0fa6caeec.jpg">
-</figure>
-```
-
-Image fullscreen avec un texte qui repose au dessus:
-
-Et si vous voulez que le texte soit blanc: `<p class="text--white">`.
-
-```
-<figure class="fullscreen">
-    <p>Mais ma vie, c’est aussi d’autres choses qu’il me semble utile de partager avec vous.</p>
-    <img src="http://i.f1g.fr/media/figaro/1280x580_crop/2016/04/08/XVMe0a5d610-fd5d-11e5-bf72-58d0fa6caeec.jpg">
-</figure>
-```
-
-Note: on peut ajouter des options de gradient si necessaire.
-
 Ajouter une legende:
 ```
 <figure>

--- a/docs/content-styleguide.md
+++ b/docs/content-styleguide.md
@@ -56,25 +56,21 @@ Si vous voulez l'attribuer un `figcaption` à l'interieur de la `figure`.
 
 Une citation courte, large et centrée:
 ```
-<figure>
-    <div class="blockquote--short">
-        <blockquote>
-            <span>«Tout commence par la rénovation de l’engagement politique.»</span>
-        </blockquote>
-        <figcaption>Emmanuel Macron, le 12 juillet 2016</figcaption>
-    </div>
+<figure class="blockquote--short">
+    <blockquote>
+        <span>«Tout commence par la rénovation de l’engagement politique.»</span>
+    </blockquote>
+    <figcaption>Emmanuel Macron, le 12 juillet 2016</figcaption>
 </figure>
 ```
 
 Une citation longue, présentée en bloc:
 ```
-<figure>
-    <div class="blockquote--long">
-        <blockquote>
-            <span>«Tout commence par la rénovation de l’engagement politique.»</span>
-        </blockquote>
-        <figcaption>Emmanuel Macron, le 12 juillet 2016</figcaption>
-    </div>
+<figure class="blockquote--long">
+    <blockquote>
+        <span>«Tout commence par la rénovation de l’engagement politique.»</span>
+    </blockquote>
+    <figcaption>Emmanuel Macron, le 12 juillet 2016</figcaption>
 </figure>
 ```
 

--- a/front/style/_content.scss
+++ b/front/style/_content.scss
@@ -123,9 +123,8 @@
     }
 
     ul {
-       padding-left: 90px;
-       margin-top: 14px;
-       margin-bottom: 14px;
+       padding-left: 40px;
+       margin-top: 14px 0;
 
         li {
            list-style-type: disc;
@@ -178,8 +177,7 @@
         justify-content: space-between;
         padding: 25px;
         background: $pink;
-        margin-top: 20px;
-        margin-bottom: 20px;
+        margin: 20px 0;
 
         &.blue {
             background: $blue;
@@ -306,8 +304,7 @@
     }
 
     figure {
-        margin-top: 40px;
-        margin-bottom: 40px;
+        margin: 40px 0;
 
         &.fullscreen {
             max-width: 100%;
@@ -353,7 +350,7 @@
             }
         }
 
-        .blockquote--short blockquote {
+        &.blockquote--short blockquote {
             @include text--large;
             @include text--bold;
             line-height: 42px; /* Overwrite text--large */
@@ -381,7 +378,7 @@
             }
         }
 
-        .blockquote--long {
+        &.blockquote--long {
             background: $blue--light;
             border-left: 5px solid $blue;
             margin: 0 40px;

--- a/front/style/_content.scss
+++ b/front/style/_content.scss
@@ -87,7 +87,7 @@
     }
 }
 
-.articles article {
+.emmanuel-macron article {
     > h1, > h2, > h3, > h4, > h5, > h6,
     > p, > ul, > ol, > div, > blockquote,
     > figure, > img, > iframe {


### PR DESCRIPTION
Un petit compromis puisqu'il n'y a pas de videos ou citations sur ces pages. 