### PR TITLE
Bugfix - by default phone country fallback to address country

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2072,16 +2072,16 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.8.9",
+            "version": "8.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "44e2fb8ee3a62c3fd00fb8a37fe0bad394992c2e"
+                "reference": "919d24a13ff772b6af07d0f3ffefe8963cfb635c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/44e2fb8ee3a62c3fd00fb8a37fe0bad394992c2e",
-                "reference": "44e2fb8ee3a62c3fd00fb8a37fe0bad394992c2e",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/919d24a13ff772b6af07d0f3ffefe8963cfb635c",
+                "reference": "919d24a13ff772b6af07d0f3ffefe8963cfb635c",
                 "shasum": ""
             },
             "require": {
@@ -2136,7 +2136,7 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2018-01-09T19:14:30+00:00"
+            "time": "2018-02-07T11:27:18+00:00"
         },
         {
             "name": "giggsey/locale",
@@ -4291,35 +4291,35 @@
         },
         {
             "name": "misd/phone-number-bundle",
-            "version": "v1.2.0",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/misd-service-development/phone-number-bundle.git",
-                "reference": "44888e72dc9bf6f22949a6659be45330580ea84e"
+                "reference": "32e569b8aa4378e89345668e0cc526d1e0e5837a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/misd-service-development/phone-number-bundle/zipball/44888e72dc9bf6f22949a6659be45330580ea84e",
-                "reference": "44888e72dc9bf6f22949a6659be45330580ea84e",
+                "url": "https://api.github.com/repos/misd-service-development/phone-number-bundle/zipball/32e569b8aa4378e89345668e0cc526d1e0e5837a",
+                "reference": "32e569b8aa4378e89345668e0cc526d1e0e5837a",
                 "shasum": ""
             },
             "require": {
                 "giggsey/libphonenumber-for-php": "~5.7|~6.0|~7.0|~8.0",
                 "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.1|~3.0"
+                "symfony/framework-bundle": "~2.1|~3.0|^4.0"
             },
             "conflict": {
                 "twig/twig": "<1.12.0"
             },
             "require-dev": {
                 "doctrine/doctrine-bundle": "~1.0",
-                "jms/serializer-bundle": "~0.11|~1.0",
-                "phpunit/phpunit": "~4.0",
-                "symfony/form": "~2.3|~3.0",
-                "symfony/serializer": "~2.7|~3.1",
-                "symfony/templating": "~2.1|~3.0",
-                "symfony/twig-bundle": "~2.1|~3.0",
-                "symfony/validator": "~2.1|~3.0"
+                "jms/serializer-bundle": "~0.11|~1.0|~2.0",
+                "phpunit/phpunit": "~4.0|^5.7",
+                "symfony/form": "~2.3|~3.0|^4.0",
+                "symfony/serializer": "~2.7|~3.1|^4.0",
+                "symfony/templating": "~2.1|~3.0|^4.0",
+                "symfony/twig-bundle": "~2.1|~3.0|^4.0",
+                "symfony/validator": "~2.1|~3.0|^4.0"
             },
             "suggest": {
                 "doctrine/doctrine-bundle": "Add a DBAL mapping type",
@@ -4333,13 +4333,16 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Misd\\PhoneNumberBundle\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4354,7 +4357,7 @@
                 "phonenumber",
                 "telephone number"
             ],
-            "time": "2016-12-17T17:15:49+01:00"
+            "time": "2018-01-18T09:06:41+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/Controller/EnMarche/MembershipController.php
+++ b/src/Controller/EnMarche/MembershipController.php
@@ -80,7 +80,7 @@ class MembershipController extends Controller
         }
 
         $fromActivation = $request->query->getBoolean('from_activation');
-        $membership = MembershipRequest::createFromAdherent($user, $this->get('libphonenumber.phone_number_util'));
+        $membership = MembershipRequest::createFromAdherent($user);
         $form = $this->createForm(BecomeAdherentType::class, $membership)
             ->add('submit', SubmitType::class, ['label' => 'J\'adhère'])
         ;

--- a/src/Controller/EnMarche/UserController.php
+++ b/src/Controller/EnMarche/UserController.php
@@ -39,7 +39,7 @@ class UserController extends Controller
     public function profileAction(Request $request): Response
     {
         $adherent = $this->getUser();
-        $membership = MembershipRequest::createFromAdherent($adherent, $this->get('libphonenumber.phone_number_util'));
+        $membership = MembershipRequest::createFromAdherent($adherent);
         $form = $this->createForm(AdherentType::class, $membership)
             ->add('submit', SubmitType::class, ['label' => 'Enregistrer les modifications'])
         ;

--- a/src/Membership/MembershipRequest.php
+++ b/src/Membership/MembershipRequest.php
@@ -7,7 +7,6 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Validator\Recaptcha as AssertRecaptcha;
 use AppBundle\Validator\UniqueMembership as AssertUniqueMembership;
 use libphonenumber\PhoneNumber;
-use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -120,7 +119,7 @@ class MembershipRequest implements MembershipInterface
         return $dto;
     }
 
-    public static function createFromAdherent(Adherent $adherent, PhoneNumberUtil $phoneNumberUtil): self
+    public static function createFromAdherent(Adherent $adherent): self
     {
         $dto = new self();
         $dto->gender = $adherent->getGender();
@@ -132,13 +131,6 @@ class MembershipRequest implements MembershipInterface
         $dto->phone = $adherent->getPhone();
         $dto->comMobile = $adherent->getComMobile();
         $dto->emailAddress = $adherent->getEmailAddress();
-
-        if (!$dto->phone) {
-            $countryCode = $phoneNumberUtil->getCountryCodeForRegion($dto->address->getCountry());
-            $countryCode = $countryCode ?: 33;
-            $dto->phone = new PhoneNumber();
-            $dto->phone->setCountryCode($countryCode);
-        }
 
         return $dto;
     }


### PR DESCRIPTION
Previously the phone country was set through the object but in some cases
where the code country matches more than 1 country the PhoneNumberType was
not able to choose the right country.

Now, the default phone country is set though the form type which
prevents any weird behavior like this.