### PR TITLE
Switch to the md5 encoder in test env to speed up tests

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -58,3 +58,14 @@ framework:
 web_profiler:
     toolbar: false
     intercept_redirects: false
+
+security:
+    encoders:
+        AppBundle\Entity\Administrator:
+            algorithm: md5
+            encode_as_base64: false
+            iterations: 0
+        AppBundle\Entity\Adherent:
+            algorithm: md5
+            encode_as_base64: false
+            iterations: 0


### PR DESCRIPTION
The test duration is divided by 3 now.