### PR TITLE
Removed contact link for not connected users on committee page

### DIFF
--- a/templates/committee/_sidebar.html.twig
+++ b/templates/committee/_sidebar.html.twig
@@ -19,6 +19,9 @@
             {{ include('components/admin.html.twig') }}
             Administration
         </h5>
+        {% if not has_role_user %}
+            <span class="text--small">Connectez-vous pour pouvoir contacter les responsables de comité.</span>
+        {% endif %}
         <ul class="committee__hosts">
             {% for host in committee_hosts %}
                 <li class="committee-host text--body text--bold">
@@ -28,7 +31,7 @@
                     </div>
                     {% if is_host and app.user.equals(host) %}
                         (vous)
-                    {% else %}
+                    {% elseif has_role_user %}
                         <a href="{{ path('app_adherent_contact', {'uuid': host.uuid, 'from': 'committee', 'id': committee.uuid.toString}) }}"
                            class="link--no-decor text--blue text--normal">
                             Contacter

--- a/templates/events/show.html.twig
+++ b/templates/events/show.html.twig
@@ -147,7 +147,7 @@
                 {% endif %}
                 {% if event.organizer %}
                 <li>
-                    {% if app.user %}
+                    {% if has_role_user %}
                         <a href="{{ path('app_adherent_contact', {'uuid': event.organizer.uuid, 'from': 'event', 'id': event.uuid.toString}) }}">
                             Contact
                         </a>


### PR DESCRIPTION
https://app.clubhouse.io/enmarche/story/4606/supprimer-les-liens-de-contact-pour-les-non-adh%C3%A9rents-sur-les-pages-de-comit%C3%A9s