### PR TITLE
Send event links to mail templates

### DIFF
--- a/app/config/services/platform.xml
+++ b/app/config/services/platform.xml
@@ -268,6 +268,7 @@
             <argument type="service" id="app.event.registration_factory"/>
             <argument type="service" id="app.event.registration_manager"/>
             <argument type="service" id="app.mailjet.transactional_mailer"/>
+            <argument type="service" id="app.routing.remote_url_generator"/>
         </service>
 
         <service id="app.citizen_initiative.registration_handler" class="AppBundle\CitizenInitiative\CitizenInitiativeRegistrationCommandHandler">
@@ -275,6 +276,7 @@
             <argument type="service" id="app.event.registration_manager"/>
             <argument type="service" id="app.activity_subscription.manager"/>
             <argument type="service" id="app.mailjet.transactional_mailer"/>
+            <argument type="service" id="app.routing.remote_url_generator"/>
         </service>
 
         <service id="app.event.message_notifier" class="AppBundle\Event\EventMessageNotifier">

--- a/src/Mailjet/Message/CitizenInitiativeRegistrationConfirmationMessage.php
+++ b/src/Mailjet/Message/CitizenInitiativeRegistrationConfirmationMessage.php
@@ -7,7 +7,7 @@ use Ramsey\Uuid\Uuid;
 
 final class CitizenInitiativeRegistrationConfirmationMessage extends MailjetMessage
 {
-    public static function createFromRegistration(EventRegistration $registration): self
+    public static function createFromRegistration(EventRegistration $registration, string $citizenInitiativeLink): self
     {
         $event = $registration->getEvent();
         $firstName = $registration->getFirstName();
@@ -22,7 +22,8 @@ final class CitizenInitiativeRegistrationConfirmationMessage extends MailjetMess
             static::getTemplateVars(
                 $event->getName(),
                 $organizer->getFirstName(),
-                $organizer->getLastName()
+                $organizer->getLastName(),
+                $citizenInitiativeLink
             ),
             static::getRecipientVars($firstName)
         );
@@ -31,16 +32,18 @@ final class CitizenInitiativeRegistrationConfirmationMessage extends MailjetMess
     private static function getTemplateVars(
         string $initiativeName,
         string $referentFirstName,
-        string $referentLastName
+        string $referentLastName,
+        string $citizenInitiativeLink
     ): array {
         return [
             'IC_name' => self::escape($initiativeName),
             'IC_organiser_firstname' => self::escape($referentFirstName),
             'IC_organiser_lastname' => self::escape($referentLastName),
+            'IC_link' => $citizenInitiativeLink,
         ];
     }
 
-    public static function getRecipientVars(string $firstName): array
+    private static function getRecipientVars(string $firstName): array
     {
         return [
             'prenom' => self::escape($firstName),

--- a/src/Mailjet/Message/EventRegistrationConfirmationMessage.php
+++ b/src/Mailjet/Message/EventRegistrationConfirmationMessage.php
@@ -7,7 +7,7 @@ use Ramsey\Uuid\Uuid;
 
 final class EventRegistrationConfirmationMessage extends MailjetMessage
 {
-    public static function createFromRegistration(EventRegistration $registration): self
+    public static function createFromRegistration(EventRegistration $registration, string $eventLink): self
     {
         $event = $registration->getEvent();
         $firstName = $registration->getFirstName();
@@ -18,11 +18,31 @@ final class EventRegistrationConfirmationMessage extends MailjetMessage
             $registration->getEmailAddress(),
             self::fixMailjetParsing($firstName),
             'Confirmation de participation à un événement En Marche !',
-            [
-                'prenom' => self::escape($firstName),
-                'event_name' => self::escape($event->getName()),
-                'event_organiser' => self::escape($event->getOrganizerName()),
-            ]
+            static::getTemplateVars(
+                $event->getName(),
+                $event->getOrganizerName(),
+                $eventLink
+            ),
+            static::getRecipientVars($firstName)
         );
+    }
+
+    private static function getTemplateVars(
+        string $eventName,
+        string $organizerName,
+        string $eventLink
+    ): array {
+        return [
+            'event_name' => self::escape($eventName),
+            'event_organiser' => self::escape($organizerName),
+            'event_link' => $eventLink,
+        ];
+    }
+
+    private static function getRecipientVars(string $firstName): array
+    {
+        return [
+            'prenom' => self::escape($firstName),
+        ];
     }
 }

--- a/tests/Mailjet/Message/CitizenInitiativeRegistrationConfirmationMessageTest.php
+++ b/tests/Mailjet/Message/CitizenInitiativeRegistrationConfirmationMessageTest.php
@@ -8,6 +8,8 @@ use Ramsey\Uuid\UuidInterface;
 
 class CitizenInitiativeRegistrationConfirmationMessageTest extends AbstractEventMessageTest
 {
+    const CITIZEN_INITIATIVE_LINK = 'http://en-marche.fr/initiative_citoyenne/254/2017-12-27-initiative-citoyenne-a-lyon';
+
     public function testCreateMessageFromEventRegistration()
     {
         $organizer = $this->createAdherentMock('michelle.doe@example.com', 'Michelle', 'Doe');
@@ -20,7 +22,7 @@ class CitizenInitiativeRegistrationConfirmationMessageTest extends AbstractEvent
         $registration->expects($this->any())->method('getFirstName')->willReturn('John');
         $registration->expects($this->any())->method('getEmailAddress')->willReturn('john@bar.com');
 
-        $message = CitizenInitiativeRegistrationConfirmationMessage::createFromRegistration($registration);
+        $message = CitizenInitiativeRegistrationConfirmationMessage::createFromRegistration($registration, self::CITIZEN_INITIATIVE_LINK);
 
         $this->assertInstanceOf(CitizenInitiativeRegistrationConfirmationMessage::class, $message);
         $this->assertInstanceOf(UuidInterface::class, $message->getUuid());
@@ -33,8 +35,22 @@ class CitizenInitiativeRegistrationConfirmationMessageTest extends AbstractEvent
                 'IC_name' => 'Grand Meeting de Paris',
                 'IC_organiser_firstname' => 'Michelle',
                 'IC_organiser_lastname' => 'Doe',
+                'IC_link' => self::CITIZEN_INITIATIVE_LINK,
             ],
             $message->getVars()
+        );
+
+        $recipient = $message->getRecipient(0);
+
+        $this->assertSame(
+            [
+                'IC_name' => 'Grand Meeting de Paris',
+                'IC_organiser_firstname' => 'Michelle',
+                'IC_organiser_lastname' => 'Doe',
+                'IC_link' => self::CITIZEN_INITIATIVE_LINK,
+                'prenom' => 'John',
+            ],
+            $recipient->getVars()
         );
     }
 }

