### PR TITLE
Add an endpoint for emails subscriptions graph by month in referent managed area

### DIFF
--- a/app/config/services/repositories.xml
+++ b/app/config/services/repositories.xml
@@ -200,9 +200,11 @@
             <argument>AppBundle\Entity\WebHook\WebHook</argument>
         </service>
 
-        <service id="AppBundle\Repository\ReferentTagRepository" public="false">
+        <service id="AppBundle\Repository\ReferentTagRepository">
             <factory service="doctrine" method="getRepository" />
             <argument>AppBundle\Entity\ReferentTag</argument>
         </service>
+
+        <service id="AppBundle\Repository\EmailSubscriptionHistoryRepository" />
     </services>
 </container>

--- a/features/admin/adherent.feature
+++ b/features/admin/adherent.feature
@@ -9,7 +9,7 @@ Feature: Manage adherent from admin panel
   Scenario: Display list of adherents
     When I am on "/admin/app/adherent/list"
     Then the response status code should be 200
-    And I should see 18 "tbody tr" elements
+    And I should see 19 "tbody tr" elements
 
   Scenario: A user update must trigger an event in RabbitMQ
     Given I am on "/admin/app/adherent/list"

--- a/features/api/adherents.feature
+++ b/features/api/adherents.feature
@@ -4,9 +4,11 @@ Feature:
   I should be able to acces adherents API data
 
   Background:
-    Given the following fixtures are loaded:
-      | LoadUserData      |
-      | LoadAdherentData  |
+    Given I freeze the clock to "2018-04-17"
+    And the following fixtures are loaded:
+      | LoadUserData                     |
+      | LoadAdherentData                 |
+      | LoadEmailSubscriptionHistoryData |
 
   Scenario: As a non logged-in user I can not access the adherents count information
     When I am on "/api/adherents/count"
@@ -26,7 +28,7 @@ Feature:
     And the JSON should be equal to:
     """
     {
-      "female":6,"male":11,"total":17
+      "female":7,"male":11,"total":18
     }
     """
 
@@ -41,13 +43,23 @@ Feature:
     Then the response status code should be 403
 
   Scenario: As a referent I can access the managed by referent adherents count information
-    When I am logged as "referent@en-marche-dev.fr"
+    When I am logged as "referent-75-77@en-marche-dev.fr"
     And I am on "/api/adherents/count-by-referent-area"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON should be equal to:
     """
     {
-      "female":1,"male":7,"total":8
+      "female":4,
+      "male":5,
+      "total":9,
+      "email_subscriptions": {
+          "2018-04": {"subscribed_emails_local_host": 7, "subscribed_emails_referents": 7},
+          "2018-03": {"subscribed_emails_local_host": 0, "subscribed_emails_referents": 0},
+          "2018-02": {"subscribed_emails_local_host": 4, "subscribed_emails_referents": 0},
+          "2018-01": {"subscribed_emails_local_host": 3, "subscribed_emails_referents": 0},
+          "2017-12": {"subscribed_emails_local_host": 2, "subscribed_emails_referents": 0},
+          "2017-11": {"subscribed_emails_local_host": 1, "subscribed_emails_referents": 0}
+      }
     }
     """

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,11 +1,27 @@
 <?php
 
 use Behat\MinkExtension\Context\RawMinkContext;
