### PR TITLE
[docker] Remove deprecated parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ deps: vendor web/built                                                          
 # Internal rules
 
 build:
-	$(DOCKER_COMPOSE) pull --parallel --ignore-pull-failures
+	$(DOCKER_COMPOSE) pull --ignore-pull-failures
 	$(DOCKER_COMPOSE) build --force-rm
 
 up:


### PR DESCRIPTION
Remove a deprecated parameter : pulling multiple images in parallel is now enabled by default.
See https://docs.docker.com/compose/reference/pull/