### PR TITLE
Set the default background and text color in order to make the front page legible on some configuration

### DIFF
--- a/front/style/_base.scss
+++ b/front/style/_base.scss
@@ -10,6 +10,10 @@ body {
     font-size: 16px;
     line-height: 24px;
     font-family: $font-gillsans;
+
+    // Sets the default color in case the visitor has changed them
+    background-color: $defaultBackgroundColor;
+    color : $defaultTextColor;
 }
 
 svg path,

--- a/front/style/_colors.scss
+++ b/front/style/_colors.scss
@@ -1,3 +1,7 @@
+// Base colors
+$defaultBackgroundColor : white;
+$defaultTextColor : #333333;
+
 // Colors
 $pink: #FF3680;
 $pink-hover: #E53072;


### PR DESCRIPTION
FR:
Sur la page d'accueil et d'autres pages, la règle CSS `color` est définie, tandis que la règle `background-color` ne l'est pas.
Cela peut se révéler gênant si le visiteur a modifié les couleurs par défaut de son navigateur (`background-color` et `color`) pour obtenir un thème sombre par exemple (en particulier pour les pages de chargements).
Dans ce cas on obtient une `color` et une `background-color` foncé très proche, rendant le texte difficilement lisible, sans oublier que la charte graphique n'est alors plus respectée :
![bug_website_enmarche](https://cloud.githubusercontent.com/assets/7248877/26572916/79b2be1c-44b7-11e7-8286-dec7155bffb9.png)

La solution consiste uniquement à définir les couleurs par défaut au niveau de `body`.

EN:
This is needed when the visitor has changed his default browser `background-color` and `color` rules.
Those are usually `white` and `#333` by default, but some users change them to setup a 'dark theme',
which means than on the front page, if the font color `color` rule is set in the CSS, but the
`background-color` is not set, then you get a black-on-black result, making the text illegible.

Signed-off-by: Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>