### PR TITLE
[ADI] Switch name to title and update css

### DIFF
--- a/src/Admin/IdeasWorkshopIdeaAdmin.php
+++ b/src/Admin/IdeasWorkshopIdeaAdmin.php
@@ -51,7 +51,7 @@ class IdeasWorkshopIdeaAdmin extends AbstractAdmin
     {
         $showMapper
             ->add('name', null, [
-                'label' => 'Nom',
+                'label' => 'Titre',
             ])
             ->add('slug', null, [
                 'label' => 'Slug',
@@ -85,7 +85,7 @@ class IdeasWorkshopIdeaAdmin extends AbstractAdmin
     {
         $formMapper
             ->add('name', null, [
-                'label' => 'Nom',
+                'label' => 'Titre',
             ])
             ->add('description', null, [
                 'label' => 'Description',
@@ -145,8 +145,9 @@ class IdeasWorkshopIdeaAdmin extends AbstractAdmin
     {
         $listMapper
             ->add('name', null, [
-                'label' => 'Nom',
+                'label' => 'Titre',
                 'header_style' => 'width: 250px',
+                'row_align' => 'none;word-break: break-all;',
             ])
             ->add('createdAt', null, [
                 'label' => 'Date de création',


### PR DESCRIPTION
When we have a single word like this in a column 

![list](https://user-images.githubusercontent.com/5656168/51985651-a7ca5a80-249e-11e9-9782-cac79738fba5.png)

Even with a width limitation on header_style, word is not broke. 

As a workaround and to avoid overriding the `base_list_field.html.twig` template, I used the row style because it's the only param as a style

`<td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}"{% if field_description.options.row_align is defined %} style="text-align:{{ field_description.options.row_align }}"{% endif %}>
`

Result looks like this

![result](https://user-images.githubusercontent.com/5656168/51986667-07296a00-24a1-11e9-8c1f-516c1f591fd4.png)


