### PR TITLE
[CA] Change link displaying + add link to mail + fix error message

### DIFF
--- a/front/style/layout/_base.scss
+++ b/front/style/layout/_base.scss
@@ -66,6 +66,10 @@ a {
         }
     }
 
+    &.link--padding {
+        padding-right: 40px;
+    }
+
     &.link--newblue { // temporary until we update our color palette
         color: $blue--dark;
         border-color: transparent;

--- a/src/CitizenAction/CitizenActionMessageNotifier.php
+++ b/src/CitizenAction/CitizenActionMessageNotifier.php
@@ -63,6 +63,7 @@ class CitizenActionMessageNotifier implements EventSubscriberInterface
             $registered,
             $host,
             $citizenAction,
+            $this->urlGenerator->generate('app_search_events', [], UrlGeneratorInterface::ABSOLUTE_URL),
             function (EventRegistration $registration) {
                 return CitizenActionCancellationMessage::getRecipientVars($registration->getFirstName());
             }

--- a/src/Form/ContactMembersType.php
+++ b/src/Form/ContactMembersType.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -14,9 +13,6 @@ class ContactMembersType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('contacts', HiddenType::class, [
-                'mapped' => false,
-            ])
             ->add('subject', TextType::class, [
                 'label' => false,
                 'attr' => ['placeholder' => 'Entrez l\'objet de votre message'],

--- a/src/Mailer/Message/CitizenActionCancellationMessage.php
+++ b/src/Mailer/Message/CitizenActionCancellationMessage.php
@@ -13,6 +13,7 @@ final class CitizenActionCancellationMessage extends Message
         array $recipients,
         Adherent $author,
         CitizenAction $citizenAction,
+        string $eventsLink,
         \Closure $recipientVarsGenerator
     ): self {
         if (!$recipients) {
@@ -30,7 +31,7 @@ final class CitizenActionCancellationMessage extends Message
             $recipient->getEmailAddress(),
             $recipient->getFirstName().' '.$recipient->getLastName(),
             '[Action citoyenne] Une action citoyenne à laquelle vous participez vient d\'être annulée.',
-            static::getTemplateVars($citizenAction->getName()),
+            static::getTemplateVars($citizenAction->getName(), $eventsLink),
             $recipientVarsGenerator($recipient),
             $author->getEmailAddress()
         );
@@ -47,10 +48,11 @@ final class CitizenActionCancellationMessage extends Message
         return $message;
     }
 
-    private static function getTemplateVars(string $citizenActionName): array
+    private static function getTemplateVars(string $citizenActionName, string $eventsLink): array
     {
         return [
             'citizen_action_name' => self::escape($citizenActionName),
+            'event_slug' => $eventsLink,
         ];
     }
 

--- a/templates/citizen_action/show.html.twig
+++ b/templates/citizen_action/show.html.twig
@@ -44,10 +44,10 @@
             <div id="members">
                 {% if is_administrator and citizen_action.active %}
                     <div class="b__nudge--bottom">
-                        <a href="{{ path('app_citizen_action_manager_edit', { slug: citizen_action.slug, project_slug: citizen_action.citizenProject.slug }) }}" class="text--body link--blue link--no-decor">
+                        <a href="{{ path('app_citizen_action_manager_edit', { slug: citizen_action.slug, project_slug: citizen_action.citizenProject.slug }) }}" class="text--body link--blue link--padding link--no-decor">
                             Modifier cette action citoyenne
                         </a>
-                        <a href="{{ path("app_citizen_action_manager_cancel", { slug: citizen_action.slug, project_slug: citizen_action.citizenProject.slug }) }}" class="text--body link--no-decor">
+                        <a href="{{ path("app_citizen_action_manager_cancel", { slug: citizen_action.slug, project_slug: citizen_action.citizenProject.slug }) }}" class="text--body link--blue link--no-decor">
                             Annuler cette action citoyenne
                         </a>
                     </div>

--- a/templates/citizen_action_manager/contact_participants.html.twig
+++ b/templates/citizen_action_manager/contact_participants.html.twig
@@ -39,7 +39,7 @@
 
                 {{ form_start(form) }}
 
-                   {{ form_widget(form.contacts, { value: contacts|json_encode }) }}
+                    <input type="hidden" name="contacts" value="{{ contacts|json_encode }}" />
 
                     <div class="form__row subject">
                         {{ form_label(form.subject, 'Objet') }}

--- a/templates/committee/contact.html.twig
+++ b/templates/committee/contact.html.twig
@@ -39,7 +39,7 @@
 
             {{ form_start(form) }}
 
-                {{ form_widget(form.contacts, { value: contacts|json_encode }) }}
+                <input type="hidden" name="contacts" value="{{ contacts|json_encode }}" />
 
                 <div class="form__row subject">
                     {{ form_label(form.subject, 'Objet') }}

--- a/templates/events/contact_members.html.twig
+++ b/templates/events/contact_members.html.twig
@@ -85,7 +85,7 @@
 
                 {{ form_start(form) }}
 
-                    {{ form_widget(form.contacts, { value: contacts|json_encode }) }}
+                    <input type="hidden" name="contacts" value="{{ contacts|json_encode }}" />
 
                     <div class="form__row subject">
                         {{ form_label(form.subject, 'Objet') }}


### PR DESCRIPTION
The field `contacts` was deleted from Type class and added directly in template to avoid displaying error message when array of `contacts` passed to controller from previous page and not from page with concerned form.