-
-require_once __DIR__.'/../../vendor/phpunit/phpunit/src/Framework/Assert/Functions.php';
+use Cake\Chronos\Chronos;
+use Webmozart\Assert\Assert;
 
 class FeatureContext extends RawMinkContext
 {
+    /**
+     * @Given (I )freeze the clock to :dateTime
+     */
+    public function freezeClock(string $dateTime): void
+    {
+        Chronos::setTestNow($dateTime);
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function defreezeClock(): void
+    {
+        Chronos::setTestNow();
+    }
+
     /**
      * @Given I resolved the captcha
      */
@@ -29,7 +45,7 @@ class FeatureContext extends RawMinkContext
     {
         $field = $this->getSession()->getPage()->findById($elementId);
 
-        assertNotNull($field, 'Cannot find "'.$elementId.'"');
+        Assert::notNull($field, 'Cannot find "'.$elementId.'"');
 
         $field->click();
     }

--- a/src/Controller/Api/AdherentsController.php
+++ b/src/Controller/Api/AdherentsController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller\Api;
 
+use AppBundle\History\EmailSubscriptionHistoryHandler;
 use AppBundle\Repository\AdherentRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -31,11 +32,15 @@ class AdherentsController extends Controller
      * @Route("/count-by-referent-area", name="app_adherents_count_for_referent_managed_area")
      * @Method("GET")
      */
-    public function adherentsCountForReferentManagedAreaAction(AdherentRepository $adherentRepository): Response
-    {
-        $count = $adherentRepository->countByGenderManagedBy($this->getUser());
+    public function adherentsCountForReferentManagedAreaAction(
+        AdherentRepository $adherentRepository,
+        EmailSubscriptionHistoryHandler $historyHandler
+    ): Response {
+        $referent = $this->getUser();
+        $count = $adherentRepository->countByGenderManagedBy($referent);
+        $subscriptions = $historyHandler->queryCountByMonth($referent);
 
-        return new JsonResponse($this->aggregateCount($count));
+        return new JsonResponse(array_merge($this->aggregateCount($count), ['email_subscriptions' => $subscriptions]));
     }
 
     private function aggregateCount(array $count): array

--- a/src/DataFixtures/ORM/LoadAdherentData.php
+++ b/src/DataFixtures/ORM/LoadAdherentData.php
@@ -39,6 +39,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
     public const ADHERENT_16_UUID = '0a68eb57-c88a-5f34-9e9d-27f85e68af4f';
     public const ADHERENT_17_UUID = '1ebee762-4dc1-42f6-9884-1c83ba9c6d71';
     public const ADHERENT_18_UUID = 'e1bee762-4dc1-42f6-9884-1c83ba9c6d17';
+    public const ADHERENT_19_UUID = '2f69db3c-ecd7-4a8a-bd23-bb4c9cfd70cf';
 
     public const COMMITTEE_1_UUID = '515a56c0-bde8-56ef-b90c-4745b1c93818';
     public const COMMITTEE_2_UUID = '182d8586-8b05-4b70-a727-704fa701e816';
@@ -107,6 +108,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
             'registered_at' => '2017-01-03 08:47:54',
         ]);
         $adherent3->enableCommitteesNotifications();
+        $adherent3->addReferentTag($this->getReference('referent_tag_75'));
         $adherent3->addReferentTag($this->getReference('referent_tag_75008'));
         $this->addReference('adherent-3', $adherent3);
 
@@ -127,6 +129,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $adherent4->setInterests(['jeunesse']);
         $adherent4->enableCommitteesNotifications();
         $adherent4->setProcurationManagedAreaCodesAsString('75, 44, GB, 92130, 91300');
+        $adherent3->addReferentTag($this->getReference('referent_tag_75'));
         $adherent4->addReferentTag($this->getReference('referent_tag_75009'));
         $this->addReference('adherent-4', $adherent4);
 
@@ -212,6 +215,33 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $referent->setBoardMember(BoardMember::AREA_FRANCE_METROPOLITAN, $roles);
         $referent->enableCommitteesNotifications();
         $referent->addReferentTag($this->getReference('referent_tag_77'));
+        $this->addReference('adherent-8', $referent);
+
+        $referent75and77 = $adherentFactory->createFromArray([
+            'uuid' => self::ADHERENT_19_UUID,
+            'password' => self::DEFAULT_PASSWORD,
+            'email' => 'referent-75-77@en-marche-dev.fr',
+            'gender' => 'female',
+            'first_name' => 'Referent75and77',
+            'last_name' => 'Referent75and77',
+            'address' => PostAddress::createFrenchAddress('2 avenue Jean Jaurès', '75001-75101', 48.5278939, 2.6484923),
+            'birthdate' => '1970-01-08',
+            'position' => 'employed',
+            'phone' => '33 6765204050',
+            'registered_at' => '2018-05-12 12:31:45',
+        ]);
+        $referent75and77->setReferent(
+            [
+                $this->getReference('referent_tag_77'),
+                $this->getReference('referent_tag_75'),
+                $this->getReference('referent_tag_75008'),
+                $this->getReference('referent_tag_75009'),
+            ],
+            -1.6743,
+            48.112
+        );
+        $referent75and77->addReferentTag($this->getReference('referent_tag_75'));
+        $this->addReference('adherent-19', $referent75and77);
 
         $referentChild = $adherentFactory->createFromArray([
             'uuid' => self::ADHERENT_18_UUID,
@@ -267,7 +297,9 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
             'registered_at' => '2017-09-20 15:31:21',
         ]);
         $coordinatorCP->addCoordinatorManagedArea(new CoordinatorManagedArea(['US', '59290', '77'], CoordinatorAreaSectors::CITIZEN_PROJECT_SECTOR));
+        $coordinatorCP->addReferentTag($this->getReference('referent_tag_75'));
         $coordinatorCP->addReferentTag($this->getReference('referent_tag_75008'));
+        $this->addReference('adherent-17', $coordinatorCP);
 
         $adherent9 = $adherentFactory->createFromArray([
             'uuid' => self::ADHERENT_9_UUID,
@@ -406,6 +438,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $key6 = AdherentActivationToken::generate($adherent6);
         $key7 = AdherentActivationToken::generate($adherent7);
         $key8 = AdherentActivationToken::generate($referent);
+        $key19 = AdherentActivationToken::generate($referent75and77);
         $key18 = AdherentActivationToken::generate($referentChild);
         $key9 = AdherentActivationToken::generate($adherent9);
         $key10 = AdherentActivationToken::generate($adherent10);
@@ -425,6 +458,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $adherent6->activate($key6, '2017-01-17 08:07:45');
         $adherent7->activate($key7, '2017-01-25 19:34:02');
         $referent->activate($key8, '2017-02-07 13:20:45');
+        $referent75and77->activate($key19, '2018-05-13 07:21:01');
         $referentChild->activate($key18, '2017-02-07 13:20:45');
         $adherent9->activate($key9, '2017-02-16 17:23:15');
         $adherent10->activate($key10, '2017-02-23 14:02:18');
@@ -565,6 +599,7 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $manager->persist($adherent6);
         $manager->persist($adherent7);
         $manager->persist($referent);
+        $manager->persist($referent75and77);
         $manager->persist($referentChild);
         $manager->persist($adherent9);
         $manager->persist($adherent10);

--- a/src/Entity/Reporting/EmailSubscriptionHistory.php
+++ b/src/Entity/Reporting/EmailSubscriptionHistory.php
@@ -20,7 +20,7 @@ use Ramsey\Uuid\UuidInterface;
  *          @ORM\Index(name="adherent_email_subscription_histories_adherent_email_type_idx", columns="subscribed_email_type"),
  *      }
  * )
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\EmailSubscriptionHistoryRepository")
  *
  * @Algolia\Index(autoIndex=false)
  */

--- a/src/Repository/EmailSubscriptionHistoryRepository.php
+++ b/src/Repository/EmailSubscriptionHistoryRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace AppBundle\Repository;
+
+use AppBundle\Entity\Adherent;
+use AppBundle\Entity\Reporting\EmailSubscriptionHistory;
+use AppBundle\Entity\Reporting\EmailSubscriptionHistoryAction;
+use Cake\Chronos\Chronos;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+class EmailSubscriptionHistoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, EmailSubscriptionHistory::class);
+    }
+
+    /**
+     * Count active adherents (not users) history for each specified subscription types in the referent managed area before the specified date.
+     */
+    public function countAllByTypeForReferentManagedArea(Adherent $referent, array $subscriptionsTypes, \DateTimeInterface $until): array
+    {
+        if (!$referent->isReferent()) {
+            throw new \InvalidArgumentException('Adherent must be a referent.');
+        }
+
+        $qb = $this->createQueryBuilder('history')
+            ->select('history.adherentUuid, history.subscribedEmailType, history.action, COUNT(history) AS count')
+            ->where('history.referentTag IN (:tags)')
+            ->andWhere('history.subscribedEmailType IN (:subscriptions)')
+            ->andWhere('history.date <= :until')
+            ->groupBy('history.adherentUuid, history.subscribedEmailType, history.action')
+            ->setParameter('tags', $referent->getManagedArea()->getTags())
+            ->setParameter('subscriptions', $subscriptionsTypes)
+            ->setParameter('until', $until)
+            ->getQuery()
+        ;
+
+        // Let's cache past data as they are never going to change
+        $beginningOfThisMonth = (new Chronos('first day of this month'))->setTime(0, 0);
+        if ($beginningOfThisMonth > $until) {
+            $qb->useResultCache(true, 5184000); // 60 days
+        }
+
+        $results = $qb->getArrayResult();
+        $countBySubscriptionType = [];
+
+        foreach ($results as ['adherentUuid' => $adherentUuid, 'action' => $action, 'subscribedEmailType' => $type, 'count' => $count]) {
+            $adherentUuid = (string) $adherentUuid;
+
+            if (EmailSubscriptionHistoryAction::SUBSCRIBE === $action) {
+                $countBySubscriptionType[$type][$adherentUuid] = ($countBySubscriptionType[$type][$adherentUuid] ?? 0) + $count;
+            } elseif (EmailSubscriptionHistoryAction::UNSUBSCRIBE === $action) {
+                $countBySubscriptionType[$type][$adherentUuid] = ($countBySubscriptionType[$type][$adherentUuid] ?? 0) - $count;
+            } else {
+                throw new \RuntimeException("'$action' is not handled");
+            }
+        }
+
+        // If one adherent has multiple referent tags (With paris district for example), his email subscription must count for one and not many.
+        // That's why we remove values equal to 0 and then count the number of entries we have by type.
+        foreach ($subscriptionsTypes as $type) {
+            if (isset($countBySubscriptionType[$type]) && \is_array($countBySubscriptionType[$type])) {
+                $countBySubscriptionType[$type] = array_filter($countBySubscriptionType[$type]);
+                $countBySubscriptionType[$type] = \count($countBySubscriptionType[$type]);
+            } else {
+                $countBySubscriptionType[$type] = 0;
+            }
+        }
+
+        return $countBySubscriptionType;
+    }
+}

