### PR TITLE
Disable Xdebug on CircleCI for a faster build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,8 @@ dependencies:
               curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
             fi
         - echo "memory_limit = 2048M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
+        - rm /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
+
     override:
         - yarn install
         - composer install --no-interaction


### PR DESCRIPTION
All is in the title