--- a/tests/Mailjet/Message/EventRegistrationConfirmationMessageTest.php
+++ b/tests/Mailjet/Message/EventRegistrationConfirmationMessageTest.php
@@ -8,6 +8,8 @@ use Ramsey\Uuid\UuidInterface;
 
 class EventRegistrationConfirmationMessageTest extends AbstractEventMessageTest
 {
+    const EVENT_LINK = 'http://en-marche.fr/evenements/201/2017-12-27-evenement-a-lyon';
+
     public function testCreateMessageFromEventRegistration()
     {
         $event = $this->createEventMock('Grand Meeting de Paris', '2017-02-01 15:30:00', 'Palais des Congrés, Porte Maillot', '75001-75101', 'EM Paris');
@@ -18,7 +20,7 @@ class EventRegistrationConfirmationMessageTest extends AbstractEventMessageTest
         $registration->expects($this->any())->method('getFirstName')->willReturn('John');
         $registration->expects($this->any())->method('getEmailAddress')->willReturn('john@bar.com');
 
-        $message = EventRegistrationConfirmationMessage::createFromRegistration($registration);
+        $message = EventRegistrationConfirmationMessage::createFromRegistration($registration, self::EVENT_LINK);
 
         $this->assertInstanceOf(EventRegistrationConfirmationMessage::class, $message);
         $this->assertInstanceOf(UuidInterface::class, $message->getUuid());
@@ -28,11 +30,23 @@ class EventRegistrationConfirmationMessageTest extends AbstractEventMessageTest
         $this->assertSame('Confirmation de participation à un événement En Marche !', $message->getSubject());
         $this->assertSame(
             [
-                'prenom' => 'John',
                 'event_name' => 'Grand Meeting de Paris',
                 'event_organiser' => 'Michelle',
+                'event_link' => self::EVENT_LINK,
             ],
             $message->getVars()
+        );
+
+        $recipient = $message->getRecipient(0);
+
+        $this->assertSame(
+            [
+                'event_name' => 'Grand Meeting de Paris',
+                'event_organiser' => 'Michelle',
+                'event_link' => self::EVENT_LINK,
+                'prenom' => 'John',
+            ],
+            $recipient->getVars()
         );
     }
 }


### PR DESCRIPTION
MailJet templates must be updated accordingly after this is merged.

1. Mail ID : 118620
    => new parameter {{var:event_link}}
2. Mail ID: 196483
    => new parameter {{var:IC_link}}