### PR TITLE
Allow adherent to create an unlimited number of Citizen Projects

### DIFF
--- a/front/style/layout/_layout.scss
+++ b/front/style/layout/_layout.scss
@@ -351,6 +351,10 @@
             margin-top: 5px;
         }
 
+        &--top-0 {
+            margin-top: 0 !important;
+        }
+
         &--bottom-tiny {
             margin-bottom: 5px;
         }

--- a/front/style/pages/_citizen-projects.scss
+++ b/front/style/pages/_citizen-projects.scss
@@ -247,10 +247,6 @@
         background-color: $yellow--light;
         padding: 10px;
     }
-
-    &--margin-top-0 {
-        margin-top: 0;
-    }
 }
 
 .skill-remove,

--- a/src/DataFixtures/ORM/LoadCitizenProjectData.php
+++ b/src/DataFixtures/ORM/LoadCitizenProjectData.php
@@ -22,6 +22,8 @@ class LoadCitizenProjectData extends AbstractFixture implements FixtureInterface
     const CITIZEN_PROJECT_7_UUID = 'fc83efde-17e5-4e87-b9e9-71b165aecd10';
     const CITIZEN_PROJECT_8_UUID = '55bc9c81-612b-4108-b5ae-d065a69456d1';
     const CITIZEN_PROJECT_9_UUID = 'eacefe0b-ace6-4ed5-a747-61f874f165f6';
+    const CITIZEN_PROJECT_10_UUID = 'ac98b08c-4e2d-4894-aa61-140b5be89645';
+    const CITIZEN_PROJECT_11_UUID = '695af719-ccfb-4754-813b-6685c757a855';
 
     use ContainerAwareTrait;
 
@@ -191,6 +193,38 @@ class LoadCitizenProjectData extends AbstractFixture implements FixtureInterface
         $citizenProject9->approved('2017-10-09 13:27:42');
         $this->addReference('citizen-project-9', $citizenProject9);
 
+        $citizenProject10 = $citizenProjectFactory->createFromArray([
+            'uuid' => self::CITIZEN_PROJECT_10_UUID,
+            'name' => 'Projet citoyen refusé à Paris 8',
+            'subtitle' => 'Le projet citoyen refusé',
+            'category' => $this->getReference('cpc001'),
+            'problem_description' => 'Problème refusé',
+            'proposed_solution' => 'Solution refusée',
+            'required_means' => 'Les moyens refusés',
+            'created_by' => LoadAdherentData::ADHERENT_3_UUID,
+            'created_at' => '2018-09-01 10:22:13',
+            'address' => NullablePostAddress::createFrenchAddress('60 avenue des Champs-Élysées', '75008-75108', 48.8705073, 2.3032432),
+        ]);
+        $citizenProject10->refused('2018-09-09 10:10:10');
+        $citizenProject10->setImageName('default.png');
+        $this->addReference('citizen-project-10', $citizenProject10);
+
+        $citizenProject11 = $citizenProjectFactory->createFromArray([
+            'uuid' => self::CITIZEN_PROJECT_11_UUID,
+            'name' => '[En attente] Projet citoyen à New York City',
+            'subtitle' => '[En attente] Projet citoyen à New York City.',
+            'category' => $this->getReference('cpc003'),
+            'problem_description' => 'Problème en attente',
+            'proposed_solution' => 'Solution en attente',
+            'required_means' => 'Les moyens en attente',
+            'created_by' => LoadAdherentData::ADHERENT_12_UUID,
+            'created_at' => '2018-09-09 12:12:12',
+            'address' => NullablePostAddress::createForeignAddress('US', '10019', 'New York', '226 W 52nd St', 40.7625289, -73.9859927),
+            'phone' => '1 2123150100',
+        ]);
+        $citizenProject11->setImageName('default.png');
+        $this->addReference('citizen-project-11', $citizenProject11);
+
         $manager->persist($citizenProject1);
         $manager->persist($citizenProject2);
         $manager->persist($citizenProject3);
@@ -200,30 +234,44 @@ class LoadCitizenProjectData extends AbstractFixture implements FixtureInterface
         $manager->persist($citizenProject7);
         $manager->persist($citizenProject8);
         $manager->persist($citizenProject9);
