### PR TITLE
Fix slow Test with time using

### DIFF
--- a/tests/OAuth/PersistentTokenFactoryTest.php
+++ b/tests/OAuth/PersistentTokenFactoryTest.php
@@ -226,10 +226,11 @@ class PersistentTokenFactoryTest extends TestCase
 
     public function testCreateRefreshToken(): void
     {
+        $expirationDate = new \DateTime('+6 hours');
         $token = new InMemoryRefreshToken();
         $token->setIdentifier(self::REFRESH_TOKEN_IDENTIFIER);
         $token->setAccessToken($this->createAccessToken());
-        $token->setExpiryDateTime(new \DateTime('+6 hours'));
+        $token->setExpiryDateTime($expirationDate);
 
         $this
             ->accessTokenRepository
@@ -246,7 +247,7 @@ class PersistentTokenFactoryTest extends TestCase
             $refreshToken->getUuid()
         );
         $this->assertSame(self::REFRESH_TOKEN_IDENTIFIER, $refreshToken->getIdentifier());
-        $this->assertSame((new \DateTime('+6 hours'))->format('U'), $refreshToken->getExpiryDateTime()->format('U'));
+        $this->assertSame($expirationDate->format('U'), $refreshToken->getExpiryDateTime()->format('U'));
         $this->assertSame($accessToken, $refreshToken->getAccessToken());
     }
 


### PR DESCRIPTION
```
1) Tests\AppBundle\OAuth\PersistentTokenFactoryTest::testCreateRefreshToken
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'1526423610'
+'1526423609'

/app/tests/OAuth/PersistentTokenFactoryTest.php:249

```