### PR TITLE
Removes usage of undefined method

### DIFF
--- a/src/AppBundle/Asset/GoogleMapsStaticProvider.php
+++ b/src/AppBundle/Asset/GoogleMapsStaticProvider.php
@@ -72,11 +72,9 @@ class GoogleMapsStaticProvider
             $client = $this->client->request('GET', self::MAPS_API_ENDPOINT.'?'.$parameters);
 
             if (200 !== $client->getStatusCode()) {
-                throw new \Exception(sprintf(
-                    'Guzzle client status error: "%s" was returned with the reason "%s"',
-                    $client->getStatusCode(),
-                    $client->getReasonPhrase()
-                ));
+                throw new \Exception(
+                    sprintf('Guzzle client status error: "%s" was returned', $client->getStatusCode())
+                );
             }
 
             return $client->getBody()->getContents();


### PR DESCRIPTION
Don't ask me why, but usage of this method in this context produce the error:

```
[2017-02-10 10:57:16] php.CRITICAL: Call to undefined method GuzzleHttp\Exception\ConnectException::getReasonPhrase() {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to undefined method GuzzleHttp\\Exception\\ConnectException::getReasonPhrase() at /Users/Romain/Developer/en-marche/en-marche/vendor/csa/guzzle-bundle/src/DataCollector/GuzzleCollector.php:105)"} []
```