--- a/tests/Controller/Api/StatsControllerTest.php
+++ b/tests/Controller/Api/StatsControllerTest.php
@@ -29,7 +29,7 @@ class StatsControllerTest extends SqliteWebTestCase
         $data = \GuzzleHttp\json_decode($content, true);
 
         $this->assertArraySubset([
-            'userCount' => 18,
+            'userCount' => 19,
             'eventCount' => 14,
             'committeeCount' => 9,
         ], $data);

--- a/tests/Controller/EnMarche/AdherentControllerTest.php
+++ b/tests/Controller/EnMarche/AdherentControllerTest.php
@@ -160,8 +160,8 @@ class AdherentControllerTest extends MysqlWebTestCase
         $histories73Subscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherent, 'subscribe', '73');
         $histories73Unsubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherent, 'unsubscribe', '73');
 
-        $this->assertCount(18, $histories73Subscriptions);
-        $this->assertCount(9, $histories73Unsubscriptions);
+        $this->assertCount(9, $histories73Subscriptions);
+        $this->assertCount(0, $histories73Unsubscriptions);
         $this->assertCount(0, $histories06Subscriptions);
         $this->assertCount(0, $histories06Unsubscriptions);
 
@@ -311,8 +311,8 @@ class AdherentControllerTest extends MysqlWebTestCase
         $histories73Subscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherent, 'subscribe', '73');
         $histories73Unsubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherent, 'unsubscribe', '73');
 
