### PR TITLE
Add Timeline synchronization command

### DIFF
--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -11,14 +11,16 @@
 		<service id="AppBundle\Membership\AdherentRegistry" public="true" />
 
 		<!-- Algolia -->
-        <service id="AppBundle\Algolia\AlgoliaIndexedEntityManager" />
+		<service id="app.algolia.manual_indexer.inner" class="Algolia\AlgoliaSearchBundle\Ìndexer\ManualIndexer">
+			<factory service="algolia.indexer" method="getManualIndexer" />
+			<argument type="service" id="doctrine.orm.entity_manager" />
+		</service>
+		<service id="AppBundle\Algolia\AlgoliaIndexedEntityManager" />
 		<service id="AppBundle\Algolia\ManualIndexer">
-			<argument type="service">
-				<service class="Algolia\AlgoliaSearchBundle\Ìndexer\ManualIndexer">
-					<factory service="algolia.indexer" method="getManualIndexer" />
-					<argument type="service" id="doctrine.orm.entity_manager" />
-				</service>
-			</argument>
+			<argument type="service" id="app.algolia.manual_indexer.inner" />
+		</service>
+		<service id="AppBundle\Command\AlgoliaSynchronizeCommand">
+			<argument type="service" id="app.algolia.manual_indexer.inner" />
 		</service>
 
 		<!-- CitizenProject -->
@@ -70,7 +72,8 @@
 		<prototype namespace="AppBundle\Security\Voter\" resource="../../../src/Security/Voter" />
 
 		<!-- Timeline -->
-		<service id="AppBundle\Command\ImportTimelineCommand" />
+		<service id="AppBundle\Command\TimelineImportCommand" />
+		<service id="AppBundle\Command\TimelineSynchronizeCommand" />
 		<service id="AppBundle\Form\EventListener\EmptyTranslationRemoverListener">
 			<argument>%locales%</argument>
 			<argument>%locale%</argument>

--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -11,10 +11,6 @@
 		<service id="AppBundle\Membership\AdherentRegistry" public="true" />
 
 		<!-- Algolia -->
-		<service id="app.algolia.manual_indexer.inner" class="Algolia\AlgoliaSearchBundle\Ìndexer\ManualIndexer">
-			<factory service="algolia.indexer" method="getManualIndexer" />
-			<argument type="service" id="doctrine.orm.entity_manager" />
-		</service>
 		<service id="AppBundle\Algolia\AlgoliaIndexedEntityManager" />
 		<service id="AppBundle\Algolia\ManualIndexer" />
 		<service id="AppBundle\Command\AlgoliaSynchronizeCommand" />

--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -16,12 +16,8 @@
 			<argument type="service" id="doctrine.orm.entity_manager" />
 		</service>
 		<service id="AppBundle\Algolia\AlgoliaIndexedEntityManager" />
-		<service id="AppBundle\Algolia\ManualIndexer">
-			<argument type="service" id="app.algolia.manual_indexer.inner" />
-		</service>
-		<service id="AppBundle\Command\AlgoliaSynchronizeCommand">
-			<argument type="service" id="app.algolia.manual_indexer.inner" />
-		</service>
+		<service id="AppBundle\Algolia\ManualIndexer" />
+		<service id="AppBundle\Command\AlgoliaSynchronizeCommand" />
 
 		<!-- CitizenProject -->
         <service id="AppBundle\CitizenProject\CitizenProjectCommentCreationCommandHandler" public="true">

--- a/src/Algolia/ManualIndexer.php
+++ b/src/Algolia/ManualIndexer.php
@@ -2,24 +2,86 @@
 
 namespace AppBundle\Algolia;
 
+use Algolia\AlgoliaSearchBundle\Indexer\Indexer;
 use Algolia\AlgoliaSearchBundle\Indexer\ManualIndexer as BaseManualIndexer;
