### PR TITLE
Run php-cs-fixer just for modified files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,15 @@ test:
         - yarn test
 
         # Lint PHP
-        - php -d memory_limit=1024m vendor/bin/php-cs-fixer fix --diff --dry-run --no-interaction -v --using-cache=no
+        - |
+            COMMIT_RANGE=$(echo "${CIRCLE_COMPARE_URL}" | cut -d/ -f7 | sed -e "s/\.\.\./ /")
+            # Fix single commit
+            if [[ $COMMIT_RANGE != *"..."* ]]; then
+              COMMIT_RANGE="${COMMIT_RANGE} ${COMMIT_RANGE}"
+            fi
+            CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${COMMIT_RANGE})
+            if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
+            php -d memory_limit=1024m vendor/bin/php-cs-fixer fix --config=.php_cs.dist --dry-run --no-interaction -v --using-cache=no "${EXTRA_ARGS[@]}"
 
         # Prepare PHP tests
         - rm -rf var/cache/test /tmp/data.db app/data/dumped_referents_users:


### PR DESCRIPTION
The goal of this PR is run `php-cs-fixer` check just for modified files in `git diff`. Actually this check take 58sec in circle for checking all files of the project.
https://github.com/FriendsOfPhp/PHP-CS-Fixer#using-php-cs-fixer-on-ci