### PR TITLE
Add app security headers

### DIFF
--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -40,6 +40,10 @@ http {
         root /app/web;
         index app_dev.php;
 
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Frame-Options DENY;
+
         location / {
             try_files $uri /app_dev.php$is_args$args;
         }

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -51,6 +51,10 @@ http {
         root /app/web;
         index app.php;
 
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Frame-Options DENY;
+
         # Block WordPress Pingback DDoS attacks
         if ($http_user_agent ~* "WordPress") {
             return 403;


### PR DESCRIPTION
These three headers are pretty much standard issue, and any security scan will flag their absence.

`X-Content-Type-Options` is used to disable content sniffing, telling browsers to believe MIME types in content-type headers and not to try and figure out incorrectly-set types (see #1097). This helps prevent sniffing attacks where content types can be substituted - e.g. Javascript hidden inside GIF images. You need to be sure that your site *is* delivering correct MIME types when you enable this!

`X-XSS-Protection` enables some XSS protection features, particularly in Internet Explorer.

`X-Frame-Options` is used to prevent other sites from presenting the site in a frame, and this can help prevent clickjacking attacks.

There are several other security-related headers that can improve security, but they are more involved to configure than these - I can help with them if you need it. You can see a report on the site at [securityheaders.io](https://securityheaders.io/?q=en-marche.fr&followRedirects=on).