+use Doctrine\ORM\EntityManagerInterface;
 
 class ManualIndexer implements ManualIndexerInterface
 {
-    private $algolia;
+    private $indexer;
+    private $manager;
 
-    public function __construct(BaseManualIndexer $algolia)
+    /**
+     * @var BaseManualIndexer
+     */
+    private $manualIndexer;
+
+    public function __construct(Indexer $indexer, EntityManagerInterface $manager)
     {
-        $this->algolia = $algolia;
+        $this->indexer = $indexer;
+        $this->manager = $manager;
+        $this->manualIndexer = $indexer->getManualIndexer($manager);
     }
 
     public function index($entities, array $options = []): void
     {
-        $this->algolia->index($entities, $options);
+        $this->manualIndexer->index($entities, $options);
     }
 
     public function unIndex($entities, array $options = []): void
     {
-        $this->algolia->unIndex($entities, $options);
+        $this->manualIndexer->unIndex($entities, $options);
+    }
+
+    public function reIndex($entityName, array $options = []): int
+    {
+        $this->synchronizeEntitySettings($entityName);
+
+        return $this->manualIndexer->reIndex($entityName, array_merge([
+            'batchSize' => 3000,
+            'safe' => true,
+            'clearEntityManager' => true,
+        ], $options));
+    }
+
+    private function synchronizeEntitySettings(string $entityName): void
+    {
+        $this->discoverEntity($entityName);
+
+        if (!$settings = $this->getEntitySettings($entityName)) {
+            return;
+        }
+
+        $this->updateEntitySettings($entityName, $settings);
+
+        $this->indexer->waitForAlgoliaTasks();
+    }
+
+    private function discoverEntity(string $entityName): void
+    {
+        $this->indexer->discoverEntity($entityName, $this->manager);
+    }
+
+    private function getEntitySettings(string $entityName): array
+    {
+        if (!$settings = $this->indexer->getIndexSettings()[$entityName] ?? null) {
+            return [];
+        }
+
+        return $settings->getIndex()->getAlgoliaSettings();
+    }
+
+    private function getIndexName(string $entityName): string
+    {
+        return $this->indexer->getAlgoliaIndexName($entityName);
+    }
+
+    private function updateEntitySettings(string $entityName, array $settings): void
+    {
+        $this->indexer->setIndexSettings(
+            $this->getIndexName($entityName),
+            $settings,
+            ['adaptIndexName' => false]
+        );
     }
 }

--- a/src/Algolia/ManualIndexerInterface.php
+++ b/src/Algolia/ManualIndexerInterface.php
@@ -7,4 +7,6 @@ interface ManualIndexerInterface
     public function index($entities, array $options = []): void;
 
     public function unIndex($entities, array $options = []): void;
+
+    public function reIndex($entityName, array $options = []): int;
 }

--- a/src/Command/AlgoliaSynchronizeCommand.php
+++ b/src/Command/AlgoliaSynchronizeCommand.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Command;
 
-use Algolia\AlgoliaSearchBundle\Indexer\ManualIndexer;
+use AppBundle\Algolia\ManualIndexer;
 use AppBundle\Entity\Article;
 use AppBundle\Entity\Clarification;
 use AppBundle\Entity\CustomSearchResult;
@@ -32,19 +32,12 @@ class AlgoliaSynchronizeCommand extends Command
         Measure::class,
     ];
 
-    /**
-     * @var ManualIndexer
-     */
-    private $indexer;
-
-    /**
-     * @var EntityManagerInterface
-     */
+    private $algolia;
     private $manager;
 
-    public function __construct(ManualIndexer $indexer, EntityManagerInterface $manager)
+    public function __construct(ManualIndexer $algolia, EntityManagerInterface $manager)
     {
-        $this->indexer = $indexer;
+        $this->algolia = $algolia;
         $this->manager = $manager;
 
         $this->manager->getFilters()->disable('oneLocale');
@@ -68,17 +61,8 @@ class AlgoliaSynchronizeCommand extends Command
 
         foreach ($toIndex as $entity) {
             $output->write('Synchronizing entity '.$entity.' ... ');
-            $nbIndexes = $this->synchronizeEntity($entity);
+            $nbIndexes = $this->algolia->reIndex($entity);
             $output->writeln('done, '.$nbIndexes.' records indexed');
         }
-    }
-
-    private function synchronizeEntity($className)
-    {
-        return (int) $this->indexer->reIndex($className, [
-            'batchSize' => 3000,
-            'safe' => true,
-            'clearEntityManager' => true,
-        ]);
     }
 }

