### PR TITLE
[Turnkey Projects] Added custom validator

### DIFF
--- a/app/config/services/admin.xml
+++ b/app/config/services/admin.xml
@@ -502,7 +502,6 @@
             <argument />
             <argument>AppBundle\Entity\TurnkeyProject</argument>
             <argument />
-            <argument type="service" id="AppBundle\Repository\TurnkeyProjectRepository" />
             <argument type="service" id="AppBundle\TurnkeyProject\TurnkeyProjectManager" />
         </service>
 

--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -59,6 +59,7 @@
                 <argument type="service" id="app.glide" />
             </call>
         </service>
+        <service id="AppBundle\Validator\UniqueTurnkeyProjectPinnedValidator" />
 
         <!-- Controller -->
         <prototype namespace="AppBundle\Controller\" resource="../../../src/Controller/">

--- a/src/Admin/TurnkeyProjectAdmin.php
+++ b/src/Admin/TurnkeyProjectAdmin.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\TurnkeyProject;
 use AppBundle\Entity\TurnkeyProjectFile;
 use AppBundle\Form\Admin\BaseFileType;
 use AppBundle\Form\PurifiedTextareaType;
-use AppBundle\Repository\TurnkeyProjectRepository;
 use AppBundle\TurnkeyProject\TurnkeyProjectManager;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -14,17 +13,11 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\CollectionType;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class TurnkeyProjectAdmin extends AbstractAdmin
 {
-    /**
-     * @var TurnkeyProjectRepository
-     */
-    private $turnkeyProjectRepository;
-
     /**
      * @var TurnkeyProjectManager
      */
@@ -34,12 +27,10 @@ class TurnkeyProjectAdmin extends AbstractAdmin
         string $code,
         string $class,
         string $baseControllerName,
-        TurnkeyProjectRepository $turnkeyProjectRepository,
         TurnkeyProjectManager $turnkeyProjectManager
     ) {
         parent::__construct($code, $class, $baseControllerName);
 
-        $this->turnkeyProjectRepository = $turnkeyProjectRepository;
         $this->turnkeyProjectManager = $turnkeyProjectManager;
     }
 
@@ -280,24 +271,6 @@ class TurnkeyProjectAdmin extends AbstractAdmin
 
         if ($turnkeyProject->getImage()) {
             $this->turnkeyProjectManager->saveImage($turnkeyProject);
-        }
-    }
-
-    /**
-     * @param TurnkeyProject $object
-     */
-    public function validate(ErrorElement $errorElement, $object)
-    {
-        if ($object->isPinned()) {
-            $pinnedProject = $this->turnkeyProjectRepository->findPinned($object->getId());
-
-            if ($pinnedProject) {
-                $errorElement
-                    ->with('isPinned')
-                    ->addViolation(sprintf('Le projet clé en main "%s" est deja épinglé', $pinnedProject->getName()))
-                    ->end()
-                ;
-            }
         }
     }
 }

--- a/src/Entity/TurnkeyProject.php
+++ b/src/Entity/TurnkeyProject.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity;
 
 use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use AppBundle\Validator\UniqueTurnkeyProjectPinned;
 use AppBundle\Validator\WysiwygLength as AssertWysiwygLength;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -23,6 +24,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     }
  * )
  * @ORM\Entity(repositoryClass="AppBundle\Repository\TurnkeyProjectRepository")
+ *
+ * @UniqueTurnkeyProjectPinned
  *
  * @Algolia\Index(autoIndex=false)
  */

--- a/src/Validator/UniqueTurnkeyProjectPinned.php
+++ b/src/Validator/UniqueTurnkeyProjectPinned.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AppBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+class UniqueTurnkeyProjectPinned extends Constraint
+{
+    public $message = 'turnkey_projects.pinned.unique';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/UniqueTurnkeyProjectPinnedValidator.php
+++ b/src/Validator/UniqueTurnkeyProjectPinnedValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AppBundle\Validator;
+
+use AppBundle\Entity\TurnkeyProject;
+use AppBundle\Repository\TurnkeyProjectRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class UniqueTurnkeyProjectPinnedValidator extends ConstraintValidator
+{
+    /**
+     * @var TurnkeyProjectRepository
+     */
+    private $turnkeyProjectRepository;
+
+    public function __construct(TurnkeyProjectRepository $turnkeyProjectRepository)
+    {
+        $this->turnkeyProjectRepository = $turnkeyProjectRepository;
+    }
+
+    /**
+     * @param TurnkeyProject $value
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof UniqueTurnkeyProjectPinned) {
+            throw new UnexpectedTypeException($constraint, UniqueTurnkeyProjectPinned::class);
+        }
+
+        if (!$value instanceof TurnkeyProject) {
+            throw new UnexpectedTypeException($value, TurnkeyProject::class);
+        }
+
+        if ($value->isPinned()) {
+            $turnkeyProject = $this->turnkeyProjectRepository->findPinned($value->getId());
+
+            if ($turnkeyProject) {
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('{{ name }}', $turnkeyProject->getName())
+                    ->atPath('isPinned')
+                    ->addViolation()
+                ;
+            }
+        }
+    }
+}

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -110,6 +110,7 @@ citizen_project.action.invalid_finish_date: La date de fin de votre action ne pe
 #
 # TurnkeyProject
 #
+turnkey_projects.pinned.unique: Le projet clé en main {{ name }} est deja épinglé.
 turnkey_project.files.min_count: Un projet clé en main doit contenir au minimum 1 fichier.
 turnkey_project_file.valid_mimetypes: Seuls les fichiers PDF, Word et Powerpoint sont autorisés.
 


### PR DESCRIPTION
- Adds custom validator instead of the deprecated `validate` method of Sonata Admin
( see https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Admin/AdminInterface.php#L428 )
- Adds missed translation messages