### PR TITLE
Fixes Sentry issue #258906440.

### DIFF
--- a/app/Resources/translations/validators.fr.yml
+++ b/app/Resources/translations/validators.fr.yml
@@ -112,7 +112,8 @@ referent.message.max_length: Le message doit contenir moins de {{ limit }} carac
 # Je Marche
 #
 jemarche.email.invalid: L'e-mail {{ value }} n'est pas valide.
-jemarche.not_conviced.greater_than_or_equal_0: Vous devez entrer un nombre positif ou zéro.
+jemarche.not_conviced.greater_than_or_equal_0: Vous devez entrer un nombre entier positif supérieur ou égal à zéro.
+jemarche.not_conviced.less_than_or_equal_65000: Vous devez entrer un nombre entier positif inférieur ou égal à 65 000.
 jemarche.postal_code.not_blank: Vous devez entrer un code postal.
 jemarche.postal_code.invalid: Ce code postal n'est pas valide.
 

--- a/app/migrations/Version20170424164217.php
+++ b/app/migrations/Version20170424164217.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170424164217 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE je_marche_reports CHANGE not_convinced not_convinced SMALLINT UNSIGNED DEFAULT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE je_marche_reports CHANGE not_convinced not_convinced SMALLINT DEFAULT NULL');
+    }
+}

--- a/src/AppBundle/Entity/JeMarcheReport.php
+++ b/src/AppBundle/Entity/JeMarcheReport.php
@@ -94,9 +94,10 @@ class JeMarcheReport
     /**
      * @var int|null
      *
-     * @ORM\Column(type="smallint", nullable=true)
+     * @ORM\Column(type="smallint", nullable=true, options={"unsigned": true})
      *
      * @Assert\GreaterThanOrEqual(value=0, message="jemarche.not_conviced.greater_than_or_equal_0")
+     * @Assert\LessThanOrEqual(value=65535, message="jemarche.not_conviced.less_than_or_equal_65000")
      */
     private $notConvinced;
 
@@ -117,7 +118,7 @@ class JeMarcheReport
      */
     public $recaptcha = '';
 
-    public static function createWithCaptcha(string $recaptcha)
+    public static function createWithCaptcha(string $recaptcha): self
     {
         $report = new self();
         $report->recaptcha = $recaptcha;
@@ -128,7 +129,7 @@ class JeMarcheReport
     /**
      * @Assert\Callback
      */
-    public function validateOneFieldNotBlank(ExecutionContextInterface $context)
+    public function validateOneFieldNotBlank(ExecutionContextInterface $context): void
     {
         if (!$this->notConvinced && !$this->almostConvinced && !$this->convinced) {
             $context->addViolation('Vous devez entrer au moins un contact que vous avez obtenu durant une action.');
@@ -140,7 +141,7 @@ class JeMarcheReport
         return $this->type.' de '.$this->emailAddress;
     }
 
-    public static function getTypes()
+    public static function getTypes(): array
     {
         return [
             self::TYPE_KIOSQUE,
@@ -153,7 +154,7 @@ class JeMarcheReport
         ];
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -163,7 +164,7 @@ class JeMarcheReport
         return $this->type;
     }
 
-    public function setType(string $type)
+    public function setType(string $type): void
     {
         $this->type = $type;
     }
@@ -173,7 +174,7 @@ class JeMarcheReport
         return $this->emailAddress;
     }
 
-    public function setEmailAddress(string $emailAddress)
+    public function setEmailAddress(string $emailAddress): void
     {
         $this->emailAddress = $emailAddress;
     }
@@ -183,7 +184,7 @@ class JeMarcheReport
         return $this->postalCode;
     }
 
-    public function setPostalCode(string $postalCode)
+    public function setPostalCode(string $postalCode): void
     {
         $this->postalCode = $postalCode;
     }
@@ -208,7 +209,7 @@ class JeMarcheReport
         return count($this->convinced);
     }
 
-    public function setConvinced(array $convinced)
+    public function setConvinced(array $convinced): void
     {
         $this->convinced = $convinced;
     }
@@ -233,7 +234,7 @@ class JeMarcheReport
         return count($this->almostConvinced);
     }
 
-    public function setAlmostConvinced(array $almostConvinced)
+    public function setAlmostConvinced(array $almostConvinced): void
     {
         $this->almostConvinced = $almostConvinced;
     }
@@ -243,7 +244,7 @@ class JeMarcheReport
         return $this->notConvinced;
     }
 
-    public function setNotConvinced(?int $notConvinced)
+    public function setNotConvinced(?int $notConvinced): void
     {
         $this->notConvinced = $notConvinced;
     }
@@ -253,8 +254,8 @@ class JeMarcheReport
         return $this->reaction;
     }
 
-    public function setReaction(?string $reaction)
+    public function setReaction(?string $reaction): void
     {
-        $this->reaction = EmojisRemover::remove($reaction);
+        $this->reaction = trim(EmojisRemover::remove($reaction));
     }
 }

--- a/tests/AppBundle/Controller/JeMarcheControllerTest.php
+++ b/tests/AppBundle/Controller/JeMarcheControllerTest.php
@@ -78,7 +78,7 @@ class JeMarcheControllerTest extends SqliteWebTestCase
             'app_je_marche[convinced]' => '',
             'app_je_marche[almostConvinced]' => "xyz@en-marche.fr\ntuv@en-marche.fr",
             'app_je_marche[notConvinced]' => '',
-            'app_je_marche[reaction]' => '',
+            'app_je_marche[reaction]' => 'Emmanuel Macron va gagner ! 😀',
             'app_je_marche[emailAddress]' => 'foobar@en-marche.fr',
         ]));
 
@@ -94,7 +94,7 @@ class JeMarcheControllerTest extends SqliteWebTestCase
         $this->assertNull($report->getNotConvinced());
         $this->assertSame([], $report->getConvinced());
         $this->assertSame(['xyz@en-marche.fr', 'tuv@en-marche.fr'], $report->getAlmostConvinced());
-        $this->assertNull($report->getReaction());
+        $this->assertSame('Emmanuel Macron va gagner !', $report->getReaction());
     }
 
     protected function setUp()


### PR DESCRIPTION
This PR is not really a fix for Sentry issue [258906440](
https://sentry.io/en-marche-i7/en-marchefr/issues/258906440/). This issue is a both a bug and an invalid value. The user tried to store the integer `605,525,601` in a `SIGNED SMALLINT` field. To prevent this situation from happening again in the future, the PR provides the following fixes:

* Make the `not_convinced` SQL field `unsigned` to increase its value from up to `65535` instead of `32767`,
* Add server-side data validation to prevent the user submitting a value greater than `65000` for this field.