--- a/src/Command/AlgoliaSynchronizeCommand.php
+++ b/src/Command/AlgoliaSynchronizeCommand.php
@@ -40,7 +40,11 @@ class AlgoliaSynchronizeCommand extends Command
         $this->algolia = $algolia;
         $this->manager = $manager;
 
-        $this->manager->getFilters()->disable('oneLocale');
+        $filters = $this->manager->getFilters();
+
+        if ($filters->isEnabled('oneLocale')) {
+            $filters->disable('oneLocale');
+        }
 
         parent::__construct();
     }

--- a/src/Command/AlgoliaSynchronizeCommand.php
+++ b/src/Command/AlgoliaSynchronizeCommand.php
@@ -54,25 +54,25 @@ class AlgoliaSynchronizeCommand extends Command
         $this
             ->setName(self::COMMAND_NAME)
             ->addArgument('entityName', InputArgument::OPTIONAL, 'Which type of entity do you want to reindex? If not set, all is assumed.')
-            ->setDescription('Synchronize')
+            ->setDescription('Synchronize indices on Algolia')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        foreach ($this->getEntitiesToIndex($input) as $entity) {
-            $output->write('Synchronizing entity '.$entity.' ... ');
+        foreach ($this->getEntitiesToIndex($input->getArgument('entityName')) as $entity) {
+            $output->write("Synchronizing entity $entity ... ");
             $nbIndexes = $this->algolia->reIndex($entity);
-            $output->writeln('done, '.$nbIndexes.' records indexed');
+            $output->writeln("done, $nbIndexes records indexed");
         }
     }
 
-    protected function getEntitiesToIndex(InputInterface $input): array
+    private function getEntitiesToIndex(?string $entityName): array
     {
-        if ($entityNameToIndex = $input->getArgument('entityName')) {
-            return [$this->manager->getRepository($entityNameToIndex)->getClassName()];
+        if ($entityName) {
+            return [$this->manager->getRepository($entityName)->getClassName()];
         }
 
-        return self::ENTITIES_TO_INDEX;
+        return static::ENTITIES_TO_INDEX;
     }
 }

