### PR TITLE
Fix CommitteeManager deprecations

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -35,6 +35,10 @@ services:
         arguments:
             - '%env(SSL_PRIVATE_KEY)%'
 
+    app.committee.manager:
+        alias: 'AppBundle\Committee\CommitteeManager'
+        public: true
+
 parameters:
     env(DATABASE_NAME): "enmarche_test"
     env(RECAPTCHA_PUBLIC_KEY): 'TEST_RECAPTCHA_PUBLIC_KEY'

--- a/app/config/services/admin.xml
+++ b/app/config/services/admin.xml
@@ -222,7 +222,7 @@
             <argument />
             <argument>AppBundle\Entity\Committee</argument>
             <argument />
-            <argument type="service" id="app.committee.manager" />
+            <argument type="service" id="AppBundle\Committee\CommitteeManager" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="event_dispatcher"/>
         </service>

--- a/app/config/services/cms.xml
+++ b/app/config/services/cms.xml
@@ -32,7 +32,7 @@
 
         <service id="app.document_manager" class="AppBundle\Documents\DocumentManager">
             <argument type="service" id="AppBundle\Documents\DocumentRepository"/>
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="security.authorization_checker"/>
         </service>
 

--- a/app/config/services/platform.xml
+++ b/app/config/services/platform.xml
@@ -69,7 +69,7 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="AppBundle\Membership\AdherentRegistry"/>
             <argument type="service" id="AppBundle\Membership\AdherentManager"/>
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="AppBundle\Referent\ReferentTagManager"/>
             <argument type="service" id="AppBundle\Membership\MembershipRegistrationProcess"/>
             <argument type="service" id="AppBundle\History\EmailSubscriptionHistoryHandler"/>
@@ -121,16 +121,8 @@
         <service id="app.unregistration.serializer" class="AppBundle\Membership\UnregistrationSerializer" />
 
         <!-- Committees -->
-        <service id="app.committee.manager" alias="AppBundle\Committee\CommitteeManager">
-            <deprecated>The "app.committee.manager" is deprecated in favor of the AppBundle\Committee\CommitteeManager FQCN.</deprecated>
-        </service>
-        <service id="AppBundle\Committee\CommitteeManager">
-            <argument type="service" id="doctrine"/>
-            <argument type="service" id="event_dispatcher"/>
-        </service>
-
         <service id="app.committee.authority" class="AppBundle\Committee\CommitteeManagementAuthority">
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="router"/>
             <argument type="service" id="app.mailer.transactional"/>
         </service>
@@ -163,7 +155,7 @@
 
         <service id="app.committee.feed_manager" class="AppBundle\Committee\Feed\CommitteeFeedManager">
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="app.mailer.campaign"/>
             <argument type="service" id="router"/>
             <argument type="service" id="AppBundle\Repository\CommitteeFeedItemRepository"/>
@@ -208,7 +200,7 @@
             <argument type="service" id="old_sound_rabbit_mq.project_citizen_creation_notification_producer"/>
             <argument type="service" id="AppBundle\CitizenProject\CitizenProjectManager"/>
             <argument type="service" id="app.mailer.transactional"/>
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="router"/>
             <tag name="kernel.event_subscriber"/>
         </service>
@@ -252,7 +244,7 @@
 
         <service id="app.event.message_notifier" class="AppBundle\Event\EventMessageNotifier">
             <argument type="service" id="app.mailer.transactional"/>
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <argument type="service" id="AppBundle\Repository\EventRegistrationRepository"/>
             <argument type="service" id="router"/>
             <tag name="kernel.event_subscriber"/>

--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -50,6 +50,7 @@
         </service>
 
         <!-- Committee -->
+        <service id="AppBundle\Committee\CommitteeManager" />
         <service id="AppBundle\Committee\CommitteeMergeCommandHandler" public="true" />
         <service id="AppBundle\Form\Admin\CommitteeIdType"/>
 

--- a/app/config/services/twig.xml
+++ b/app/config/services/twig.xml
@@ -29,7 +29,7 @@
 
         <service id="AppBundle\Twig\CommitteeRuntime">
             <argument type="service" id="security.authorization_checker"/>
-            <argument type="service" id="app.committee.manager"/>
+            <argument type="service" id="AppBundle\Committee\CommitteeManager"/>
             <tag name="twig.runtime" />
         </service>
 

--- a/src/Controller/Admin/AdminCommitteeController.php
+++ b/src/Controller/Admin/AdminCommitteeController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller\Admin;
 
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Committee\CommitteeMergeCommand;
 use AppBundle\Committee\CommitteeMergeCommandHandler;
 use AppBundle\Committee\MultipleReferentsFoundException;
