### PR TITLE
Fix EventCanecellationMessage one Adherent recipients is required

### DIFF
--- a/src/AppBundle/Event/EventMessageNotifier.php
+++ b/src/AppBundle/Event/EventMessageNotifier.php
@@ -56,11 +56,15 @@ class EventMessageNotifier implements EventSubscriberInterface
             return;
         }
 
-        $this->mailjet->sendMessage($this->createCancellationMessage(
-            $this->adherentManager->findByEvent($event->getEvent()),
-            $event->getEvent(),
-            $event->getAuthor()
-        ));
+        $subscriptions = $this->adherentManager->findByEvent($event->getEvent());
+
+        if (count($subscriptions) > 0) {
+            $this->mailjet->sendMessage($this->createCancellationMessage(
+                $subscriptions,
+                $event->getEvent(),
+                $event->getAuthor()
+            ));
+        }
     }
 
     private function createMessage(


### PR DESCRIPTION
Fix https://sentry.io/en-marche-i7/en-marchefr/issues/270440031/