--- a/src/Command/AlgoliaSynchronizeCommand.php
+++ b/src/Command/AlgoliaSynchronizeCommand.php
@@ -21,7 +21,7 @@ class AlgoliaSynchronizeCommand extends Command
 {
     public const COMMAND_NAME = 'app:algolia:synchronize';
 
-    private const ENTITIES_TO_INDEX = [
+    protected const ENTITIES_TO_INDEX = [
         Article::class,
         Proposal::class,
         Clarification::class,
@@ -56,13 +56,19 @@ class AlgoliaSynchronizeCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entityNameToIndex = $input->getArgument('entityName');
-        $toIndex = $entityNameToIndex ? [$this->manager->getRepository($entityNameToIndex)->getClassName()] : self::ENTITIES_TO_INDEX;
-
-        foreach ($toIndex as $entity) {
+        foreach ($this->getEntitiesToIndex($input) as $entity) {
             $output->write('Synchronizing entity '.$entity.' ... ');
             $nbIndexes = $this->algolia->reIndex($entity);
             $output->writeln('done, '.$nbIndexes.' records indexed');
         }
+    }
+
+    protected function getEntitiesToIndex(InputInterface $input): array
+    {
+        if ($entityNameToIndex = $input->getArgument('entityName')) {
+            return [$this->manager->getRepository($entityNameToIndex)->getClassName()];
+        }
+
+        return self::ENTITIES_TO_INDEX;
     }
 }

--- a/src/Command/TimelineImportCommand.php
+++ b/src/Command/TimelineImportCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
-class ImportTimelineCommand extends Command
+class TimelineImportCommand extends Command
 {
     private const BOOLEAN_CHOICES = ['oui' => true, 'non' => false];
 
@@ -31,7 +31,7 @@ class ImportTimelineCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('app:import:timeline')
+            ->setName('app:timeline:import')
             ->addArgument('profilesUrl', InputArgument::REQUIRED)
             ->addArgument('themesUrl', InputArgument::REQUIRED)
             ->addArgument('measuresUrl', InputArgument::REQUIRED)

--- a/src/Command/TimelineSynchronizeCommand.php
+++ b/src/Command/TimelineSynchronizeCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace AppBundle\Command;
+
+use AppBundle\Entity\Timeline\Measure;
+use AppBundle\Entity\Timeline\Profile;
+use AppBundle\Entity\Timeline\Theme;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TimelineSynchronizeCommand extends Command
+{
+    private const ENTITIES_TO_INDEX = [
+        Profile::class,
+        Theme::class,
+        Measure::class,
+    ];
+
+    /**
+     * @var AlgoliaSynchronizeCommand
+     */
+    private $synchronizeCommand;
+
+    public function __construct(AlgoliaSynchronizeCommand $synchronizeCommand)
+    {
+        $this->synchronizeCommand = $synchronizeCommand;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('app:timeline:synchronize')
+            ->setDescription('Update Timeline indices on Algolia')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Synchronizing Timeline with Algolia..');
+
+        foreach (self::ENTITIES_TO_INDEX as $entityToIndex) {
+            $this->synchronizeCommand->run(new ArrayInput(['entityName' => $entityToIndex]), $output);
+        }
+
+        $output->writeln('Timeline has been successfully synchronized with Algolia.');
+    }
+}

--- a/src/Command/TimelineSynchronizeCommand.php
+++ b/src/Command/TimelineSynchronizeCommand.php
@@ -5,30 +5,16 @@ namespace AppBundle\Command;
 use AppBundle\Entity\Timeline\Measure;
 use AppBundle\Entity\Timeline\Profile;
 use AppBundle\Entity\Timeline\Theme;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TimelineSynchronizeCommand extends Command
+class TimelineSynchronizeCommand extends AlgoliaSynchronizeCommand
 {
-    private const ENTITIES_TO_INDEX = [
+    protected const ENTITIES_TO_INDEX = [
         Profile::class,
         Theme::class,
         Measure::class,
     ];
-
-    /**
-     * @var AlgoliaSynchronizeCommand
-     */
-    private $synchronizeCommand;
-
-    public function __construct(AlgoliaSynchronizeCommand $synchronizeCommand)
-    {
-        $this->synchronizeCommand = $synchronizeCommand;
-
-        parent::__construct();
-    }
 
     protected function configure()
     {
@@ -42,10 +28,13 @@ class TimelineSynchronizeCommand extends Command
     {
         $output->writeln('Synchronizing Timeline with Algolia..');
 
-        foreach (self::ENTITIES_TO_INDEX as $entityToIndex) {
-            $this->synchronizeCommand->run(new ArrayInput(['entityName' => $entityToIndex]), $output);
-        }
+        parent::execute($input, $output);
 
         $output->writeln('Timeline has been successfully synchronized with Algolia. (but the tasks may not have completed on Algolia\'s side yet)');
+    }
+
+    protected function getEntitiesToIndex(InputInterface $input): array
+    {
+        return self::ENTITIES_TO_INDEX;
     }
 }

--- a/src/Command/TimelineSynchronizeCommand.php
+++ b/src/Command/TimelineSynchronizeCommand.php
@@ -18,9 +18,11 @@ class TimelineSynchronizeCommand extends AlgoliaSynchronizeCommand
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('app:timeline:synchronize')
-            ->setDescription('Update Timeline indices on Algolia')
+            ->setDescription('Synchronize Timeline indices on Algolia')
         ;
     }
 
@@ -31,10 +33,5 @@ class TimelineSynchronizeCommand extends AlgoliaSynchronizeCommand
         parent::execute($input, $output);
 
         $output->writeln('Timeline has been successfully synchronized with Algolia. (but the tasks may not have completed on Algolia\'s side yet)');
-    }
-
-    protected function getEntitiesToIndex(InputInterface $input): array
-    {
-        return self::ENTITIES_TO_INDEX;
     }
 }

--- a/src/Command/TimelineSynchronizeCommand.php
+++ b/src/Command/TimelineSynchronizeCommand.php
@@ -46,6 +46,6 @@ class TimelineSynchronizeCommand extends Command
             $this->synchronizeCommand->run(new ArrayInput(['entityName' => $entityToIndex]), $output);
         }
 
-        $output->writeln('Timeline has been successfully synchronized with Algolia.');
+        $output->writeln('Timeline has been successfully synchronized with Algolia. (but the tasks may not have completed on Algolia\'s side yet)');
     }
 }

