### PR TITLE
Fix color display for CP media creation

### DIFF
--- a/front/style/pages/_image-generator.scss
+++ b/front/style/pages/_image-generator.scss
@@ -139,6 +139,10 @@ input.img-gen__input {
   margin-bottom: 10px;
 }
 
+[name="citizen_project_media[backgroundColor]"] + label:before {
+  content: none;
+}
+
 [name="citizen_project_media[backgroundColor]"] + label:after {
   content: '';
   position: absolute;


### PR DESCRIPTION
https://app.clubhouse.io/enmarche/story/3628/bug-les-couleurs-de-l-outil-de-promotion-d-images-pc-ne-s-affichent-pas-r%C3%A9seaux-sociaux-tract