### PR TITLE
fix visual bug on separator

### DIFF
--- a/front/style/layout/_nav.scss
+++ b/front/style/layout/_nav.scss
@@ -180,6 +180,7 @@
 
     &__separator {
         border-top: 1px solid $gray--light;
+        height: 1px;
     }
 
     &:hover {


### PR DESCRIPTION
Fix little visual bug  on separator.
With some specific user, the separator wasn't visible.
Quick fix by adding a height on border-top.