-        $this->assertCount(18, $histories73Subscriptions);
-        $this->assertCount(18, $histories73Unsubscriptions);
+        $this->assertCount(9, $histories73Subscriptions);
+        $this->assertCount(9, $histories73Unsubscriptions);
         $this->assertCount(9, $histories06Subscriptions);
         $this->assertCount(0, $histories06Unsubscriptions);
     }
@@ -481,16 +481,14 @@ class AdherentControllerTest extends MysqlWebTestCase
         $historiesReferents = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_REFERENTS);
         $historiesCitizenProjectCreation = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_CITIZEN_PROJECT_CREATION);
 
-        $this->assertCount(29, $histories);
+        $this->assertCount(11, $histories);
         $this->assertCount(1, $historiesHost);
-        $this->assertCount(3, $historiesReferents);
-        $this->assertCount(4, $historiesCitizenProjectCreation);
+        $this->assertCount(1, $historiesReferents);
+        $this->assertCount(2, $historiesCitizenProjectCreation);
         $this->assertSame('subscribe', $historiesHost[0]->getAction());
         $this->assertSame('subscribe', $historiesReferents[0]->getAction());
-        $this->assertSame('unsubscribe', $historiesReferents[1]->getAction());
         $this->assertSame('unsubscribe', $historiesCitizenProjectCreation[0]->getAction());
         $this->assertSame('subscribe', $historiesCitizenProjectCreation[1]->getAction());
