### PR TITLE
Removed default strategy for Doctrine GeneratedValue annotations

### DIFF
--- a/src/Entity/Administrator.php
+++ b/src/Entity/Administrator.php
@@ -26,7 +26,7 @@ class Administrator implements UserInterface, TwoFactorInterface
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -31,7 +31,7 @@ class Article implements EntityMediaInterface, EntityContentInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ArticleCategory.php
+++ b/src/Entity/ArticleCategory.php
@@ -21,7 +21,7 @@ class ArticleCategory
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/BoardMember/BoardMember.php
+++ b/src/Entity/BoardMember/BoardMember.php
@@ -30,7 +30,7 @@ class BoardMember
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/CitizenProjectCommitteeSupport.php
+++ b/src/Entity/CitizenProjectCommitteeSupport.php
@@ -20,7 +20,7 @@ class CitizenProjectCommitteeSupport
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Clarification.php
+++ b/src/Entity/Clarification.php
@@ -26,7 +26,7 @@ class Clarification implements EntityMediaInterface, EntityContentInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/CoordinatorManagedArea.php
+++ b/src/Entity/CoordinatorManagedArea.php
@@ -16,7 +16,7 @@ class CoordinatorManagedArea
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/CustomSearchResult.php
+++ b/src/Entity/CustomSearchResult.php
@@ -20,7 +20,7 @@ class CustomSearchResult implements EntityMediaInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      *
      * @Algolia\Attribute
      */

--- a/src/Entity/HomeBlock.php
+++ b/src/Entity/HomeBlock.php
@@ -29,7 +29,7 @@ class HomeBlock
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Jecoute/Choice.php
+++ b/src/Entity/Jecoute/Choice.php
@@ -19,7 +19,7 @@ class Choice
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      *
      * @JMS\Groups({"survey_list"})
      */

--- a/src/Entity/Jecoute/DataAnswer.php
+++ b/src/Entity/Jecoute/DataAnswer.php
@@ -22,7 +22,7 @@ class DataAnswer
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Jecoute/DataSurvey.php
+++ b/src/Entity/Jecoute/DataSurvey.php
@@ -24,7 +24,7 @@ class DataSurvey
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Jecoute/Question.php
+++ b/src/Entity/Jecoute/Question.php
@@ -34,7 +34,7 @@ class Question
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Jecoute/SurveyQuestion.php
+++ b/src/Entity/Jecoute/SurveyQuestion.php
@@ -18,7 +18,7 @@ class SurveyQuestion
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/LiveLink.php
+++ b/src/Entity/LiveLink.php
@@ -20,7 +20,7 @@ class LiveLink
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -25,7 +25,7 @@ class Media
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/NewsletterSubscription.php
+++ b/src/Entity/NewsletterSubscription.php
@@ -28,7 +28,7 @@ class NewsletterSubscription
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/OrderArticle.php
+++ b/src/Entity/OrderArticle.php
@@ -23,7 +23,7 @@ class OrderArticle implements EntityContentInterface
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/OrderSection.php
+++ b/src/Entity/OrderSection.php
@@ -20,7 +20,7 @@ class OrderSection
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -25,7 +25,7 @@ class Page implements EntityMediaInterface, EntityContentInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ProcurationManagedArea.php
+++ b/src/Entity/ProcurationManagedArea.php
@@ -16,7 +16,7 @@ class ProcurationManagedArea
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ProcurationProxy.php
+++ b/src/Entity/ProcurationProxy.php
@@ -34,7 +34,7 @@ class ProcurationProxy
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Proposal.php
+++ b/src/Entity/Proposal.php
@@ -23,7 +23,7 @@ class Proposal implements EntityContentInterface
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ProposalTheme.php
+++ b/src/Entity/ProposalTheme.php
@@ -18,7 +18,7 @@ class ProposalTheme
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Redirection.php
+++ b/src/Entity/Redirection.php
@@ -24,7 +24,7 @@ class Redirection
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ReferentManagedArea.php
+++ b/src/Entity/ReferentManagedArea.php
@@ -18,7 +18,7 @@ class ReferentManagedArea
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ReferentOrganizationalChart/AbstractOrganizationalChartItem.php
+++ b/src/Entity/ReferentOrganizationalChart/AbstractOrganizationalChartItem.php
@@ -25,7 +25,7 @@ abstract class AbstractOrganizationalChartItem
      *
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
+++ b/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
@@ -16,7 +16,7 @@ class ReferentPersonLink
      *
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/SocialShare.php
+++ b/src/Entity/SocialShare.php
@@ -30,7 +30,7 @@ class SocialShare
     /**
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/SocialShareCategory.php
+++ b/src/Entity/SocialShareCategory.php
@@ -18,7 +18,7 @@ class SocialShareCategory
     /**
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 

--- a/src/Entity/Timeline/Measure.php
+++ b/src/Entity/Timeline/Measure.php
@@ -40,7 +40,7 @@ class Measure implements AlgoliaIndexedEntityInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      *
      * @Algolia\Attribute
      */

--- a/src/Entity/Timeline/Profile.php
+++ b/src/Entity/Timeline/Profile.php
@@ -23,7 +23,7 @@ class Profile implements AlgoliaIndexedEntityInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      *
      * @Algolia\Attribute
      */

--- a/src/Entity/Timeline/Theme.php
+++ b/src/Entity/Timeline/Theme.php
@@ -35,7 +35,7 @@ class Theme implements EntityMediaInterface, AlgoliaIndexedEntityInterface
      *
      * @ORM\Column(type="bigint")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      *
      * @Algolia\Attribute
      */

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -32,7 +32,7 @@ class Transaction
      *
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private $id;
 


### PR DESCRIPTION
This PR removes the default `AUTO` strategy option of the `GeneratedValue` annotations.

See : https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html#identifier-generation-strategies