+        $manager->persist($citizenProject10);
+        $manager->persist($citizenProject11);
 
         // Make adherents join citizen projects
         $manager->persist($this->getReference('adherent-3')->administrateCitizenProject($citizenProject1, '2017-10-12 17:25:54'));
-        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject3, '2017-10-26 17:08:24'));
-        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject4));
-        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject5));
         $manager->persist($this->getReference('adherent-2')->followCitizenProject($citizenProject1));
         $manager->persist($this->getReference('adherent-4')->followCitizenProject($citizenProject1));
         $manager->persist($this->getReference('adherent-5')->followCitizenProject($citizenProject1));
+
         $manager->persist($this->getReference('adherent-6')->followCitizenProject($citizenProject2));
+
+        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject3, '2017-10-26 17:08:24'));
+        $manager->persist($this->getReference('adherent-3')->administrateCitizenProject($citizenProject3));
+
+        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject4));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject4));
+
+        $manager->persist($this->getReference('adherent-7')->administrateCitizenProject($citizenProject5));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject5));
+        $manager->persist($this->getReference('adherent-9')->followCitizenProject($citizenProject5));
+
         $manager->persist($this->getReference('adherent-9')->administrateCitizenProject($citizenProject6));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject6));
+
         $manager->persist($this->getReference('adherent-10')->administrateCitizenProject($citizenProject7));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject7));
-        $manager->persist($this->getReference('adherent-3')->administrateCitizenProject($citizenProject3));
-        $manager->persist($this->getReference('adherent-9')->followCitizenProject($citizenProject5));
+
         $manager->persist($this->getReference('adherent-11')->administrateCitizenProject($citizenProject8));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject8));
+
         $manager->persist($this->getReference('adherent-12')->administrateCitizenProject($citizenProject9));
         $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject9));
         $manager->persist($this->getReference('adherent-11')->followCitizenProject($citizenProject9));
         $manager->persist($this->getReference('adherent-13')->followCitizenProject($citizenProject9));
+
+        $manager->persist($this->getReference('adherent-3')->followCitizenProject($citizenProject10));
+
+        $manager->persist($this->getReference('adherent-12')->followCitizenProject($citizenProject11));
 
         $manager->flush();
     }

--- a/src/Entity/CitizenProject.php
+++ b/src/Entity/CitizenProject.php
@@ -41,7 +41,6 @@ class CitizenProject extends BaseGroup
 
     public const STATUSES_NOT_ALLOWED_TO_CREATE = [
         self::PENDING,
-        self::REFUSED,
         self::PRE_APPROVED,
         self::PRE_REFUSED,
     ];

--- a/src/Security/Voter/CitizenProject/CreateCitizenProjectVoter.php
+++ b/src/Security/Voter/CitizenProject/CreateCitizenProjectVoter.php
@@ -27,9 +27,8 @@ class CreateCitizenProjectVoter extends AbstractAdherentVoter
 
     protected function doVoteOnAttribute(string $attribute, Adherent $adherent, $subject): bool
     {
-        // Cannot create a project when already administrate one
+        // Cannot create a project when already has three citizen projects
         return $adherent->isAdherent()
-            && !$adherent->isCitizenProjectAdministrator()
             && !$this->projectRepository->hasCitizenProjectInStatus($adherent, CitizenProject::STATUSES_NOT_ALLOWED_TO_CREATE)
         ;
     }

--- a/templates/admin/adherent/list_status.html.twig
+++ b/templates/admin/adherent/list_status.html.twig
@@ -23,7 +23,7 @@
         {% endif %}
 
         {% if object.isCitizenProjectAdministrator %}
-            <span class="label label-primary" style="background-color: #90ade6 !important; padding: 2px;">Porteur de projet</span><br/>
+            <span class="label label-primary" style="background-color: #90ade6 !important; padding: 2px;">Porteur de projet ({{ object.citizenProjectMemberships.countCitizenProjectAdministratorMemberships }})</span><br/>
         {% endif %}
 
         {% if object.isBoardMember %}

--- a/templates/citizen_project/_sidebar.html.twig
+++ b/templates/citizen_project/_sidebar.html.twig
@@ -47,7 +47,7 @@
         </ul>
         {% if citizen_project.skills|length > 3 %}
             <div id="show-more-skills" class="text--small text--blue--dark cursor--pointer">Voir plus</div>