-        $this->assertSame('unsubscribe', $historiesCitizenProjectCreation[2]->getAction());
         $this->assertTrue($adherent->hasSubscribedLocalHostEmails());
         $this->assertTrue($adherent->hasEmailSubscription(AdherentEmailSubscription::SUBSCRIBED_EMAILS_MOVEMENT_INFORMATION));
 
@@ -525,9 +523,9 @@ class AdherentControllerTest extends MysqlWebTestCase
         $historiesHost = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_LOCAL_HOST);
         $historiesReferents = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_REFERENTS);
 
-        $this->assertCount(31, $histories);
+        $this->assertCount(13, $histories);
         $this->assertCount(2, $historiesHost);
-        $this->assertCount(4, $historiesReferents);
+        $this->assertCount(2, $historiesReferents);
         $this->assertSame('unsubscribe', $historiesHost[0]->getAction());
         $this->assertSame('unsubscribe', $historiesReferents[0]->getAction());
 
@@ -552,9 +550,9 @@ class AdherentControllerTest extends MysqlWebTestCase
         $historiesHost = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_LOCAL_HOST);
         $historiesReferents = $this->findAllEmailSubscriptionHistoryByAdherentAndType($adherent, AdherentEmailSubscription::SUBSCRIBED_EMAILS_REFERENTS);
 
-        $this->assertCount(33, $histories);
+        $this->assertCount(15, $histories);
         $this->assertCount(3, $historiesHost);
-        $this->assertCount(5, $historiesReferents);
+        $this->assertCount(3, $historiesReferents);
         $this->assertSame('subscribe', $historiesHost[0]->getAction());
         $this->assertSame('subscribe', $historiesReferents[0]->getAction());
         Chronos::setTestNow();
@@ -948,11 +946,6 @@ class AdherentControllerTest extends MysqlWebTestCase
     {
         /** @var Adherent $adherent */
         $adherentBeforeUnregistration = $this->getAdherentRepository()->findOneByEmail($userEmail);
-        $mailHistorySubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherentBeforeUnregistration, 'subscribe');
-        $mailHistoryUnsubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherentBeforeUnregistration, 'unsubscribe');
-
-        $this->assertCount(20, $mailHistorySubscriptions);
-        $this->assertCount(10, $mailHistoryUnsubscriptions);
 
         $this->authenticateAsAdherent($this->client, $userEmail);
 
@@ -1021,8 +1014,7 @@ class AdherentControllerTest extends MysqlWebTestCase
         $mailHistorySubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherentBeforeUnregistration, 'subscribe');
         $mailHistoryUnsubscriptions = $this->findEmailSubscriptionHistoryByAdherent($adherentBeforeUnregistration, 'unsubscribe');
 
-        $this->assertCount(20, $mailHistorySubscriptions);
-        $this->assertCount(20, $mailHistoryUnsubscriptions);
+        $this->assertSame(count($mailHistorySubscriptions), count($mailHistoryUnsubscriptions));
         $this->assertSame(array_values($chosenReasons), $unregistration->getReasons());
         $this->assertSame('Je me désinscris', $unregistration->getComment());
         $this->assertSame($adherentBeforeUnregistration->getRegisteredAt()->format('Y-m-d H:i:s'), $unregistration->getRegisteredAt()->format('Y-m-d H:i:s'));

