### PR TITLE
Use correct MIME type for woff2 fonts

### DIFF
--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -23,10 +23,10 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
     include /etc/nginx/mime.types;
-    types {
-      font/woff2 woff2;
-    }
     default_type application/octet-stream;
+    types {
+        font/woff2 woff2;
+    }
     client_max_body_size 10M;
 
     ##

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -23,6 +23,9 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
     include /etc/nginx/mime.types;
+    types {
+      font/woff2 woff2;
+    }
     default_type application/octet-stream;
     client_max_body_size 10M;
 

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -24,6 +24,9 @@ http {
     types_hash_max_size 2048;
     server_tokens off;
     include /etc/nginx/mime.types;
+    types {
+      font/woff2 woff2;
+    }
     default_type application/octet-stream;
     client_max_body_size 10M;
 

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -24,10 +24,10 @@ http {
     types_hash_max_size 2048;
     server_tokens off;
     include /etc/nginx/mime.types;
-    types {
-      font/woff2 woff2;
-    }
     default_type application/octet-stream;
+    types {
+        font/woff2 woff2;
+    }
     client_max_body_size 10M;
 
     ##


### PR DESCRIPTION
The EnMarche site delivers woff2-format fonts with an incorrect MIME type. Nginx does not have a MIME type mapping included in its standard `mime.types` file for woff2, so it defaults to `application/octet-stream`, and then relies on the browser to figure out (sniff) what type the content really is. In some browsers (e.g. Safari), this is not a problem, however, other browsers may not allow MIME type sniffing as it is a security risk, and this may cause fonts to be ignored.

Example on the live site:
```
#curl -I https://en-marche.fr/fonts/gillsans-heavy-italic.woff2
HTTP/1.1 200 OK
Date: Tue, 09 May 2017 12:23:38 GMT
Content-Type: application/octet-stream
Content-Length: 48140
...
```

This PR adds the `font/woff2` MIME type (see [WOFF2 spec](https://dev.w3.org/webfonts/WOFF2/spec/#IMT) for reference) mapping for items with a `woff2` extension in both the dev and prod docker configs.

Note that woff2 fonts are already compressed (using Brotli) and so should not be added to gzip config. They should have long expiry times set to aid client-side caching, but that's a separate issue.