-            <ul id="other-skills" class="visually-hidden citizen-project--margin-top-0 citizen-project__skills">
+            <ul id="other-skills" class="visually-hidden b__nudge--top-0 citizen-project__skills">
                 {% for skill in citizen_project.skills|slice(3) %}
                     <li>{{ skill }}</li>
                 {% endfor %}

--- a/templates/citizen_project/edit.html.twig
+++ b/templates/citizen_project/edit.html.twig
@@ -26,8 +26,14 @@
                 {{ include('components/caret--left.html.twig') }}
                 Retour au projet citoyen</a>
 
-            {% if not citizen_project.isApproved %}
-                <div class="committee__waiting-for-approval">
+            {% if citizen_project.isRefused %}
+                <div class="citizen-project__waiting-for-approval">
+                    En l'état, votre projet citoyen n'a pas été validé par nos équipes.
+                    Vous pouvez à tout moment modifier ce projet ou en proposer un nouveau.
+                    Pour plus d’informations, reportez-vous à <a class="link--blue" href="https://storage.googleapis.com/en-marche-prod/documents/projets-citoyens/La%20Charte%20des%20Projets%20Citoyens.pdf">la Charte des Projets Citoyens</a>.
+                </div>
+            {% elseif not citizen_project.isApproved %}
+                <div class="citizen-project__waiting-for-approval">
                     Votre projet citoyen est en attente de validation par nos équipes.
                     Vous serez alerté(e) par e-mail quand il sera validé.
                 </div>

--- a/templates/citizen_project/show_base.html.twig
+++ b/templates/citizen_project/show_base.html.twig
@@ -62,9 +62,17 @@
         </nav>
     {% endif %}
 
-    {% if not citizen_project.isApproved %}
+    {% if citizen_project.isRefused %}
         <section>
-            <div class="citizen-project__waiting-for-approval flex--left flex--center--mobile">
+            <div class="citizen-project__waiting-for-approval flex--center--mobile">
+                En l'état, votre projet citoyen n'a pas été validé par nos équipes.
+                Vous pouvez à tout moment modifier ce projet ou en proposer un nouveau.
+                Pour plus d'informations, reportez-vous à <a class="link--blue" href="https://storage.googleapis.com/en-marche-prod/documents/projets-citoyens/La%20Charte%20des%20Projets%20Citoyens.pdf">la Charte des Projets Citoyens</a>.
+            </div>
+        </section>
+    {% elseif not citizen_project.isApproved %}
+        <section>
+            <div class="citizen-project__waiting-for-approval flex--center--mobile">
                 Votre projet citoyen est en attente de validation par les équipes d'En Marche !
                 Vous serez alerté(e) par e-mail quand il sera validé.
                 <br>

--- a/tests/Controller/EnMarche/CitizenProjectControllerTest.php
+++ b/tests/Controller/EnMarche/CitizenProjectControllerTest.php
@@ -66,13 +66,38 @@ class CitizenProjectControllerTest extends AbstractGroupControllerTest
         $this->assertContains($citizenProject->getRequiredMeans(), $crawler->filter('#citizen-project-required-means > p:nth-child(2)')->text());
     }
 
-    public function testAdministratorCanSeeUnapprovedCitizenProject(): void
+    public function testCreatorCanSeePendingCitizenProject(): void
     {
-        $this->authenticateAsAdherent($this->client, 'benjyd@aol.com');
-        $this->client->request(Request::METHOD_GET, '/projets-citoyens/13003-le-projet-citoyen-a-marseille');
+        $this->authenticateAsAdherent($this->client, 'kiroule.p@blabla.tld');
+        $crawler = $this->client->request(Request::METHOD_GET, '/projets-citoyens/10019-en-attente-projet-citoyen-a-new-york-city');
+
         $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
         $this->assertFalse($this->seeCommentSection());
         $this->assertCount(0, $this->client->getCrawler()->selectLink('Signaler un abus'));
+        $this->assertSame(
+            "Votre projet citoyen est en attente de validation par les équipes d'En Marche !
+                Vous serez alerté(e) par e-mail quand il sera validé.
+                
+                Une fois que votre projet citoyen sera validé, vous pourrez contacter les adhérents suivants votre projet citoyen
+                sur cette page.",
+            trim($crawler->filter('.citizen-project__waiting-for-approval')->text())
+        );
+    }
+
+    public function testCreatorCanSeeRefusedCitizenProject(): void
+    {
+        $this->authenticateAsAdherent($this->client, 'jacques.picard@en-marche.fr');
+        $crawler = $this->client->request(Request::METHOD_GET, '/projets-citoyens/75008-projet-citoyen-refuse-a-paris-8');
+
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+        $this->assertFalse($this->seeCommentSection());
+        $this->assertCount(0, $this->client->getCrawler()->selectLink('Signaler un abus'));
+        $this->assertSame(
+            "En l'état, votre projet citoyen n'a pas été validé par nos équipes.
+                Vous pouvez à tout moment modifier ce projet ou en proposer un nouveau.
+                Pour plus d'informations, reportez-vous à la Charte des Projets Citoyens.",
+            trim($crawler->filter('.citizen-project__waiting-for-approval')->text())
+        );
     }
 
     public function testAdministratorCanSeeACitizenProject(): void