--- a/tests/Controller/EnMarche/MapControllerTest.php
+++ b/tests/Controller/EnMarche/MapControllerTest.php
@@ -26,7 +26,7 @@ class MapControllerTest extends SqliteWebTestCase
 
         $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
         $this->assertSame(1, $crawler->filter('html:contains("La carte des comités")')->count());
-        $this->assertContains('18 adhérents', $crawler->filter('#counter-adherents')->text());
+        $this->assertContains('19 adhérents', $crawler->filter('#counter-adherents')->text());
         $this->assertContains('9 comités', $crawler->filter('#counter-committees')->text());
         $this->assertContains('14 événements', $crawler->filter('#counter-events')->text());
     }

--- a/tests/Repository/AdherentRepositoryMysqlTest.php
+++ b/tests/Repository/AdherentRepositoryMysqlTest.php
@@ -62,7 +62,7 @@ class AdherentRepositoryMysqlTest extends MysqlWebTestCase
 
         $this->assertEmpty($referents);
 
-        // Departemental Committee with Referent
+        // Departmental Committee with Referent
         $committeeTags = new ArrayCollection([
             $this->referentTagRepository->findOneByCode('77'),
         ]);
@@ -72,12 +72,9 @@ class AdherentRepositoryMysqlTest extends MysqlWebTestCase
 
         $referents = $this->adherentRepository->findReferentsByCommittee($committee);
 
-        $this->assertCount(1, $referents);
-
-        $referent = $referents->first();
-
-        $this->assertSame('Referent Referent', $referent->getFullName());
-        $this->assertSame('referent@en-marche-dev.fr', $referent->getEmailAddress());
+        $this->assertCount(2, $referents);
+        $this->assertSame('referent@en-marche-dev.fr', $referents[0]->getEmailAddress());
+        $this->assertSame('referent-75-77@en-marche-dev.fr', $referents[1]->getEmailAddress());
     }
 
     public function testFindCoordinatorsByCitizenProject()

--- a/tests/Repository/AdherentRepositoryTest.php
+++ b/tests/Repository/AdherentRepositoryTest.php
@@ -47,7 +47,7 @@ class AdherentRepositoryTest extends SqliteWebTestCase
 
     public function testCountActiveAdherents()
     {
-        $this->assertSame(17, $this->repository->countActiveAdherents());
+        $this->assertSame(18, $this->repository->countActiveAdherents());
     }
 
     public function testFindAllManagedBy()

--- a/tests/TestHelperTrait.php
+++ b/tests/TestHelperTrait.php
@@ -42,6 +42,7 @@ use AppBundle\Repository\CommitteeMembershipRepository;
 use AppBundle\Repository\CommitteeRepository;
 use AppBundle\Repository\DonationRepository;
 use AppBundle\Repository\EmailRepository;
+use AppBundle\Repository\EmailSubscriptionHistoryRepository;
 use AppBundle\Repository\EventRegistrationRepository;
 use AppBundle\Repository\EventRepository;
 use AppBundle\Repository\InvitationRepository;
@@ -57,7 +58,6 @@ use AppBundle\Repository\TonMacronChoiceRepository;
 use AppBundle\Repository\TonMacronFriendInvitationRepository;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
-use Doctrine\ORM\EntityRepository;
 use League\Flysystem\Filesystem;
 use League\Glide\Server;
 use libphonenumber\PhoneNumber;
@@ -243,7 +243,7 @@ trait TestHelperTrait
         return $this->getRepository(PurchasingPowerInvitation::class);
     }
 
-    public function getEmailSubscriptionHistoryRepository(): EntityRepository
+    public function getEmailSubscriptionHistoryRepository(): EmailSubscriptionHistoryRepository
     {
         return $this->getRepository(EmailSubscriptionHistory::class);
     }


### PR DESCRIPTION
https://app.clubhouse.io/enmarche/story/3637/1%C3%A8re-partie-section-adh%C3%A9rents-graph-double-histogramme-emails-subscription

Need to change tests to be not time depending.