### PR TITLE
Updated PHPUnit to 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,9 @@
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.0",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.2",
         "fabpot/goutte": "^3.2",
-        "liip/functional-test-bundle": "^1.7"
+        "liip/functional-test-bundle": "^1.8"
     },
     "scripts": {
         "symfony-scripts": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8293299acbb821cf68c7032c86b5ac06",
+    "content-hash": "6157fb29a831e4e15f9efd2bc0eff751",
     "packages": [
         {
             "name": "algolia/algolia-search-bundle",
@@ -1874,16 +1874,16 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.5.1",
+            "version": "8.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "ab23498bb5b787ae108f5fba3e50134ce3635503"
+                "reference": "25e86a18972d349480b5456805c4a61a76667e22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/ab23498bb5b787ae108f5fba3e50134ce3635503",
-                "reference": "ab23498bb5b787ae108f5fba3e50134ce3635503",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/25e86a18972d349480b5456805c4a61a76667e22",
+                "reference": "25e86a18972d349480b5456805c4a61a76667e22",
                 "shasum": ""
             },
             "require": {
@@ -1938,7 +1938,7 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2017-06-06T14:19:18+00:00"
+            "time": "2017-06-20T18:25:02+00:00"
         },
         {
             "name": "giggsey/locale",
@@ -3795,16 +3795,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.22.1",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0",
-                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
                 "shasum": ""
             },
             "require": {
@@ -3825,7 +3825,7 @@
                 "phpunit/phpunit-mock-objects": "2.3.0",
                 "ruflin/elastica": ">=0.90 <3.0",
                 "sentry/sentry": "^0.13",
-                "swiftmailer/swiftmailer": "~5.3"
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -3869,7 +3869,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-03-13T07:08:03+01:00"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -7213,7 +7213,7 @@
         },
         {
             "name": "willdurand/geocoder",
-            "version": "v3.3.0",
+            "version": "v3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/geocoder-php/php-common.git",
@@ -7269,7 +7269,7 @@
                 "geocoding",
                 "geoip"
             ],
-            "time": "2015-12-06T20:17:20+01:00"
+            "time": "2015-12-06T20:17:20+00:00"
         },
         {
             "name": "willdurand/geocoder-bundle",
@@ -7538,16 +7538,16 @@
         },
         {
             "name": "liip/functional-test-bundle",
-            "version": "1.7.3",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipFunctionalTestBundle.git",
-                "reference": "fac05bc216c88e8cc855e0cd5fb3e2e81e54593a"
+                "reference": "e18866bc434fccdf0d04a4e776289ed999862b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/fac05bc216c88e8cc855e0cd5fb3e2e81e54593a",
-                "reference": "fac05bc216c88e8cc855e0cd5fb3e2e81e54593a",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/e18866bc434fccdf0d04a4e776289ed999862b66",
+                "reference": "e18866bc434fccdf0d04a4e776289ed999862b66",
                 "shasum": ""
             },
             "require": {
@@ -7566,13 +7566,13 @@
                 "hautelook/alice-bundle": "~0.2|~1.2",
                 "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",
                 "nelmio/alice": "~1.7|~2.0",
-                "phpunit/phpunit": "4.8.*|~5.2",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.1",
                 "symfony/assetic-bundle": "~2.3",
                 "symfony/console": "~2.5|~3.0",
                 "symfony/monolog-bundle": "~2.4",
                 "symfony/phpunit-bridge": "^2.7|~3.0",
                 "symfony/symfony": "~2.3.27|~2.7|~3.0",
-                "twig/twig": "~1.12"
+                "twig/twig": "~1.12|~2.0"
             },
             "suggest": {
                 "brianium/paratest": "Required when using paratest to parallelize tests",
@@ -7612,7 +7612,7 @@
             "keywords": [
                 "Symfony2"
             ],
-            "time": "2017-04-21T17:22:21+02:00"
+            "time": "2017-06-19T09:12:22+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -7655,6 +7655,108 @@
                 "object graph"
             ],
             "time": "2017-04-12T18:52:22+02:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7867,40 +7969,41 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/dc421f9ca5082a0c0cb04afb171c765f79add85b",
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.3",
                 "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -7926,7 +8029,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+02:00"
+            "time": "2017-04-21T08:03:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8116,16 +8219,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.20",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b"
+                "reference": "f2786490399836d2a544a34785c4a8d3ab32cf0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f2786490399836d2a544a34785c4a8d3ab32cf0e",
+                "reference": "f2786490399836d2a544a34785c4a8d3ab32cf0e",
                 "shasum": ""
             },
             "require": {
@@ -8134,33 +8237,35 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "myclabs/deep-copy": "^1.3",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.2",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^4.0",
+                "sebastian/comparator": "^2.0",
+                "sebastian/diff": "^1.4.3 || ^2.0",
+                "sebastian/environment": "^3.0.2",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^1.1 || ^2.0",
+                "sebastian/object-enumerator": "^3.0.2",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -8168,7 +8273,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.2.x-dev"
                 }
             },
             "autoload": {
@@ -8194,33 +8299,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-22T07:42:55+00:00"
+            "time": "2017-06-13T14:07:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "sebastian/exporter": "^3.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -8228,7 +8333,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -8253,7 +8358,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+01:00"
+            "time": "2017-03-03T06:30:20+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -8302,30 +8407,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/exporter": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -8362,32 +8467,32 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+01:00"
+            "time": "2017-03-03T06:26:08+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "74776f8dbc081cab9287c2a601c0c1d842568744"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/74776f8dbc081cab9287c2a601c0c1d842568744",
+                "reference": "74776f8dbc081cab9287c2a601c0c1d842568744",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -8412,34 +8517,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+01:00"
+            "time": "2017-06-20T16:25:05+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -8479,27 +8584,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+01:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -8507,7 +8612,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -8530,33 +8635,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+02:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/31dd3379d16446c5d86dec32ab1ad1f378581ad8",
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -8576,32 +8682,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+01:00"
+            "time": "2017-03-12T15:17:29+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -8629,7 +8780,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+01:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -8831,6 +8982,46 @@
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
             "time": "2017-06-01T14:45:22+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,19 +2,19 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <server name="KERNEL_DIR" value="app/" />
+        <server name="KERNEL_CLASS" value="AppKernel" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
 
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="En Marche Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Address;
 
 use AppBundle\Address\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     public function testCreateValidForeignAddress()
     {

--- a/tests/Address/GeocodableAddressTest.php
+++ b/tests/Address/GeocodableAddressTest.php
@@ -4,8 +4,9 @@ namespace Tests\AppBundle\Address;
 
 use AppBundle\Address\Address;
 use AppBundle\Address\GeocodableAddress;
+use PHPUnit\Framework\TestCase;
 
-class GeocodableAddressTest extends \PHPUnit_Framework_TestCase
+class GeocodableAddressTest extends TestCase
 {
     public function testCreateGeocodableAddressFromAddress()
     {

--- a/tests/Address/PostAddressFactoryTest.php
+++ b/tests/Address/PostAddressFactoryTest.php
@@ -5,8 +5,9 @@ namespace Tests\AppBundle\Address;
 use AppBundle\Address\Address;
 use AppBundle\Address\PostAddressFactory;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 
-class PostAddressFactoryTest extends \PHPUnit_Framework_TestCase
+class PostAddressFactoryTest extends TestCase
 {
     public function testCreateFrenchAddress()
     {

--- a/tests/Api/CommitteeProviderTest.php
+++ b/tests/Api/CommitteeProviderTest.php
@@ -6,9 +6,10 @@ use AppBundle\Api\CommitteeProvider;
 use AppBundle\Committee\CommitteeUrlGenerator;
 use AppBundle\Entity\Committee;
 use AppBundle\Repository\CommitteeRepository;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class CommitteeProviderTest extends \PHPUnit_Framework_TestCase
+class CommitteeProviderTest extends TestCase
 {
     public function testGetApprovedCommittees()
     {

--- a/tests/Api/EventProviderTest.php
+++ b/tests/Api/EventProviderTest.php
@@ -5,11 +5,12 @@ namespace Tests\AppBundle\Api;
 use AppBundle\Api\EventProvider;
 use AppBundle\Entity\Event;
 use AppBundle\Repository\EventRepository;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Tests\AppBundle\TestHelperTrait;
 
-class EventProviderTest extends \PHPUnit_Framework_TestCase
+class EventProviderTest extends TestCase
 {
     use TestHelperTrait;
 

--- a/tests/Campaign/CampaignSilenceProcessorTest.php
+++ b/tests/Campaign/CampaignSilenceProcessorTest.php
@@ -4,12 +4,13 @@ namespace Tests\AppBundle\Campaign;
 
 use AppBundle\Campaign\CampaignSilenceProcessor;
 use GeoIp2\Database\Reader;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 
-class CampaignSilenceProcessorTest extends \PHPUnit_Framework_TestCase
+class CampaignSilenceProcessorTest extends TestCase
 {
     const IP_AU_SYDNEY = '45.63.31.236';
     const IP_CA_TORONTO = '159.203.18.38';

--- a/tests/Committee/CommitteeCommandTest.php
+++ b/tests/Committee/CommitteeCommandTest.php
@@ -5,9 +5,10 @@ namespace Tests\AppBundle\Committee;
 use AppBundle\Committee\CommitteeCommand;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class CommitteeCommandTest extends \PHPUnit_Framework_TestCase
+class CommitteeCommandTest extends TestCase
 {
     const CREATOR_UUID = '3966af25-2b09-407c-9283-c4d2103d0448';
 

--- a/tests/Committee/CommitteeFactoryTest.php
+++ b/tests/Committee/CommitteeFactoryTest.php
@@ -8,8 +8,9 @@ use AppBundle\Committee\CommitteeFactory;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 
-class CommitteeFactoryTest extends \PHPUnit_Framework_TestCase
+class CommitteeFactoryTest extends TestCase
 {
     public function testCreateCommitteeFromCommitteeCreationCommand()
     {

--- a/tests/Committee/CommitteeUtilsTest.php
+++ b/tests/Committee/CommitteeUtilsTest.php
@@ -5,13 +5,13 @@ namespace Tests\AppBundle\Committee;
 use AppBundle\Committee\CommitteeUtils;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Ramsey\Uuid\Uuid;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 use Tests\AppBundle\TestHelperTrait;
 
 /**
  * @group functional
  */
-class CommitteeUtilsTest extends MysqlWebTestCase
+class CommitteeUtilsTest extends SqliteWebTestCase
 {
     use TestHelperTrait;
 

--- a/tests/Committee/Serializer/AdherentCsvSerializerTest.php
+++ b/tests/Committee/Serializer/AdherentCsvSerializerTest.php
@@ -6,10 +6,11 @@ use AppBundle\Committee\Serializer\AdherentCsvSerializer;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\PostAddress;
 use AppBundle\Membership\AdherentFactory;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\EncoderFactory;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 
-class AdherentCsvSerializerTest extends \PHPUnit_Framework_TestCase
+class AdherentCsvSerializerTest extends TestCase
 {
     public function testSerialize()
     {

--- a/tests/Committee/Voter/AbstractCommitteeVoterTest.php
+++ b/tests/Committee/Voter/AbstractCommitteeVoterTest.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\PostAddress;
 use AppBundle\Membership\AdherentFactory;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -14,7 +15,7 @@ use Symfony\Component\Security\Core\Encoder\EncoderFactory;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-abstract class AbstractCommitteeVoterTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractCommitteeVoterTest extends TestCase
 {
     const ADHERENT_1_UUID = '313bd28f-efc8-57c9-8ab7-2106c8be9697';
     const ADHERENT_2_UUID = '91ed3e73-0384-4963-9159-3505c849fe39';

--- a/tests/Committee/Voter/HostCommitteeVoterTest.php
+++ b/tests/Committee/Voter/HostCommitteeVoterTest.php
@@ -7,10 +7,11 @@ use AppBundle\Committee\CommitteePermissions;
 use AppBundle\Committee\Voter\HostCommitteeVoter;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class HostCommitteeVoterTest extends \PHPUnit_Framework_TestCase
+class HostCommitteeVoterTest extends TestCase
 {
     const COMMITTEE_UUID = '515a56c0-bde8-56ef-b90c-4745b1c93818';
 

--- a/tests/Controller/Api/LegislativesControllerTest.php
+++ b/tests/Controller/Api/LegislativesControllerTest.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ApiControllerTestTrait;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class LegislativesControllerTest extends MysqlWebTestCase
+class LegislativesControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
     use ApiControllerTestTrait;

--- a/tests/Controller/Api/StatsControllerTest.php
+++ b/tests/Controller/Api/StatsControllerTest.php
@@ -5,12 +5,12 @@ namespace Tests\AppBundle\Controller\Api;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class StatsControllerTest extends MysqlWebTestCase
+class StatsControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Controller/EnMarche/AdherentControllerTest.php
+++ b/tests/Controller/EnMarche/AdherentControllerTest.php
@@ -17,12 +17,12 @@ use AppBundle\Repository\MailjetEmailRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class AdherentControllerTest extends MysqlWebTestCase
+class AdherentControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Controller/EnMarche/CommitteeControllerTest.php
+++ b/tests/Controller/EnMarche/CommitteeControllerTest.php
@@ -11,12 +11,12 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class CommitteeControllerTest extends MysqlWebTestCase
+class CommitteeControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Controller/EnMarche/EventManagerControllerTest.php
+++ b/tests/Controller/EnMarche/EventManagerControllerTest.php
@@ -12,12 +12,12 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class EventManagerControllerTest extends MysqlWebTestCase
+class EventManagerControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Controller/EnMarche/LegislativesControllerTest.php
+++ b/tests/Controller/EnMarche/LegislativesControllerTest.php
@@ -8,12 +8,12 @@ use AppBundle\Repository\MailjetEmailRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class LegislativesControllerTest extends MysqlWebTestCase
+class LegislativesControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Controller/EnMarche/Security/AdherentSecurityControllerTest.php
+++ b/tests/Controller/EnMarche/Security/AdherentSecurityControllerTest.php
@@ -11,12 +11,12 @@ use AppBundle\Repository\MailjetEmailRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
-use Tests\AppBundle\MysqlWebTestCase;
+use Tests\AppBundle\SqliteWebTestCase;
 
 /**
  * @group functional
  */
-class AdherentSecurityControllerTest extends MysqlWebTestCase
+class AdherentSecurityControllerTest extends SqliteWebTestCase
 {
     use ControllerTestTrait;
 

--- a/tests/Documents/DocumentRepositoryTest.php
+++ b/tests/Documents/DocumentRepositoryTest.php
@@ -5,8 +5,9 @@ namespace Tests\AppBundle\Documents;
 use AppBundle\Documents\DocumentRepository;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Memory\MemoryAdapter;
+use PHPUnit\Framework\TestCase;
 
-class DocumentRepositoryTest extends \PHPUnit_Framework_TestCase
+class DocumentRepositoryTest extends TestCase
 {
     /** @var Filesystem */
     private $filesystem;

--- a/tests/Donation/DonationFactoryTest.php
+++ b/tests/Donation/DonationFactoryTest.php
@@ -7,10 +7,11 @@ use AppBundle\Donation\DonationFactory;
 use AppBundle\Donation\DonationRequest;
 use AppBundle\Entity\Donation;
 use libphonenumber\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-class DonationFactoryTest extends \PHPUnit_Framework_TestCase
+class DonationFactoryTest extends TestCase
 {
     const DONATION_REQUEST_UUID = 'cfd3c04f-cce0-405d-865f-f5f3a2c1792e';
 

--- a/tests/Donation/DonationRequestTest.php
+++ b/tests/Donation/DonationRequestTest.php
@@ -6,9 +6,10 @@ use AppBundle\Donation\DonationRequest;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\PostAddress;
 use libphonenumber\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 
-class DonationRequestTest extends \PHPUnit_Framework_TestCase
+class DonationRequestTest extends TestCase
 {
     public function testCreateDonationRequestFromAdherent()
     {

--- a/tests/Entity/AbstractAdherentTokenTest.php
+++ b/tests/Entity/AbstractAdherentTokenTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\AppBundle\Entity;
 
-use AppBundle\Exception\AdherentTokenAlreadyUsedException;
 use AppBundle\ValueObject\SHA1;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use Tests\AppBundle\TestHelperTrait;
 
-abstract class AbstractAdherentTokenTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractAdherentTokenTest extends TestCase
 {
     use TestHelperTrait;
 
@@ -36,6 +36,9 @@ abstract class AbstractAdherentTokenTest extends \PHPUnit_Framework_TestCase
         $token->consume($adherent2);
     }
 
+    /**
+     * @expectedException \AppBundle\Exception\AdherentTokenAlreadyUsedException
+     */
     public function testCannotActivateSameAdherentActivationTokenTwice()
     {
         $adherent = $this->createAdherent();
@@ -44,11 +47,7 @@ abstract class AbstractAdherentTokenTest extends \PHPUnit_Framework_TestCase
 
         $token->consume($adherent);
 
-        try {
-            $token->consume($adherent);
-            $this->fail('Adherent activation token cannot be activated more than once.');
-        } catch (AdherentTokenAlreadyUsedException $e) {
-        }
+        $token->consume($adherent);
     }
 
     public function testConsumeTokenIsSuccessful()

--- a/tests/Entity/AdherentTest.php
+++ b/tests/Entity/AdherentTest.php
@@ -5,14 +5,14 @@ namespace Tests\AppBundle\Entity;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\AdherentActivationToken;
 use AppBundle\Entity\PostAddress;
-use AppBundle\Exception\AdherentAlreadyEnabledException;
 use AppBundle\Geocoder\Coordinates;
 use AppBundle\Membership\ActivityPositions;
 use libphonenumber\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use Tests\AppBundle\TestHelperTrait;
 
-class AdherentTest extends \PHPUnit_Framework_TestCase
+class AdherentTest extends TestCase
 {
     use TestHelperTrait;
 
@@ -84,6 +84,9 @@ class AdherentTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(\DateTime::class, $activationToken->getUsageDate());
     }
 
+    /**
+     * @expectedException \AppBundle\Exception\AdherentAlreadyEnabledException
+     */
     public function testActivateAdherentAccountTwice()
     {
         $adherent = $this->createAdherent();
@@ -91,11 +94,7 @@ class AdherentTest extends \PHPUnit_Framework_TestCase
 
         $adherent->activate($activationToken);
 
-        try {
-            $adherent->activate($activationToken);
-            $this->fail('Adherent account cannot be enabled more than once.');
-        } catch (AdherentAlreadyEnabledException $exception) {
-        }
+        $adherent->activate($activationToken);
     }
 
     public function testAuthenticateAdherentAccount()

--- a/tests/Entity/CommitteeMembershipTest.php
+++ b/tests/Entity/CommitteeMembershipTest.php
@@ -5,10 +5,11 @@ namespace Tests\AppBundle\Entity;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\CommitteeMembership;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-class CommitteeMembershipTest extends \PHPUnit_Framework_TestCase
+class CommitteeMembershipTest extends TestCase
 {
     const ADHERENT_UUID = '0f5afdb8-09f6-4522-9e36-f0fd227a8442';
     const COMMITTEE_UUID = 'ebd9f0c8-4158-4939-8372-28505f6cf892';

--- a/tests/Entity/CommitteeTest.php
+++ b/tests/Entity/CommitteeTest.php
@@ -4,11 +4,11 @@ namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\PostAddress;
-use AppBundle\Exception\CommitteeAlreadyApprovedException;
 use AppBundle\Geocoder\Coordinates;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class CommitteeTest extends \PHPUnit_Framework_TestCase
+class CommitteeTest extends TestCase
 {
     public function testConstructor()
     {
@@ -88,16 +88,15 @@ class CommitteeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \DateTime($timestamp), $committee->getApprovedAt());
     }
 
+    /**
+     * @expectedException \AppBundle\Exception\CommitteeAlreadyApprovedException
+     */
     public function testApproveCommitteeTwice()
     {
         $committee = $this->createCommittee();
         $committee->approved();
 
-        try {
-            $committee->approved();
-            $this->fail();
-        } catch (CommitteeAlreadyApprovedException $exception) {
-        }
+        $committee->approved();
     }
 
     private function createCommittee(): Committee

--- a/tests/Entity/EventRegistrationTest.php
+++ b/tests/Entity/EventRegistrationTest.php
@@ -5,9 +5,10 @@ namespace Tests\AppBundle\Entity;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Event;
 use AppBundle\Entity\EventRegistration;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class EventRegistrationTest extends \PHPUnit_Framework_TestCase
+class EventRegistrationTest extends TestCase
 {
     const REGISTRATION_UUID = '75aac96a-9cba-4bd8-91f4-414d269ca0b0';
 

--- a/tests/Entity/EventTest.php
+++ b/tests/Entity/EventTest.php
@@ -6,9 +6,10 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Event;
 use AppBundle\Entity\EventCategory;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     /**
      * @dataProvider provideNotFinishedEventDate

--- a/tests/Entity/LegislativeDistrictZoneTest.php
+++ b/tests/Entity/LegislativeDistrictZoneTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\LegislativeDistrictZone;
+use PHPUnit\Framework\TestCase;
 
-class LegislativeDistrictZoneTest extends \PHPUnit_Framework_TestCase
+class LegislativeDistrictZoneTest extends TestCase
 {
     public function testCreateRegionDistrictZone()
     {

--- a/tests/Entity/PostAddressTest.php
+++ b/tests/Entity/PostAddressTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 
-class PostAddressTest extends \PHPUnit_Framework_TestCase
+class PostAddressTest extends TestCase
 {
     public function testCreateFullFrenchAddress()
     {

--- a/tests/Entity/ProcurationRequestTest.php
+++ b/tests/Entity/ProcurationRequestTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\ProcurationRequest;
+use PHPUnit\Framework\TestCase;
 
-class ProcurationRequestTest extends \PHPUnit_Framework_TestCase
+class ProcurationRequestTest extends TestCase
 {
     public function testGetElectionsRoundsCount()
     {

--- a/tests/Feed/ArticleFeedGeneratorTest.php
+++ b/tests/Feed/ArticleFeedGeneratorTest.php
@@ -7,10 +7,11 @@ use AppBundle\Entity\ArticleCategory;
 use AppBundle\Feed\ArticleFeedGenerator;
 use AppBundle\Feed\Exception\FeedGeneratorException;
 use League\CommonMark\CommonMarkConverter;
+use PHPUnit\Framework\TestCase;
 use Suin\RSSWriter\FeedInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class ArticleFeedGeneratorTest extends \PHPUnit_Framework_TestCase
+class ArticleFeedGeneratorTest extends TestCase
 {
     protected $locale = 'fr';
     protected $ttl = 120;

--- a/tests/Geocoder/DummyGeocoderTest.php
+++ b/tests/Geocoder/DummyGeocoderTest.php
@@ -3,9 +3,10 @@
 namespace Tests\AppBundle\Geocoder;
 
 use AppBundle\Geocoder\Coordinates;
+use PHPUnit\Framework\TestCase;
 use Tests\AppBundle\Test\Geocoder\DummyGeocoder;
 
-class DummyGeocoderTest extends \PHPUnit_Framework_TestCase
+class DummyGeocoderTest extends TestCase
 {
     /**
      * @expectedException \AppBundle\Geocoder\Exception\GeocodingException

--- a/tests/Geocoder/GeocoderTest.php
+++ b/tests/Geocoder/GeocoderTest.php
@@ -8,8 +8,9 @@ use Geocoder\Geocoder as BazingaGeocoder;
 use Geocoder\Model\Address;
 use Geocoder\Model\AddressCollection;
 use Geocoder\Model\Coordinates as BazingaCoordinates;
+use PHPUnit\Framework\TestCase;
 
-class GeocoderTest extends \PHPUnit_Framework_TestCase
+class GeocoderTest extends TestCase
 {
     const ADDRESS = '92 bld victor hugo, 92110 clichy, france';
 

--- a/tests/Geocoder/Subscriber/EntityAddressGeocodingSubscriberTest.php
+++ b/tests/Geocoder/Subscriber/EntityAddressGeocodingSubscriberTest.php
@@ -12,10 +12,11 @@ use AppBundle\Membership\ActivityPositions;
 use AppBundle\Membership\AdherentAccountWasCreatedEvent;
 use AppBundle\Membership\AdherentProfileWasUpdatedEvent;
 use Doctrine\Common\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\AppBundle\Test\Geocoder\DummyGeocoder;
 
-class EntityAddressGeocodingSubscriberTest extends \PHPUnit_Framework_TestCase
+class EntityAddressGeocodingSubscriberTest extends TestCase
 {
     private $manager;
 

--- a/tests/Intl/FranceCitiesBundleTest.php
+++ b/tests/Intl/FranceCitiesBundleTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Intl;
 
 use AppBundle\Intl\FranceCitiesBundle;
+use PHPUnit\Framework\TestCase;
 
-class FranceCitiesBundleTest extends \PHPUnit_Framework_TestCase
+class FranceCitiesBundleTest extends TestCase
 {
     /**
      * @dataProvider providePostalCodes

--- a/tests/Intl/UnitedNationsBundleTest.php
+++ b/tests/Intl/UnitedNationsBundleTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\Intl;
 
 use AppBundle\Intl\UnitedNationsBundle;
+use PHPUnit\Framework\TestCase;
 
-class UnitedNationsBundleTest extends \PHPUnit_Framework_TestCase
+class UnitedNationsBundleTest extends TestCase
 {
     public function testGetCountries()
     {

--- a/tests/Mailjet/EmailTemplateTest.php
+++ b/tests/Mailjet/EmailTemplateTest.php
@@ -3,10 +3,11 @@
 namespace Tests\AppBundle\Mailjet;
 
 use AppBundle\Mailjet\EmailTemplate;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\AppBundle\Test\Mailjet\Message\DummyMessage;
 
-class EmailTemplateTest extends \PHPUnit_Framework_TestCase
+class EmailTemplateTest extends TestCase
 {
     /**
      * @expectedException \AppBundle\Mailjet\Exception\MailjetException

--- a/tests/Mailjet/EventSubscriber/EmailPersisterEventSubscriberTest.php
+++ b/tests/Mailjet/EventSubscriber/EmailPersisterEventSubscriberTest.php
@@ -11,10 +11,11 @@ use AppBundle\Mailjet\EmailTemplate;
 use AppBundle\Mailjet\Message\CommitteeMessageNotificationMessage;
 use AppBundle\Repository\MailjetEmailRepository;
 use Doctrine\Common\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\AppBundle\Test\Mailjet\Message\DummyMessage;
 
-class EmailPersisterEventSubscriberTest extends \PHPUnit_Framework_TestCase
+class EmailPersisterEventSubscriberTest extends TestCase
 {
     /** @var EmailPersisterEventSubscriber */
     private $subscriber;

--- a/tests/Mailjet/MailjetServiceTest.php
+++ b/tests/Mailjet/MailjetServiceTest.php
@@ -6,12 +6,13 @@ use AppBundle\Mailjet\Event\MailjetEvent;
 use AppBundle\Mailjet\Event\MailjetEvents;
 use AppBundle\Mailjet\MailjetService;
 use AppBundle\Mailjet\EmailTemplateFactory;
+use PHPUnit\Framework\TestCase;
 use Tests\AppBundle\Test\Mailjet\Message\DummyMessage;
 use Tests\AppBundle\Test\Mailjet\Transport\FailingTransport;
 use Tests\AppBundle\Test\Mailjet\Transport\NullTransport;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class MailjetServiceTest extends \PHPUnit_Framework_TestCase
+class MailjetServiceTest extends TestCase
 {
     public function testSendMessage()
     {

--- a/tests/Mailjet/Message/AbstractEventMessageTest.php
+++ b/tests/Mailjet/Message/AbstractEventMessageTest.php
@@ -6,8 +6,9 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\Event;
 use AppBundle\Entity\PostAddress;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractEventMessageTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractEventMessageTest extends TestCase
 {
     protected function createEventMock(string $name, string $beginAt, string $street, string $cityCode, ?string $committeeName = null): Event
     {

--- a/tests/Mailjet/Message/AdherentAccountActivationMessageTest.php
+++ b/tests/Mailjet/Message/AdherentAccountActivationMessageTest.php
@@ -5,8 +5,9 @@ namespace Tests\AppBundle\Mailjet\Message;
 use AppBundle\Entity\Adherent;
 use AppBundle\Mailjet\Message\AdherentAccountActivationMessage;
 use AppBundle\Mailjet\Message\MailjetMessageRecipient;
+use PHPUnit\Framework\TestCase;
 
-class AdherentAccountActivationMessageTest extends \PHPUnit_Framework_TestCase
+class AdherentAccountActivationMessageTest extends TestCase
 {
     public function testCreateAdherentAccountActivationMessage()
     {

--- a/tests/Mailjet/Message/AdherentAccountConfirmationMessageTest.php
+++ b/tests/Mailjet/Message/AdherentAccountConfirmationMessageTest.php
@@ -5,8 +5,9 @@ namespace Tests\AppBundle\Mailjet\Message;
 use AppBundle\Entity\Adherent;
 use AppBundle\Mailjet\Message\AdherentAccountConfirmationMessage;
 use AppBundle\Mailjet\Message\MailjetMessageRecipient;
+use PHPUnit\Framework\TestCase;
 
-class AdherentAccountConfirmationMessageTest extends \PHPUnit_Framework_TestCase
+class AdherentAccountConfirmationMessageTest extends TestCase
 {
     public function testCreateAdherentAccountConfirmationMessage()
     {

--- a/tests/Mailjet/Message/InvitationMessageTest.php
+++ b/tests/Mailjet/Message/InvitationMessageTest.php
@@ -5,8 +5,9 @@ namespace Tests\AppBundle\Mailjet\Message;
 use AppBundle\Entity\Invite;
 use AppBundle\Mailjet\Message\InvitationMessage;
 use AppBundle\Mailjet\Message\MailjetMessageRecipient;
+use PHPUnit\Framework\TestCase;
 
-class InvitationMessageTest extends \PHPUnit_Framework_TestCase
+class InvitationMessageTest extends TestCase
 {
     public function testCreateInvitationMessageFromInvite()
     {

--- a/tests/Mailjet/Message/JeMarcheReportMessageTest.php
+++ b/tests/Mailjet/Message/JeMarcheReportMessageTest.php
@@ -4,9 +4,10 @@ namespace Tests\AppBundle\Mailjet\Message;
 
 use AppBundle\Entity\JeMarcheReport;
 use AppBundle\Mailjet\Message\JeMarcheReportMessage;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 
-class JeMarcheReportMessageTest extends \PHPUnit_Framework_TestCase
+class JeMarcheReportMessageTest extends TestCase
 {
     public function testCreateJeMarcheReportMessageFromJeMarcheReport()
     {

--- a/tests/Mailjet/Transport/ApiTransportTest.php
+++ b/tests/Mailjet/Transport/ApiTransportTest.php
@@ -7,9 +7,10 @@ use AppBundle\Mailjet\Transport\ApiTransport;
 use AppBundle\Mailjet\EmailTemplate;
 use GuzzleHttp\ClientInterface as HttpClientInterface;
 use GuzzleHttp\Psr7\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class ApiTransportTest extends \PHPUnit_Framework_TestCase
+class ApiTransportTest extends TestCase
 {
     /**
      * @expectedException \AppBundle\Mailjet\Exception\MailjetException

--- a/tests/Mailjet/Transport/NullTransportTest.php
+++ b/tests/Mailjet/Transport/NullTransportTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\AppBundle\Mailjet\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\AppBundle\Test\Mailjet\Transport\NullTransport;
 use AppBundle\Mailjet\EmailTemplate;
 use Psr\Log\LoggerInterface;
 
-class NullTransportTest extends \PHPUnit_Framework_TestCase
+class NullTransportTest extends TestCase
 {
     public function testSendTemplateEmail()
     {

--- a/tests/Membership/AdherentFactoryTest.php
+++ b/tests/Membership/AdherentFactoryTest.php
@@ -9,11 +9,12 @@ use AppBundle\Membership\ActivityPositions;
 use AppBundle\Membership\AdherentFactory;
 use AppBundle\Membership\MembershipRequest;
 use libphonenumber\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactory;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 
-class AdherentFactoryTest extends \PHPUnit_Framework_TestCase
+class AdherentFactoryTest extends TestCase
 {
     public function testCreateNonFrenchAdherentFromArray()
     {

--- a/tests/Procuration/ProcurationProxyMessageFactoryTest.php
+++ b/tests/Procuration/ProcurationProxyMessageFactoryTest.php
@@ -10,8 +10,9 @@ use AppBundle\Mailjet\Message\ProcurationProxyFoundMessage;
 use AppBundle\Procuration\ProcurationProxyMessageFactory;
 use AppBundle\Routing\RemoteUrlGenerator;
 use libphonenumber\PhoneNumberUtil;
+use PHPUnit\Framework\TestCase;
 
-class ProcurationProxyMessageFactoryTest extends \PHPUnit_Framework_TestCase
+class ProcurationProxyMessageFactoryTest extends TestCase
 {
     private $urlGenerator;
 

--- a/tests/Security/AdherentLoginTimestampRecorderTest.php
+++ b/tests/Security/AdherentLoginTimestampRecorderTest.php
@@ -7,11 +7,12 @@ use AppBundle\Entity\PostAddress;
 use AppBundle\Membership\ActivityPositions;
 use AppBundle\Security\AdherentLoginTimestampRecorder;
 use Doctrine\Common\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
-class AdherentLoginTimestampRecorderTest extends \PHPUnit_Framework_TestCase
+class AdherentLoginTimestampRecorderTest extends TestCase
 {
     public function testRecordLastLoginTimestamp()
     {

--- a/tests/Serializer/EventIcalHandlerTest.php
+++ b/tests/Serializer/EventIcalHandlerTest.php
@@ -7,9 +7,10 @@ use AppBundle\Serializer\EventICalHandler;
 use AppBundle\Serializer\IcalSerializationVisitor;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\SerializationContext;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 
-class EventIcalHandlerTest extends \PHPUnit_Framework_TestCase
+class EventIcalHandlerTest extends TestCase
 {
     /**
      * @var EventICalHandler

--- a/tests/Serializer/IcalSerializationVisitorTest.php
+++ b/tests/Serializer/IcalSerializationVisitorTest.php
@@ -4,8 +4,9 @@ namespace Tests\AppBundle\Serializer;
 
 use AppBundle\Serializer\IcalSerializationVisitor;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use PHPUnit\Framework\TestCase;
 
-class IcalSerializationVisitorTest extends \PHPUnit_Framework_TestCase
+class IcalSerializationVisitorTest extends TestCase
 {
     protected $propertyNamingStrategy;
     /**

--- a/tests/Storage/FilesystemAdapterFactoryTest.php
+++ b/tests/Storage/FilesystemAdapterFactoryTest.php
@@ -5,9 +5,10 @@ namespace Tests\AppBundle\Storage;
 use AppBundle\Storage\FilesystemAdapterFactory;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Cached\CachedAdapter;
+use PHPUnit\Framework\TestCase;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 
-class FilesystemAdapterFactoryTest extends \PHPUnit_Framework_TestCase
+class FilesystemAdapterFactoryTest extends TestCase
 {
     public function testCreateDevAdapter()
     {

--- a/tests/TonMacron/TonMacronMessageBodyBuilderTest.php
+++ b/tests/TonMacron/TonMacronMessageBodyBuilderTest.php
@@ -6,9 +6,10 @@ use AppBundle\Entity\TonMacronChoice;
 use AppBundle\Repository\TonMacronChoiceRepository;
 use AppBundle\TonMacron\InvitationProcessor;
 use AppBundle\TonMacron\TonMacronMessageBodyBuilder;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class TonMacronMessageBodyBuilderTest extends \PHPUnit_Framework_TestCase
+class TonMacronMessageBodyBuilderTest extends TestCase
 {
     private $repository;
 

--- a/tests/Utils/EmojisRemoverTest.php
+++ b/tests/Utils/EmojisRemoverTest.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\ValueObject;
 
 use AppBundle\Utils\EmojisRemover;
+use PHPUnit\Framework\TestCase;
 
-class EmojisRemoverTest extends \PHPUnit_Framework_TestCase
+class EmojisRemoverTest extends TestCase
 {
     public function testEmojis()
     {

--- a/tests/ValueObject/SHA1Test.php
+++ b/tests/ValueObject/SHA1Test.php
@@ -3,8 +3,9 @@
 namespace Tests\AppBundle\ValueObject;
 
 use AppBundle\ValueObject\SHA1;
+use PHPUnit\Framework\TestCase;
 
-class SHA1Test extends \PHPUnit_Framework_TestCase
+class SHA1Test extends TestCase
 {
     /**
      * @dataProvider provideInvalidHash


### PR DESCRIPTION
- Updated dependencies:
  - Updating liip/functional-test-bundle (1.7.3 => 1.8.0)    
  - Updating sebastian/recursion-context (2.0.0 => 3.0.0)
  - Installing sebastian/object-reflector (1.1.1)
  - Updating sebastian/object-enumerator (2.0.1 => 3.0.2)
  - Updating sebastian/global-state (1.1.1 => 2.0.0)
  - Updating sebastian/exporter (2.0.0 => 3.1.0)
  - Updating sebastian/environment (2.0.0 => 3.0.4)         
  - Updating sebastian/comparator (1.2.4 => 2.0.0)
  - Updating phpunit/phpunit-mock-objects (3.4.3 => 4.0.1)
  - Installing theseer/tokenizer (1.1.0)
  - Updating phpunit/php-code-coverage (4.0.8 => 5.2.1)
  - Installing phar-io/version (1.0.1)
  - Installing phar-io/manifest (1.0.1)
  - Updating phpunit/phpunit (5.7.20 => 6.2.2)         
  - Updating giggsey/libphonenumber-for-php (8.5.1 => 8.5.2)      
  - Updating monolog/monolog (1.22.1 => 1.23.0)    
  - Updating willdurand/geocoder (v3.3.0 => v3.3.2)

- Removed deprecations by ensuring each test has at least one assertion.

- Used PHPUnit namespaces