--- a/tests/Security/Voter/CitizenProject/CreateCitizenProjectVoterTest.php
+++ b/tests/Security/Voter/CitizenProject/CreateCitizenProjectVoterTest.php
@@ -52,20 +52,20 @@ class CreateCitizenProjectVoterTest extends AbstractAdherentVoterTest
         $this->assertGrantedForAdherent(false, true, $adherent, CitizenProjectPermissions::CREATE);
     }
 
-    public function testAdherentIsNotGrantedWhenAlreadyProjectAdministrator()
-    {
-        $adherent = $this->getAdherentMock(true, false, true);
-
-        $this->assertRepositoryBehavior(null);
-        $this->assertGrantedForAdherent(false, true, $adherent, CitizenProjectPermissions::CREATE);
-    }
-
-    public function testAdherentIsNotGrantedWhenAlreadyHasProjectInInvalidStatus()
+    public function testAdherentWithAPendingProjectIsNotGranted()
     {
         $adherent = $this->getAdherentMock(true);
 
-        $this->assertRepositoryBehavior($adherent);
+        $this->assertRepositoryBehavior($adherent, false);
         $this->assertGrantedForAdherent(false, true, $adherent, CitizenProjectPermissions::CREATE);
+    }
+
+    public function testAdherentIsGrantedWhenAlreadyProjectAdministrator()
+    {
+        $adherent = $this->getAdherentMock(true);
+
+        $this->assertRepositoryBehavior($adherent, true);
+        $this->assertGrantedForAdherent(true, true, $adherent, CitizenProjectPermissions::CREATE);
     }
 
     public function testAdherentIsGranted()
@@ -78,18 +78,16 @@ class CreateCitizenProjectVoterTest extends AbstractAdherentVoterTest
 
     public function testReferentIsGranted()
     {
-        $adherent = $this->getAdherentMock(true, true, true);
+        $adherent = $this->getAdherentMock(true);
 
-        $this->assertRepositoryBehavior(null);
-        $this->assertGrantedForAdherent(false, true, $adherent, CitizenProjectPermissions::CREATE);
+        $this->assertRepositoryBehavior($adherent, true);
+        $this->assertGrantedForAdherent(true, true, $adherent, CitizenProjectPermissions::CREATE);
     }
 
     /**
-     * @param bool|null $isCitizenProjectAdministrator
-     *
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(bool $isAdherent, bool $isReferent = false, bool $isCitizenProjectAdministrator = false): Adherent
+    private function getAdherentMock(bool $isAdherent): Adherent
     {
         $adherent = $this->createAdherentMock();
 
@@ -100,12 +98,10 @@ class CreateCitizenProjectVoterTest extends AbstractAdherentVoterTest
 
         $adherent->expects($this->never())
             ->method('isReferent')
-            ->willReturn($isReferent)
         ;
 
-        $adherent->expects($isCitizenProjectAdministrator ? $this->once() : $this->any())
+        $adherent->expects($this->never())
             ->method('isCitizenProjectAdministrator')
-            ->willReturn($isCitizenProjectAdministrator)
         ;
 
         return $adherent;


### PR DESCRIPTION
Adherent can create an unlimited number of Citizen Projects but only in the case when he has no Citizen Project with pending, pre-approved or pre-refused status.