### PR TITLE
[RFR] Remove popup from html after click on accept

### DIFF
--- a/templates/javascript.js.twig
+++ b/templates/javascript.js.twig
@@ -375,7 +375,7 @@ $(document).ready(function() {
                     type: 'PUT'
                 });
 
-                $(this).dialog("destroy");
+                element.remove();
             }
         },
         beforeClose: function (event, ui) {


### PR DESCRIPTION
Problem : Chart still visible under the tab

![destroy](https://user-images.githubusercontent.com/5656168/49097596-5a96f600-f26d-11e8-8d02-d1a2098fb48a.png)

Solution 1 : `element.css("visibility", "hidden");` => Big white space under tab

![hidden](https://user-images.githubusercontent.com/5656168/49097637-700c2000-f26d-11e8-8002-68bfb5be742c.png)

Solution 2 : `element.remove();` => No white space, no more chart

![remove](https://user-images.githubusercontent.com/5656168/49097659-7dc1a580-f26d-11e8-9b00-2e0361095bf6.png)
