### PR TITLE
[ADI] Enable in production

### DIFF
--- a/src/React/App/IdeasWorkshopApp.php
+++ b/src/React/App/IdeasWorkshopApp.php
@@ -16,8 +16,7 @@ class IdeasWorkshopApp implements ReactAppInterface
 
     public function enableInProduction(): bool
     {
-        // ;)
-        return false;
+        return true;
     }
 
     public function getRoutes(): array

--- a/templates/components/_nav_desktop.html.twig
+++ b/templates/components/_nav_desktop.html.twig
@@ -19,9 +19,11 @@
         <li>
             <a href="{{ path('react_app_citizen_projects_home') }}">Projets citoyens</a>
         </li>
+        {% if enable_canary %}
         <li>
             <a href="{{ path('react_app_ideas_workshop_home') }}">Atelier des idées</a>
         </li>
+        {% endif %}
         <li>
             <a href="{{ path('page_campus') }}">Formation</a>
         </li>

--- a/templates/components/_nav_mobile.html.twig
+++ b/templates/components/_nav_mobile.html.twig
@@ -113,9 +113,11 @@
                 <li>
                     <a href="{{ path('react_app_citizen_projects_home') }}">Projets citoyens</a>
                 </li>
+                {% if enable_canary %}
                 <li>
                     <a href="{{ path('react_app_ideas_workshop_home') }}">Atelier des idées</a>
                 </li>
+                {% endif %}
                 <li>
                     <a href="{{ path('page_campus') }}">Formation</a>
                 </li>


### PR DESCRIPTION
i confirm we want to:
- hide the links pointing to ideas workshop in the navigation (for now)
- enable the react app of ideas workshop