### PR TITLE
Optimize number of SQL queries whenever possible.

### DIFF
--- a/app/Resources/views/adherent/list_my_committees.html.twig
+++ b/app/Resources/views/adherent/list_my_committees.html.twig
@@ -6,7 +6,8 @@
 {% else %}
     <ul>
         {% for committee in committees %}
-            <li class="bullet {{ is_host(committee) ? 'bullet--own' : '' }}">
+            {# using the Adherent::isHostOf() method instead of a voter below prevents unneeded SQL queries #}
+            <li class="bullet {{ app.user.hostOf(committee) ? 'bullet--own' : '' }}">
                 <a href="{{ committee_path('app_committee_show', committee) }}"
                    title="{{ committee.name }}">
                     {{- committee.name -}}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -121,7 +121,11 @@
                             </div>
                             <div class="nav__user__menu">
                                 <div class="nav__user__menu__comites">
-                                    {{ render(controller('AppBundle:Adherent:listMyCommittees')) }}
+                                    {# Prerendering this block and saving it in a variable prevents extra SQL queries #}
+                                    {% set adherent_committees %}
+                                        {{ render(controller('AppBundle:Adherent:listMyCommittees')) }}
+                                    {% endset %}
+                                    {{ adherent_committees }}
                                 </div>
                                 <ul class="nav__user__menu__account">
                                     <li><a href="{{ path('app_search_events') }}">Tous les événements</a></li>
@@ -206,7 +210,7 @@
                         <hr>
                         {% if user_is_adherent %}
                             <div class="text--medium-small">
-                                {{ render(controller('AppBundle:Adherent:listMyCommittees')) }}
+                                {{ adherent_committees }}
                                 <hr>
                             </div>
                         {% endif %}

--- a/app/config/services/platform.xml
+++ b/app/config/services/platform.xml
@@ -158,13 +158,12 @@
         </service>
 
         <service id="app.voter.supervise_committee_voter" class="AppBundle\Committee\Voter\SuperviseCommitteeVoter" public="false">
-            <argument type="service" id="app.repository.committee_membership"/>
+            <argument type="service" id="app.committee.manager"/>
             <tag name="security.voter" priority="-1000"/>
         </service>
 
         <service id="app.voter.create_committee_voter" class="AppBundle\Committee\Voter\CreateCommitteeVoter" public="false">
-            <argument type="service" id="app.repository.committee_membership"/>
-            <argument type="service" id="app.repository.committee"/>
+            <argument type="service" id="app.committee.manager"/>
             <tag name="security.voter"/>
         </service>
 
@@ -173,17 +172,17 @@
         </service>
 
         <service id="app.voter.follow_committee_voter" class="AppBundle\Committee\Voter\FollowCommitteeVoter" public="false">
-            <argument type="service" id="app.repository.committee_membership"/>
+            <argument type="service" id="app.committee.manager"/>
             <tag name="security.voter"/>
         </service>
 
         <service id="app.voter.host_committee_voter" class="AppBundle\Committee\Voter\HostCommitteeVoter" public="false">
-            <argument type="service" id="app.repository.committee_membership"/>
+            <argument type="service" id="app.committee.manager"/>
             <tag name="security.voter"/>
         </service>
 
         <service id="app.voter.post_message_voter" class="AppBundle\Committee\Voter\PostMessageCommitteeVoter" public="false">
-            <argument type="service" id="app.repository.committee_membership"/>
+            <argument type="service" id="app.committee.manager"/>
             <tag name="security.voter"/>
         </service>
 

--- a/src/AppBundle/Collection/CommitteeCollection.php
+++ b/src/AppBundle/Collection/CommitteeCollection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Collection;
+
+use AppBundle\Entity\Committee;
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class CommitteeCollection extends ArrayCollection
+{
+    public function getOrderedCommittees(CommitteeMembershipCollection $memberships): self
+    {
+        $uuids = $memberships->getCommitteeSupervisorMemberships()->getCommitteeUuids();
+        $supervisedCommittees = $this->filter(function (Committee $committee) use ($uuids) {
+            return in_array((string) $committee->getUuid(), $uuids);
+        });
+
+        $uuids = $memberships->getCommitteeHostMemberships(CommitteeMembershipCollection::EXCLUDE_SUPERVISORS)->getCommitteeUuids();
+        $hostedCommittees = $this->filter(function (Committee $committee) use ($uuids) {
+            return in_array((string) $committee->getUuid(), $uuids);
+        });
+
+        $uuids = $memberships->getCommitteeFollowerMemberships()->getCommitteeUuids();
+        $followedCommittees = $this->filter(function (Committee $committee) use ($uuids) {
+            return in_array((string) $committee->getUuid(), $uuids);
+        });
+
+        return new static(array_merge(
+            $supervisedCommittees->toArray(),
+            $hostedCommittees->toArray(),
+            $followedCommittees->toArray()
+        ));
+    }
+}

--- a/src/AppBundle/Collection/CommitteeMembershipCollection.php
+++ b/src/AppBundle/Collection/CommitteeMembershipCollection.php
@@ -7,6 +7,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 class CommitteeMembershipCollection extends ArrayCollection
 {
+    const INCLUDE_SUPERVISORS = 1;
+    const EXCLUDE_SUPERVISORS = 2;
+
     public function getAdherentUuids(): array
     {
         return array_map(
@@ -27,8 +30,21 @@ class CommitteeMembershipCollection extends ArrayCollection
         );
     }
 
-    public function getCommitteeHostMemberships(): self
+    public function countCommitteeHostMemberships(): int
     {
+        return count($this->filter(function (CommitteeMembership $membership) {
+            return $membership->canHostCommittee();
+        }));
+    }
+
+    public function getCommitteeHostMemberships(int $withSupervisors = self::INCLUDE_SUPERVISORS): self
+    {
+        if (self::EXCLUDE_SUPERVISORS === $withSupervisors) {
+            return $this->filter(function (CommitteeMembership $membership) {
+                return $membership->isHostMember();
+            });
+        }
+
         // Supervised committees must have top priority in the list.
         $committees = $this->filter(function (CommitteeMembership $membership) {
             return $membership->isSupervisor();
@@ -46,6 +62,13 @@ class CommitteeMembershipCollection extends ArrayCollection
     {
         return $this->filter(function (CommitteeMembership $membership) {
             return $membership->isFollower();
+        });
+    }
+
+    public function getCommitteeSupervisorMemberships(): self
+    {
+        return $this->filter(function (CommitteeMembership $membership) {
+            return $membership->isSupervisor();
         });
     }
 

--- a/src/AppBundle/Committee/Voter/HostCommitteeVoter.php
+++ b/src/AppBundle/Committee/Voter/HostCommitteeVoter.php
@@ -2,18 +2,18 @@
 
 namespace AppBundle\Committee\Voter;
 
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Committee\CommitteePermissions;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
-use AppBundle\Repository\CommitteeMembershipRepository;
 
 class HostCommitteeVoter extends AbstractCommitteeVoter
 {
-    private $repository;
+    private $manager;
 
-    public function __construct(CommitteeMembershipRepository $repository)
+    public function __construct(CommitteeManager $manager)
     {
-        $this->repository = $repository;
+        $this->manager = $manager;
     }
 
     protected function supports($attribute, $committee)
@@ -23,6 +23,6 @@ class HostCommitteeVoter extends AbstractCommitteeVoter
 
     protected function doVoteOnAttribute(string $attribute, Adherent $adherent, Committee $committee): bool
     {
-        return $this->repository->hostCommittee($adherent, (string) $committee->getUuid());
+        return $this->manager->hostCommittee($adherent, $committee);
     }
 }

--- a/src/AppBundle/Committee/Voter/PostMessageCommitteeVoter.php
+++ b/src/AppBundle/Committee/Voter/PostMessageCommitteeVoter.php
@@ -2,18 +2,18 @@
 
 namespace AppBundle\Committee\Voter;
 
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Committee\CommitteePermissions;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
-use AppBundle\Repository\CommitteeMembershipRepository;
 
 class PostMessageCommitteeVoter extends AbstractCommitteeVoter
 {
-    private $repository;
+    private $manager;
 
-    public function __construct(CommitteeMembershipRepository $repository)
+    public function __construct(CommitteeManager $manager)
     {
-        $this->repository = $repository;
+        $this->manager = $manager;
     }
 
     protected function supports($attribute, $committee)
@@ -23,6 +23,6 @@ class PostMessageCommitteeVoter extends AbstractCommitteeVoter
 
     protected function doVoteOnAttribute(string $attribute, Adherent $adherent, Committee $committee): bool
     {
-        return $this->repository->hostCommittee($adherent, (string) $committee->getUuid()) && $committee->isApproved();
+        return $committee->isApproved() && $this->manager->hostCommittee($adherent, $committee);
     }
 }

--- a/src/AppBundle/Committee/Voter/SuperviseCommitteeVoter.php
+++ b/src/AppBundle/Committee/Voter/SuperviseCommitteeVoter.php
@@ -2,21 +2,21 @@
 
 namespace AppBundle\Committee\Voter;
 
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Committee\CommitteePermissions;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
-use AppBundle\Repository\CommitteeMembershipRepository;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class SuperviseCommitteeVoter extends Voter
 {
-    private $committeeMembershipRepository;
+    private $manager;
 
-    public function __construct(CommitteeMembershipRepository $committeeMembershipRepository)
+    public function __construct(CommitteeManager $manager)
     {
-        $this->committeeMembershipRepository = $committeeMembershipRepository;
+        $this->manager = $manager;
     }
 
     protected function supports($attribute, $subject): bool
@@ -43,6 +43,6 @@ class SuperviseCommitteeVoter extends Voter
             return false;
         }
 
-        return $this->committeeMembershipRepository->superviseCommittee($supervisor, $committee->getUuid());
+        return $this->manager->superviseCommittee($supervisor, $committee);
     }
 }

--- a/src/AppBundle/Entity/CommitteeMembership.php
+++ b/src/AppBundle/Entity/CommitteeMembership.php
@@ -236,4 +236,9 @@ class CommitteeMembership
     {
         return new \DateTimeImmutable($this->joinedAt->format(DATE_RFC822), $this->joinedAt->getTimezone());
     }
+
+    public function matches(Adherent $adherent, Committee $committee): bool
+    {
+        return $adherent->equals($this->getAdherent()) && $this->committeeUuid->equals($committee->getUuid());
+    }
 }

--- a/src/AppBundle/Repository/CommitteeMembershipRepository.php
+++ b/src/AppBundle/Repository/CommitteeMembershipRepository.php
@@ -77,32 +77,6 @@ class CommitteeMembershipRepository extends EntityRepository
         return (int) $qb->getQuery()->getSingleScalarResult() >= 1;
     }
 
-    /**
-     * Returns whether or not an adherent is already member of a committee.
-     *
-     * @param Adherent $adherent
-     * @param string   $committeeUuid
-     *
-     * @return bool
-     */
-    public function isMemberOf(Adherent $adherent, string $committeeUuid): bool
-    {
-        $query = $this
-            ->createMembershipQueryBuilder($adherent, $committeeUuid)
-            ->select('COUNT(cm.uuid)')
-            ->getQuery()
-        ;
-
-        return 1 === (int) $query->getSingleScalarResult();
-    }
-
-    /**
-     * Finds all the memberships for an adherent.
-     *
-     * @param Adherent $adherent
-     *
-     * @return CommitteeMembershipCollection
-     */
     public function findMemberships(Adherent $adherent): CommitteeMembershipCollection
     {
         $query = $this
@@ -115,14 +89,6 @@ class CommitteeMembershipRepository extends EntityRepository
         return new CommitteeMembershipCollection($query->getResult());
     }
 
-    /**
-     * Finds the membership relationship between an adherent and a committee.
-     *
-     * @param Adherent $adherent
-     * @param string   $committeeUuid
-     *
-     * @return CommitteeMembership|null
-     */
     public function findMembership(Adherent $adherent, string $committeeUuid): ?CommitteeMembership
     {
         $query = $this

--- a/tests/AppBundle/Committee/CommitteeManagerTest.php
+++ b/tests/AppBundle/Committee/CommitteeManagerTest.php
@@ -132,13 +132,6 @@ class CommitteeManagerTest extends MysqlWebTestCase
         $this->assertSame('Antenne En Marche de Fontainebleau', (string) $committees[3]);
         $this->assertSame('En Marche - Comité de Rouen', (string) $committees[4]);
         $this->assertSame('En Marche - Comité de Berlin', (string) $committees[5], 'Followed committee - least popular one last');
-
-        // With a fixed limit of 4 committees maximum.
-        $this->assertCount(4, $this->committeeManager->getAdherentCommittees($adherent, 4));
-        $this->assertSame('En Marche Paris 8', (string) $committees[0], 'Supervised committee must come first');
-        $this->assertSame('En Marche Dammarie-les-Lys', (string) $committees[1], 'Hosted committee must come after supervised committees');
-        $this->assertSame('En Marche - Comité de Évry', (string) $committees[2], 'Followed committee - most popular of the list must come first');
-        $this->assertSame('Antenne En Marche de Fontainebleau', (string) $committees[3], 'Followed committee - least popular of the list must come last');
     }
 
     private function getCommitteeMock(string $uuid)

--- a/tests/AppBundle/Controller/AdherentControllerTest.php
+++ b/tests/AppBundle/Controller/AdherentControllerTest.php
@@ -332,9 +332,9 @@ class AdherentControllerTest extends SqliteWebTestCase
      * @group functionnal
      * @dataProvider provideCommitteesHostsAdherentsCredentials
      */
-    public function testCommitteesAdherentsHostsAreNotAllowedToCreateNewCommittees(string $emaiLAddress, string $password)
+    public function testCommitteesAdherentsHostsAreNotAllowedToCreateNewCommittees(string $emailAddress, string $password)
     {
-        $crawler = $this->authenticateAsAdherent($this->client, $emaiLAddress, $password);
+        $crawler = $this->authenticateAsAdherent($this->client, $emailAddress, $password);
         $this->assertSame(0, $crawler->selectLink('Créer un comité')->count());
 
         // Try to cheat the system with a direct URL access.

--- a/tests/AppBundle/Controller/Api/CommitteesControllerTest.php
+++ b/tests/AppBundle/Controller/Api/CommitteesControllerTest.php
@@ -10,7 +10,7 @@ use Tests\AppBundle\Controller\ControllerTestTrait;
 use Tests\AppBundle\MysqlWebTestCase;
 
 /**
- * @group functional
+ * @group functionnal
  */
 class CommitteesControllerTest extends MysqlWebTestCase
 {

--- a/tests/AppBundle/Controller/Api/IntlControllerTest.php
+++ b/tests/AppBundle/Controller/Api/IntlControllerTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\SqliteWebTestCase;
 
 /**
- * @group functional
+ * @group functionnal
  */
 class IntlControllerTest extends SqliteWebTestCase
 {

--- a/tests/AppBundle/Controller/PageControllerTest.php
+++ b/tests/AppBundle/Controller/PageControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\SqliteWebTestCase;
 
 /**
- * @group functional
+ * @group functionnal
  */
 class PageControllerTest extends SqliteWebTestCase
 {

--- a/tests/AppBundle/Controller/ProcurationManagerControllerTest.php
+++ b/tests/AppBundle/Controller/ProcurationManagerControllerTest.php
@@ -8,25 +8,26 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\SqliteWebTestCase;
 
+/**
+ * @group functionnal
+ */
 class ProcurationManagerControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 
     /**
-     * @group functionnal
      * @dataProvider providePages
      */
-    public function testProcurationManagerBackendIsForbiddenAsAnonymous($path)
+    public function testProcurationManagerBackendIsForbiddenAsAnonymous(string $path)
     {
         $this->client->request(Request::METHOD_GET, $path);
         $this->assertClientIsRedirectedTo('http://localhost/espace-adherent/connexion', $this->client);
     }
 
     /**
-     * @group functionnal
      * @dataProvider providePages
      */
-    public function testProcurationManagerBackendIsForbiddenAsAdherentNotReferent($path)
+    public function testProcurationManagerBackendIsForbiddenAsAdherentNotReferent(string $path)
     {
         $this->authenticateAsAdherent($this->client, 'carl999@example.fr', 'secret!12345');
 
@@ -38,14 +39,12 @@ class ProcurationManagerControllerTest extends SqliteWebTestCase
     {
         return [
             ['/espace-responsable-procuration'],
+            ['/espace-responsable-procuration/mandataires'],
             ['/espace-responsable-procuration/demande/1'],
             ['/espace-responsable-procuration/demande/2'],
         ];
     }
 
-    /**
-     * @group functionnal
-     */
     public function testProcurationManagerNotManagedRequestIsForbidden()
     {
         $this->authenticateAsAdherent($this->client, 'luciole1989@spambox.fr', 'EnMarche2017');
@@ -54,9 +53,6 @@ class ProcurationManagerControllerTest extends SqliteWebTestCase
         $this->assertStatusCode(Response::HTTP_NOT_FOUND, $this->client);
     }
 
-    /**
-     * @group functionnal
-     */
     public function testAssociateDeassociateRequest()
     {
         $this->authenticateAsAdherent($this->client, 'luciole1989@spambox.fr', 'EnMarche2017');
@@ -134,9 +130,6 @@ class ProcurationManagerControllerTest extends SqliteWebTestCase
         $this->assertSame('Jean-Michel Carbonneau', trim($crawler->filter('.datagrid__table tbody tr td strong')->text()));
     }
 
-    /**
-     * @group functionnal
-     */
     public function testProcurationManagerProxiesList()
     {
         $this->authenticateAsAdherent($this->client, 'luciole1989@spambox.fr', 'EnMarche2017');

--- a/tests/AppBundle/Controller/Security/AdherentSecurityControllerTest.php
+++ b/tests/AppBundle/Controller/Security/AdherentSecurityControllerTest.php
@@ -14,7 +14,7 @@ use Tests\AppBundle\Controller\ControllerTestTrait;
 use Tests\AppBundle\SqliteWebTestCase;
 
 /**
- * @group functional
+ * @group functionnal
  */
 class AdherentSecurityControllerTest extends SqliteWebTestCase
 {

--- a/tests/AppBundle/Repository/CommitteeMembershipRepositoryTest.php
+++ b/tests/AppBundle/Repository/CommitteeMembershipRepositoryTest.php
@@ -45,15 +45,6 @@ class CommitteeMembershipRepositoryTest extends SqliteWebTestCase
         $this->assertInstanceOf(CommitteeMembership::class, $this->repository->findMembership($this->getAdherent(LoadAdherentData::ADHERENT_5_UUID), LoadAdherentData::COMMITTEE_1_UUID));
     }
 
-    public function testAdherentIsMemberOfCommittee()
-    {
-        $this->assertFalse($this->repository->isMemberOf($this->getAdherent(LoadAdherentData::ADHERENT_1_UUID), LoadAdherentData::COMMITTEE_1_UUID));
-        $this->assertTrue($this->repository->isMemberOf($this->getAdherent(LoadAdherentData::ADHERENT_2_UUID), LoadAdherentData::COMMITTEE_1_UUID));
-        $this->assertTrue($this->repository->isMemberOf($this->getAdherent(LoadAdherentData::ADHERENT_3_UUID), LoadAdherentData::COMMITTEE_1_UUID));
-        $this->assertTrue($this->repository->isMemberOf($this->getAdherent(LoadAdherentData::ADHERENT_4_UUID), LoadAdherentData::COMMITTEE_1_UUID));
-        $this->assertTrue($this->repository->isMemberOf($this->getAdherent(LoadAdherentData::ADHERENT_5_UUID), LoadAdherentData::COMMITTEE_1_UUID));
-    }
-
     public function testMemberIsCommitteeHost()
     {
         $this->assertTrue($this->repository->hostCommittee($this->getAdherent(LoadAdherentData::ADHERENT_3_UUID)));

--- a/tests/AppBundle/Repository/CommitteeRepositoryTest.php
+++ b/tests/AppBundle/Repository/CommitteeRepositoryTest.php
@@ -16,16 +16,6 @@ class CommitteeRepositoryTest extends SqliteWebTestCase
 
     use ControllerTestTrait;
 
-    public function testAdherentHasWaitingForApprovalCommittees()
-    {
-        $this->assertFalse($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_1_UUID));
-        $this->assertFalse($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_2_UUID));
-        $this->assertFalse($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_3_UUID));
-        $this->assertFalse($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_4_UUID));
-        $this->assertFalse($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_5_UUID));
-        $this->assertTrue($this->repository->hasWaitingForApprovalCommittees(LoadAdherentData::ADHERENT_6_UUID));
-    }
-
     public function testCountApprovedCommittees()
     {
         $this->assertSame(6, $this->repository->countApprovedCommittees());


### PR DESCRIPTION
This PR greatly improves the number of SQL queries performed on the frontend side when an adherent is logged in to his\her account. From 21 SQL queries to only 2!

Before
![enmarche-dev-after](https://cloud.githubusercontent.com/assets/235550/24604516/56feea4a-1865-11e7-9df4-47f6558372df.png)

After
![enmarche-dev-before](https://cloud.githubusercontent.com/assets/235550/24604508/50ae711a-1865-11e7-8b3c-b910a109306b.png)

The duplicated SQL queries came from two different locations:

1. the adherent's navigation bar in the top right end corner,
2. security voters.

All voters now receive the `CommitteeManager` class that performs SQL queries with Doctrine repositories. This means optimizing can now be done inside the `CommitteeManager` class directly as everything is centralized. The `CommitteeManager` object is now able to check an `Adherent` entity's memberships directly before falling back to repositories to perform SQL queries. This way we can prevent some extra unneeded SQL queries to the database.

Thus, this design also enables us to add a caching layer on top of the committee manager by wrapping the `CommitteeManager` object in a `CachedCommitteeManager` object if necessary. The main downside of using a decorator here for this use case will be to reimplement all the methods from `CommitteeManager` in the decorator object and forward all method calls.