### PR TITLE
Remove configure hosts from circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,6 @@ references:
     pull_docker_images: &pull_docker_images
         run: gcloud docker -- pull $APP_DOCKER_IMAGE_NAME:$APP_DOCKER_IMAGE_MD5
 
-    configure_hosts: &configure_hosts
-        run: |
-            echo 127.0.0.1 test.enmarche.code | sudo tee -a /etc/hosts
-            echo 127.0.0.1 test.m.enmarche.code | sudo tee -a /etc/hosts
-            echo 127.0.0.1 test.legislatives.enmarche.code | sudo tee -a /etc/hosts
-
     start_containers: &start_containers
         run: make up perm
 
@@ -108,7 +102,6 @@ jobs:
             - *generate_docker_hashes
             - *authenticate_on_registry
             - *pull_docker_images
-            - *configure_hosts
             - *start_containers
             - run: |
                 set -x
@@ -145,7 +138,6 @@ jobs:
             - *generate_docker_hashes
             - *authenticate_on_registry
             - *pull_docker_images
-            - *configure_hosts
             - *start_containers
             - run: |
                 set -x


### PR DESCRIPTION
Useless because already configured by docker aliases