### PR TITLE
Notify if no mail is sent to any referent

### DIFF
--- a/src/Committee/CommitteeManager.php
+++ b/src/Committee/CommitteeManager.php
@@ -152,9 +152,9 @@ class CommitteeManager
         return $this->getAdherentRepository()->findOneByUuid($committee->getCreatedBy());
     }
 
-    public function getCommitteeReferent(Committee $committee): ?Adherent
+    public function getCommitteeReferents(Committee $committee): AdherentCollection
     {
-        return $this->getAdherentRepository()->findReferentByCommittee($committee);
+        return $this->getAdherentRepository()->findReferentsByCommittee($committee);
     }
 
     public function getCommitteeFollowers(Committee $committee, bool $withHosts = self::INCLUDE_HOSTS): AdherentCollection

--- a/src/Committee/MultipleReferentsFoundException.php
+++ b/src/Committee/MultipleReferentsFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AppBundle\Committee;
+
+use AppBundle\Collection\AdherentCollection;
+
+class MultipleReferentsFoundException extends \LogicException
+{
+    private $referents;
+
+    public function __construct(AdherentCollection $referents, $message = '', \Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+
+        $this->referents = $referents;
+    }
+
+    public function getReferents(): AdherentCollection
+    {
+        return $this->referents;
+    }
+}

--- a/src/Repository/AdherentRepository.php
+++ b/src/Repository/AdherentRepository.php
@@ -189,7 +189,7 @@ class AdherentRepository extends EntityRepository implements UserLoaderInterface
         ;
     }
 
-    public function findReferentByCommittee(Committee $committee): ?Adherent
+    public function findReferentsByCommittee(Committee $committee): AdherentCollection
     {
         $qb = $this
             ->createReferentQueryBuilder()
@@ -197,7 +197,7 @@ class AdherentRepository extends EntityRepository implements UserLoaderInterface
             ->setParameter('code', ManagedAreaUtils::getCodeFromCommittee($committee))
         ;
 
-        return $qb->getQuery()->getOneOrNullResult();
+        return new AdherentCollection($qb->getQuery()->getResult());
     }
 
     /**

--- a/tests/Controller/Admin/AdminCommitteeControllerTest.php
+++ b/tests/Controller/Admin/AdminCommitteeControllerTest.php
@@ -24,6 +24,8 @@ class AdminCommitteeControllerTest extends MysqlWebTestCase
     {
         $committee = $this->committeeRepository->findOneByUuid(LoadAdherentData::COMMITTEE_2_UUID);
 
+        $this->assertFalse($committee->isApproved());
+
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/login');
 
         // connect as admin

--- a/tests/Repository/AdherentRepositoryMysqlTest.php
+++ b/tests/Repository/AdherentRepositoryMysqlTest.php
@@ -36,15 +36,19 @@ class AdherentRepositoryMysqlTest extends MysqlWebTestCase
         $this->assertSame('Lucie Olivera', $adherents[0]->getFullName());
     }
 
-    public function testFindReferentByCommittee()
+    public function testFindReferentsByCommittee()
     {
         // Foreign Committee with Referent
         $committee = $this->createMock(Committee::class);
         $committee->expects(static::any())->method('getCountry')->willReturn('CH');
 
-        $referent = $this->repository->findReferentByCommittee($committee);
+        $referents = $this->repository->findReferentsByCommittee($committee);
 
-        $this->assertNotNull($referent);
+        $this->assertNotEmpty($referents);
+        $this->assertCount(1, $referents);
+
+        $referent = $referents->first();
+
         $this->assertSame('Referent Referent', $referent->getFullName());
         $this->assertSame('referent@en-marche-dev.fr', $referent->getEmailAddress());
 
@@ -53,18 +57,21 @@ class AdherentRepositoryMysqlTest extends MysqlWebTestCase
         $committee->expects(static::any())->method('getCountry')->willReturn('FR');
         $committee->expects(static::any())->method('getPostalCode')->willReturn('06200');
 
-        $referent = $this->repository->findReferentByCommittee($committee);
+        $referents = $this->repository->findReferentsByCommittee($committee);
 
-        $this->assertNull($referent);
+        $this->assertEmpty($referents);
 
         // Departemental Commitee with Referent
         $committee = $this->createMock(Committee::class);
         $committee->expects(static::any())->method('getCountry')->willReturn('FR');
         $committee->expects(static::any())->method('getPostalCode')->willReturn('77190');
 
-        $referent = $this->repository->findReferentByCommittee($committee);
+        $referents = $this->repository->findReferentsByCommittee($committee);
 
-        $this->assertNotNull($referent);
+        $this->assertCount(1, $referents);
+
+        $referent = $referents->first();
+
         $this->assertSame('Referent Referent', $referent->getFullName());
         $this->assertSame('referent@en-marche-dev.fr', $referent->getEmailAddress());
     }


### PR DESCRIPTION
- a committee can now be managed by more than one referent
- no mail is sent to referents after a committee approval if more than one referent is found
- admins should be notified about this eventual referent conflict