### PR TITLE
[ch3001] Fix display in "my account" for un-adherent

### DIFF
--- a/templates/user/my_account.html.twig
+++ b/templates/user/my_account.html.twig
@@ -8,7 +8,7 @@
         <span class="settings__username"><strong>Email</strong> {{ app.user.emailaddress }}</span><br />
         <span class="settings__username"><strong>Code postal</strong> {{ app.user.postAddress.postalCode }}</span><br/>
 
-        {% if app.user.activatedAt %}
+        {% if has_role_adherent and app.user.activatedAt %}
             <div class="settings__membership">Adhérent{{ app.user.female ? "e" }} depuis {{ app.user.registeredAt|localizeddate('none', 'none', 'fr_FR', null, 'MMMM Y') }}.</div>
         {% else %}
             <div class="settings__membership">Non adhérent{{ app.user.female ? "e" }}.</div>


### PR DESCRIPTION
https://app.clubhouse.io/enmarche/story/3001/la-partie-adherente-depuis-x-devrait-etre-visible-uniquement-si-la-personne-est-adherente