--- a/src/Entity/Timeline/Theme.php
+++ b/src/Entity/Timeline/Theme.php
@@ -18,7 +18,11 @@ use Doctrine\ORM\Mapping as ORM;
  * @Algolia\Index(
  *     autoIndex=false,
  *     hitsPerPage=100,
- *     attributesForFaceting={"title", "profileIds"}
+ *     attributesForFaceting={
+ *         "titles.fr",
+ *         "titles.en",
+ *         "profileIds"
+ *     }
  * )
  */
 class Theme implements EntityMediaInterface, AlgoliaIndexedEntityInterface

--- a/tests/Command/AlgoliaSynchronizeCommandTest.php
+++ b/tests/Command/AlgoliaSynchronizeCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\AppBundle\Command;
+
+use AppBundle\DataFixtures\ORM\LoadAdherentData;
+use AppBundle\DataFixtures\ORM\LoadArticleData;
+use AppBundle\DataFixtures\ORM\LoadEventData;
+use AppBundle\DataFixtures\ORM\LoadProposalData;
+use AppBundle\DataFixtures\ORM\LoadTimelineData;
+use Tests\AppBundle\SqliteWebTestCase;
+
+/**
+ * @group functional
+ */
+class AlgoliaSynchronizeCommandTest extends SqliteWebTestCase
+{
+    /**
+     * @dataProvider dataProviderTestCommand
+     */
+    public function testCommand(array $parameters, array $expectedOutputs)
+    {
+        $output = $this->runCommand('app:algolia:synchronize', $parameters);
+
+        foreach ($expectedOutputs as $expectedOutput) {
+            $this->assertContains($expectedOutput, $output);
+        }
+    }
+
+    public function dataProviderTestCommand(): array
+    {
+        return [
+            [
+                ['entityName' => 'AppBundle:Event'],
+                ['Synchronizing entity AppBundle\Entity\Event ... done, 15 records indexed'],
+            ],
+            [
+                ['entityName' => 'AppBundle\Entity\Timeline\Theme'],
+                ['Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed'],
+            ],
+            [
+                [], // no parameters
+                [
+                    'Synchronizing entity AppBundle\Entity\Article ... done, 154 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Proposal ... done, 3 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Clarification ... done, 0 records indexed',
+                    'Synchronizing entity AppBundle\Entity\CustomSearchResult ... done, 0 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Event ... done, 15 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Timeline\Profile ... done, 5 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Timeline\Measure ... done, 17 records indexed',
+                ],
+            ],
+        ];
+    }
+
+    public function setUp()
+    {
+        $this->loadFixtures([
+            LoadAdherentData::class,
+            LoadArticleData::class,
+            LoadEventData::class,
+            LoadProposalData::class,
+            LoadTimelineData::class,
+        ]);
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        $this->loadFixtures([]);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Command/ImportReferentBioPictureCommandTest.php
+++ b/tests/Command/ImportReferentBioPictureCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Command;
+namespace Tests\AppBundle\Command;
 
 use AppBundle\DataFixtures\ORM\LoadReferentData;
 use AppBundle\Entity\Media;

--- a/tests/Command/ImportReferentBioPictureCommandTest.php
+++ b/tests/Command/ImportReferentBioPictureCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Command;
 
+use AppBundle\Command\ImportReferentBioPictureCommand;
 use AppBundle\DataFixtures\ORM\LoadReferentData;
 use AppBundle\Entity\Media;
 use AppBundle\Entity\Referent;

--- a/tests/Command/ProcurationSendReminderCommandTest.php
+++ b/tests/Command/ProcurationSendReminderCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Command;
 
+use AppBundle\Command\ProcurationSendReminderCommand;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadProcurationData;
 use AppBundle\Mailer\Message\ProcurationProxyReminderMessage;

--- a/tests/Command/ProcurationSendReminderCommandTest.php
+++ b/tests/Command/ProcurationSendReminderCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Command;
+namespace Tests\AppBundle\Command;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadProcurationData;

--- a/tests/Command/TimelineSynchronizeCommandTest.php
+++ b/tests/Command/TimelineSynchronizeCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AppBundle\Command;
+
+use AppBundle\DataFixtures\ORM\LoadTimelineData;
+use Tests\AppBundle\SqliteWebTestCase;
+
+/**
+ * @group functional
+ */
+class TimelineSynchronizeCommandTest extends SqliteWebTestCase
+{
+    public function testCommand()
+    {
+        $output = $this->runCommand('app:timeline:synchronize');
+
+        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Profile ... done, 5 records indexed', $output);
+        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed', $output);
+        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Measure ... done, 17 records indexed', $output);
+        $this->assertContains('Timeline has been successfully synchronized with Algolia.', $output);
+    }
+
+    public function setUp()
+    {
+        $this->loadFixtures([
+            LoadTimelineData::class,
+        ]);
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        $this->loadFixtures([]);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Command/TimelineSynchronizeCommandTest.php
+++ b/tests/Command/TimelineSynchronizeCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Command;
+namespace Tests\AppBundle\Command;
 
 use AppBundle\DataFixtures\ORM\LoadTimelineData;
 use Tests\AppBundle\SqliteWebTestCase;

--- a/tests/Command/TimelineSynchronizeCommandTest.php
+++ b/tests/Command/TimelineSynchronizeCommandTest.php
@@ -14,10 +14,14 @@ class TimelineSynchronizeCommandTest extends SqliteWebTestCase
     {
         $output = $this->runCommand('app:timeline:synchronize');
 
-        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Profile ... done, 5 records indexed', $output);
-        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed', $output);
-        $this->assertContains('Synchronizing entity AppBundle\Entity\Timeline\Measure ... done, 17 records indexed', $output);
-        $this->assertContains('Timeline has been successfully synchronized with Algolia.', $output);
+        $expectedOutput = <<<EOL
+Synchronizing entity AppBundle\Entity\Timeline\Profile ... done, 5 records indexed
+Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed
+Synchronizing entity AppBundle\Entity\Timeline\Measure ... done, 17 records indexed
+Timeline has been successfully synchronized with Algolia.
+EOL;
+
+        $this->assertContains($expectedOutput, $output);
     }
 
     public function setUp()

--- a/tests/Test/Algolia/DummyIndexer.php
+++ b/tests/Test/Algolia/DummyIndexer.php
@@ -3,6 +3,7 @@
 namespace Tests\AppBundle\Test\Algolia;
 
 use Algolia\AlgoliaSearchBundle\Indexer\Indexer;
+use Doctrine\ORM\EntityManager;
 
 class DummyIndexer extends Indexer
 {
@@ -48,5 +49,10 @@ class DummyIndexer extends Indexer
     {
         $this->entitiesToIndex = [];
         $this->entitiesToUnIndex = [];
+    }
+
+    public function getManualIndexer(EntityManager $em)
+    {
+        return new DummyManualIndexer($this, $em);
     }
 }

--- a/tests/Test/Algolia/DummyIndexer.php
+++ b/tests/Test/Algolia/DummyIndexer.php
@@ -55,4 +55,8 @@ class DummyIndexer extends Indexer
     {
         return new DummyManualIndexer($this, $em);
     }
+
+    public function setIndexSettings($indexName, array $settings, array $options = [])
+    {
+    }
 }

--- a/tests/Test/Algolia/DummyManualIndexer.php
+++ b/tests/Test/Algolia/DummyManualIndexer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\AppBundle\Test\Algolia;
+
+use Algolia\AlgoliaSearchBundle\Indexer\ManualIndexer;
+
+class DummyManualIndexer extends ManualIndexer
+{
+    public function reIndex($entityName, array $options = [])
+    {
+        $options = array_merge($options, ['safe' => false]);
+
+        return parent::reIndex($entityName, $options);
+    }
+}


### PR DESCRIPTION
1. Command `app:algolia:synchronize` now updates Algolia index settings **if defined**.
2. Introduced the command `app:timeline:synchronize` which synchronizes the entities and index settings related to the Timeline with Algolia.