### PR TITLE
Fixed display of error message

### DIFF
--- a/app/Resources/views/security/adherent_reset_password.html.twig
+++ b/app/Resources/views/security/adherent_reset_password.html.twig
@@ -18,6 +18,7 @@
 
                         <div class="form__row">
                             {{ form_errors(form.password) }}
+                            {{ form_errors(form.password.first) }}
                             {{ form_widget(form.password.first, { attr: { class: 'form--full' } }) }}
                             {{ form_widget(form.password.second, { attr: { class: 'form--full' } }) }}
                         </div>


### PR DESCRIPTION
When using an invalid password (ie length < 8), the error was not displayed