### PR TITLE
[Hotfix] Add id to postalCode row

### DIFF
--- a/templates/procuration/proposal.html.twig
+++ b/templates/procuration/proposal.html.twig
@@ -88,7 +88,7 @@
                                 {{ form_errors(procuration_form.country) }}
                             </div>
 
-                            <div class="register__form__zip_code register__form--third">
+                            <div id="vote-row-postal-code" class="register__form__zip_code register__form--third">
                                 {{ form_widget(procuration_form.postalCode, { attr: { placeholder: 'Code postal' } }) }}
                             </div>
 


### PR DESCRIPTION
Without this id:
- the JS breaks
- city input stays hidden
(see https://github.com/EnMarche/en-marche.fr/blob/develop/front/services/vote/VoteLocationForm.js#L65)