### PR TITLE
[ADI] fix migration

### DIFF
--- a/app/migrations/Version20190118142342.php
+++ b/app/migrations/Version20190118142342.php
@@ -11,7 +11,7 @@ final class Version20190118142342 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql(
-            "INSERT INTO adherent_tags (`name`) VALUES('?')",
+            'INSERT INTO adherent_tags (`name`) VALUES(?)',
             [AdherentTagEnum::LAREM],
             [\PDO::PARAM_STR]
         );
@@ -20,7 +20,7 @@ final class Version20190118142342 extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->addSql(
-            "DELETE FROM adherent_tags WHERE label = '?'",
+            'DELETE FROM adherent_tags WHERE `name` = ?',
             [AdherentTagEnum::LAREM],
             [\PDO::PARAM_STR]
         );


### PR DESCRIPTION
I had to fix the migration because, when executed, a `?` was put as name instead of `LaREM` tag. 
I also fixed the down part, no `label` column exists here. 

Also, as the migration has already been executed on both staging and staging-adi env, I updated direclty the tag name from the admin.