### PR TITLE
Add tag based build for deployment to google cloud container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
             - *authenticate_on_registry
             - setup_remote_docker
             - run: |
-                bash scripts/build.sh ${CIRCLE_BRANCH}
+                bash scripts/build.sh
 
 workflows:
     version: 2
@@ -185,3 +185,5 @@ workflows:
                     branches:
                         only:
                             - master
+                    tags:
+                        only: /^v[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
Examples:

```
❯ GCLOUD_PROJECT=project CIRCLE_BRANCH=master CIRCLE_TAG=v1.0.0 CIRCLE_SHA1=sha1 scripts/build.sh
DOCKER_IMAGE_TAG       = eu.gcr.io/project/app:v1.0.0-sha1
DOCKER_IMAGE_CACHE_TAG = eu.gcr.io/project/app:master

❯ GCLOUD_PROJECT=project CIRCLE_BRANCH=hotfix-for-something CIRCLE_TAG=v1.0.1 CIRCLE_SHA1=sha1 scripts/build.sh
DOCKER_IMAGE_TAG       = eu.gcr.io/project/app:v1.0.1-sha1
DOCKER_IMAGE_CACHE_TAG = eu.gcr.io/project/app:master

❯ GCLOUD_PROJECT=project CIRCLE_TAG=v1.0.1 CIRCLE_SHA1=sha1 scripts/build.sh
DOCKER_IMAGE_TAG       = eu.gcr.io/project/app:v1.0.1-sha1
DOCKER_IMAGE_CACHE_TAG = eu.gcr.io/project/app:master

❯ GCLOUD_PROJECT=project CIRCLE_BRANCH=master CIRCLE_SHA1=sha1 scripts/build.sh
DOCKER_IMAGE_TAG       = eu.gcr.io/project/app:master-sha1
DOCKER_IMAGE_CACHE_TAG = eu.gcr.io/project/app:master
```