### PR TITLE
Add docker latest tag and workers deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -79,6 +79,9 @@ deployment:
             # Push the images to Google Cloud
             - sudo /opt/google-cloud-sdk/bin/gcloud docker -- push eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1
 
+            # Tag image as latest
+            - sudo /opt/google-cloud-sdk/bin/gcloud container images add-tag eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1 eu.gcr.io/$GCLOUD_PROJECT/app:latest --quiet
+
             # Deploy to staging
             - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update kubectl
             - sudo /opt/google-cloud-sdk/bin/gcloud container clusters get-credentials $GCLOUD_CLUSTER --project $GCLOUD_PROJECT --zone europe-west1-d

--- a/circle.yml
+++ b/circle.yml
@@ -86,3 +86,6 @@ deployment:
             - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update kubectl
             - sudo /opt/google-cloud-sdk/bin/gcloud container clusters get-credentials $GCLOUD_CLUSTER --project $GCLOUD_PROJECT --zone europe-west1-d
             - sudo GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json /opt/google-cloud-sdk/bin/kubectl set image deployment/staging-app enmarche=eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1
+            - sudo GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json /opt/google-cloud-sdk/bin/kubectl set image deployment/staging-worker-mailjet-campaign enmarche=eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1
+            - sudo GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json /opt/google-cloud-sdk/bin/kubectl set image deployment/staging-worker-mailjet-transactional enmarche=eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1
+            - sudo GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json /opt/google-cloud-sdk/bin/kubectl set image deployment/staging-worker-referent enmarche=eu.gcr.io/$GCLOUD_PROJECT/app:$CIRCLE_SHA1


### PR DESCRIPTION
using :latest tag will only be used for staging updates and not for production as it's hard to track what image is really in use