@@ -79,10 +80,8 @@ class AdminCommitteeController extends Controller
      * @Method("GET")
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
-    public function membersAction(Committee $committee): Response
+    public function membersAction(CommitteeManager $manager, Committee $committee): Response
     {
-        $manager = $this->get('app.committee.manager');
-
         return $this->render('admin/committee/members.html.twig', [
             'committee' => $committee,
             'memberships' => $memberships = $manager->getCommitteeMemberships($committee),
@@ -95,8 +94,13 @@ class AdminCommitteeController extends Controller
      * @Method("GET")
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
-    public function changePrivilegeAction(Request $request, Committee $committee, Adherent $adherent, string $privilege): Response
-    {
+    public function changePrivilegeAction(
+        Request $request,
+        CommitteeManager $manager,
+        Committee $committee,
+        Adherent $adherent,
+        string $privilege
+    ): Response {
         if (!$committee->isApproved()) {
             throw new BadRequestHttpException('Committee must be approved to change member privileges.');
         }
@@ -106,7 +110,7 @@ class AdminCommitteeController extends Controller
         }
 
         try {
-            $this->get('app.committee.manager')->changePrivilege($adherent, $committee, $privilege);
+            $manager->changePrivilege($adherent, $committee, $privilege);
         } catch (CommitteeMembershipException $e) {
             $this->addFlash('error', $e->getMessage());
         }

--- a/src/Controller/EnMarche/AdherentController.php
+++ b/src/Controller/EnMarche/AdherentController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\CitizenProject\CitizenProjectPermissions;
 use AppBundle\Committee\CommitteeCreationCommand;
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Contact\ContactMessage;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\CitizenProject;
@@ -246,20 +247,16 @@ class AdherentController extends Controller
         ]);
     }
 
-    public function listMyCommitteesAction(string $noResultMessage = null): Response
+    public function listMyCommitteesAction(CommitteeManager $manager, string $noResultMessage = null): Response
     {
-        $manager = $this->get('app.committee.manager');
-
         return $this->render('adherent/list_my_committees.html.twig', [
             'committees' => $manager->getAdherentCommittees($this->getUser()),
             'no_result_message' => $noResultMessage,
         ]);
     }
 
-    public function listCommitteesAlAction(): Response
+    public function listCommitteesAlAction(CommitteeManager $manager): Response
     {
-        $manager = $this->get('app.committee.manager');
-
         return $this->render('adherent/list_my_committees_al.html.twig', [
             'committees' => $manager->getAdherentCommittees($this->getUser()),
         ]);

--- a/src/Controller/EnMarche/Coordinator/CoordinatorCommitteeController.php
+++ b/src/Controller/EnMarche/Coordinator/CoordinatorCommitteeController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller\EnMarche\Coordinator;
 
+use AppBundle\Committee\CommitteeManager;
 use AppBundle\Entity\Committee;
 use AppBundle\Exception\BaseGroupException;
 use AppBundle\Coordinator\Filter\CommitteeFilter;
@@ -24,7 +25,7 @@ class CoordinatorCommitteeController extends Controller
      * @Route("/list", name="app_coordinator_committees")
      * @Method("GET")
      */
-    public function committeesAction(Request $request): Response
+    public function committeesAction(Request $request, CommitteeManager $committeeManager): Response
     {
         try {
             $filter = CommitteeFilter::fromQueryString($request);
@@ -32,7 +33,7 @@ class CoordinatorCommitteeController extends Controller
             throw new BadRequestHttpException('Unexpected committee request status in the query string.', $e);
         }
 
-        $committees = $this->get('app.committee.manager')->getCoordinatorCommittees($this->getUser(), $filter);
+        $committees = $committeeManager->getCoordinatorCommittees($this->getUser(), $filter);
 
         $forms = [];
         foreach ($committees as $committee) {

--- a/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
+++ b/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
@@ -598,7 +598,7 @@ class CommitteeManagerControllerTest extends WebTestCase
     public function testAllowToCreateCommmitee()
     {
         /** @var CommitteeManager $manager */
-        $manager = $this->get('app.committee.manager');
+        $manager = $this->get(CommitteeManager::class);
 
         $this->authenticateAsAdherent($this->client, 'martine.lindt@gmail.com');
         $adherent = $this->getAdherentRepository()->findOneByEmail('martine.lindt@gmail.com');

--- a/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
+++ b/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
@@ -598,7 +598,7 @@ class CommitteeManagerControllerTest extends WebTestCase
     public function testAllowToCreateCommmitee()
     {
         /** @var CommitteeManager $manager */
-        $manager = $this->get(CommitteeManager::class);
+        $manager = $this->get('app.committee.manager');
 
         $this->authenticateAsAdherent($this->client, 'martine.lindt@gmail.com');
         $adherent = $this->getAdherentRepository()->findOneByEmail('martine.lindt@gmail.com');


### PR DESCRIPTION
```User Deprecated: The "AppBundle\Committee\CommitteeManager" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.```