### PR TITLE
Mails consumer requires a routing key

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -306,7 +306,7 @@ old_sound_rabbit_mq:
         mailer:
             connection:        default
             exchange_options:  { name: 'mails', type: direct }
-            queue_options:     { name: 'mails', durable: false }
+            queue_options:     { name: 'mails', durable: false, routing_keys: [mailer.scheduled_mail] }
             callback:          AppBundle\Consumer\MailerConsumer
             qos_options:       { prefetch_size: 0, prefetch_count: 1, global: false }
 


### PR DESCRIPTION
We misunderstood each other with @ottaviano.
The routing key should be part of the consumer as the bundle has one by default when messages are produced.