### PR TITLE
[Test][Perf] Use DAMA\DoctrineTestBundle. (changes the way we use fixtures in tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ test-behat:                                                                     
 test-phpunit:                                                                                          ## Run phpunit tests
 	$(PHPUNIT) $(PHPUNIT_ARGS)
 
+test-debug:                                                                                            ## Run tests with debug group/tags
+	$(PHPUNIT) -vvv --group debug
+
 test-phpunit-functional:                                                                               ## Run phpunit fonctional tests
 	$(PHPUNIT) --group functional
 
@@ -148,6 +151,7 @@ tfp-db: wait-for-db                                                             
 	$(CONSOLE) doctrine:database:import --env=test -n -- dump/dump-2018.sql
 	$(CONSOLE) doctrine:migration:migrate -n --env=test
 	$(CONSOLE) doctrine:schema:validate --env=test
+	$(CONSOLE) doctrine:fixtures:load --env=test -n
 
 tj: node_modules                                                                                       ## Run the Javascript tests
 	$(EXEC) yarn test

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -9,6 +9,10 @@ parameters:
     timeline_max_messages: 10
 
 services:
+    app.geocoder:
+        class: 'Tests\AppBundle\Test\Geocoder\DummyGeocoder'
+        public: false
+
     app.mailer.transactional_client:
         class: 'Tests\AppBundle\Test\Mailer\NullEmailClient'
         public: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,10 +3,6 @@ imports:
     - { resource: assets_version.yml }
 
 services:
-    app.geocoder:
-        class: 'Tests\AppBundle\Test\Geocoder\DummyGeocoder'
-        public: false
-
     app.map.google_maps_static_provider:
         class: 'Tests\AppBundle\Test\Map\DummyStaticMapProvider'
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
     </testsuites>
 
     <listeners>
+        <listener class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener" />
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
 

--- a/src/Repository/AdherentRepository.php
+++ b/src/Repository/AdherentRepository.php
@@ -178,6 +178,7 @@ class AdherentRepository extends ServiceEntityRepository implements UserLoaderIn
             ->createQueryBuilder('a')
             ->select('COUNT(a.uuid)')
             ->where('a.status = :status')
+            ->andWhere('a.adherent = 1')
             ->setParameter('status', Adherent::ENABLED)
             ->getQuery()
         ;

--- a/tests/Admin/AdherentAdminTest.php
+++ b/tests/Admin/AdherentAdminTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\Entity\Adherent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -170,10 +169,7 @@ class AdherentAdminTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadAdherentData::class,
-        ]);
+        $this->init();
 
         $this->adherentRepository = $this->getAdherentRepository();
     }

--- a/tests/Admin/ArticleAdminTest.php
+++ b/tests/Admin/ArticleAdminTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Admin;
 
-use AppBundle\DataFixtures\ORM\LoadAdminData;
-use AppBundle\DataFixtures\ORM\LoadArticleData;
 use AppBundle\Entity\Article;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -120,10 +118,7 @@ class ArticleAdminTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadArticleData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Admin/ArticleCategoryAdminTest.php
+++ b/tests/Admin/ArticleCategoryAdminTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Admin;
 
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -94,7 +93,7 @@ class ArticleCategoryAdminTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([LoadAdminData::class]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/BoardMember/BoardMemberManagerTest.php
+++ b/tests/BoardMember/BoardMemberManagerTest.php
@@ -6,7 +6,6 @@ use AppBundle\BoardMember\BoardMemberFilter;
 use AppBundle\BoardMember\BoardMemberManager;
 use AppBundle\Collection\AdherentCollection;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadBoardMemberRoleData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\BoardMember\Role;
 use AppBundle\Repository\AdherentRepository;
@@ -35,7 +34,7 @@ class BoardMemberManagerTest extends WebTestCase
     public function testSearchMembers()
     {
         $filter = BoardMemberFilter::createFromArray([]);
-        $excludedMember = $this->getAdherentRepository()->findOneByEmail('kiroule.p@blabla.tld');
+        $excludedMember = $this->adherentRepository->findOneByEmail('kiroule.p@blabla.tld');
 
         $members = $this->boardMemberManager->paginateMembers($filter, $excludedMember);
 
@@ -47,7 +46,7 @@ class BoardMemberManagerTest extends WebTestCase
     public function testPaginateMembers()
     {
         $filter = BoardMemberFilter::createFromArray([]);
-        $excludedMember = $this->getAdherentRepository()->findOneByEmail('kiroule.p@blabla.tld');
+        $excludedMember = $this->adherentRepository->findOneByEmail('kiroule.p@blabla.tld');
 
         $paginator = $this->boardMemberManager->paginateMembers($filter, $excludedMember);
 
@@ -91,12 +90,8 @@ class BoardMemberManagerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadBoardMemberRoleData::class,
-        ]);
+        $this->init();
 
-        $this->container = $this->getContainer();
         $this->adherentRepository = $this->getAdherentRepository();
         $this->boardMemberManager = $this->container->get('app.board_member.manager');
     }
@@ -107,7 +102,6 @@ class BoardMemberManagerTest extends WebTestCase
 
         $this->boardMemberManager = null;
         $this->adherentRepository = null;
-        $this->container = null;
 
         parent::tearDown();
     }

--- a/tests/CitizenProject/CitizenProjectManagerTest.php
+++ b/tests/CitizenProject/CitizenProjectManagerTest.php
@@ -6,7 +6,6 @@ use AppBundle\CitizenProject\CitizenProjectAuthority;
 use AppBundle\CitizenProject\CitizenProjectManager;
 use AppBundle\CitizenProject\CitizenProjectMessageNotifier;
 use AppBundle\Collection\AdherentCollection;
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadCitizenProjectData;
 use AppBundle\Membership\CitizenProjectNotificationDistance;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -85,12 +84,8 @@ class CitizenProjectManagerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadCitizenProjectData::class,
-        ]);
+        $this->init();
 
-        $this->container = $this->getContainer();
         $this->citizenProjectManager = new CitizenProjectManager(
             $this->getManagerRegistry(),
             $this->getStorage(),
@@ -100,9 +95,9 @@ class CitizenProjectManagerTest extends WebTestCase
 
     protected function tearDown()
     {
-        $this->kill();
-
         $this->citizenProjectManager = null;
+
+        $this->kill();
 
         parent::tearDown();
     }

--- a/tests/Command/AlgoliaSynchronizeCommandTest.php
+++ b/tests/Command/AlgoliaSynchronizeCommandTest.php
@@ -2,11 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadArticleData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadProposalData;
-use AppBundle\DataFixtures\ORM\LoadTimelineData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -45,8 +40,8 @@ class AlgoliaSynchronizeCommandTest extends WebTestCase
                 [
                     'Synchronizing entity AppBundle\Entity\Article ... done, 180 records indexed',
                     'Synchronizing entity AppBundle\Entity\Proposal ... done, 3 records indexed',
-                    'Synchronizing entity AppBundle\Entity\Clarification ... done, 0 records indexed',
-                    'Synchronizing entity AppBundle\Entity\CustomSearchResult ... done, 0 records indexed',
+                    'Synchronizing entity AppBundle\Entity\Clarification ... done, 21 records indexed',
+                    'Synchronizing entity AppBundle\Entity\CustomSearchResult ... done, 2 records indexed',
                     'Synchronizing entity AppBundle\Entity\Event ... done, 21 records indexed',
                     'Synchronizing entity AppBundle\Entity\Timeline\Profile ... done, 5 records indexed',
                     'Synchronizing entity AppBundle\Entity\Timeline\Theme ... done, 5 records indexed',
@@ -54,25 +49,5 @@ class AlgoliaSynchronizeCommandTest extends WebTestCase
                 ],
             ],
         ];
-    }
-
-    public function setUp()
-    {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadArticleData::class,
-            LoadEventData::class,
-            LoadProposalData::class,
-            LoadTimelineData::class,
-        ]);
-
-        parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        $this->kill();
-
-        parent::tearDown();
     }
 }

--- a/tests/Command/ApiScheduleCommitteeCreationCommandTest.php
+++ b/tests/Command/ApiScheduleCommitteeCreationCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -20,21 +19,5 @@ class ApiScheduleCommitteeCreationCommandTest extends WebTestCase
         $this->assertContains('Starting synchronization.', $output);
         $this->assertContains('10/10', $output);
         $this->assertContains('Successfully scheduled for synchronization!', $output);
-    }
-
-    public function setUp()
-    {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-        ]);
-
-        parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        $this->kill();
-
-        parent::tearDown();
     }
 }

--- a/tests/Command/ApiScheduleEventCreationCommandTest.php
+++ b/tests/Command/ApiScheduleEventCreationCommandTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -21,22 +19,5 @@ class ApiScheduleEventCreationCommandTest extends WebTestCase
         $this->assertContains('Starting synchronization.', $output);
         $this->assertContains('21/21', $output);
         $this->assertContains('Successfully scheduled for synchronization!', $output);
-    }
-
-    public function setUp()
-    {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadEventData::class,
-        ]);
-
-        parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        $this->kill();
-
-        parent::tearDown();
     }
 }

--- a/tests/Command/DonationUpdateReferenceCommandTest.php
+++ b/tests/Command/DonationUpdateReferenceCommandTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadDonationData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -21,22 +19,5 @@ class DonationUpdateReferenceCommandTest extends WebTestCase
         $this->assertContains('Starting Donations reference update.', $output);
         $this->assertContains('Updated 7 Donations reference.', $output);
         $this->assertContains('Donations reference updated successfully!', $output);
-    }
-
-    public function setUp()
-    {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadDonationData::class,
-        ]);
-
-        parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        $this->kill();
-
-        parent::tearDown();
     }
 }

--- a/tests/Command/ImportReferentBioPictureCommandTest.php
+++ b/tests/Command/ImportReferentBioPictureCommandTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Command;
 
 use AppBundle\Command\ImportReferentBioPictureCommand;
-use AppBundle\DataFixtures\ORM\LoadReferentData;
 use AppBundle\Entity\Media;
 use AppBundle\Entity\Referent;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -164,10 +163,6 @@ class ImportReferentBioPictureCommandTest extends WebTestCase
 
     public function setUp()
     {
-        $this->loadFixtures([
-            LoadReferentData::class,
-        ]);
-
         $this->container = $this->getContainer();
 
         parent::setUp();

--- a/tests/Command/ProcurationSendReminderCommandTest.php
+++ b/tests/Command/ProcurationSendReminderCommandTest.php
@@ -3,10 +3,7 @@
 namespace Tests\AppBundle\Command;
 
 use AppBundle\Command\ProcurationSendReminderCommand;
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadProcurationData;
 use AppBundle\Mailer\Message\ProcurationProxyReminderMessage;
-use AppBundle\Repository\ProcurationRequestRepository;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -17,9 +14,6 @@ class ProcurationSendReminderCommandTest extends WebTestCase
 {
     use ControllerTestTrait;
 
-    /** @var ProcurationRequestRepository */
-    private $procurationRequestRepository;
-
     public function testCommand()
     {
         $this->decorated = false;
@@ -27,18 +21,12 @@ class ProcurationSendReminderCommandTest extends WebTestCase
 
         $this->assertContains('1 reminders sent', $output);
         $this->assertCountMails(1, ProcurationProxyReminderMessage::class);
-        $this->assertCount(1, $this->procurationRequestRepository->findBy(['reminded' => 1]), 'The command should add a reminder.');
+        $this->assertCount(1, $this->getProcurationRequestRepository()->findBy(['reminded' => 1]), 'The command should add a reminder.');
     }
 
     public function setUp()
     {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadProcurationData::class,
-        ]);
-
         $this->container = $this->getContainer();
-        $this->procurationRequestRepository = $this->getProcurationRequestRepository();
 
         parent::setUp();
     }
@@ -46,8 +34,6 @@ class ProcurationSendReminderCommandTest extends WebTestCase
     public function tearDown()
     {
         $this->kill();
-
-        $this->procurationRequestRepository = null;
 
         parent::tearDown();
     }

--- a/tests/Command/TimelineSynchronizeCommandTest.php
+++ b/tests/Command/TimelineSynchronizeCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use AppBundle\DataFixtures\ORM\LoadTimelineData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -25,21 +24,5 @@ Timeline has been successfully synchronized with Algolia.
 EOL;
 
         $this->assertContains($expectedOutput, $output);
-    }
-
-    public function setUp()
-    {
-        $this->loadFixtures([
-            LoadTimelineData::class,
-        ]);
-
-        parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        $this->kill();
-
-        parent::tearDown();
     }
 }

--- a/tests/Committee/CommitteeManagerTest.php
+++ b/tests/Committee/CommitteeManagerTest.php
@@ -5,7 +5,6 @@ namespace Tests\AppBundle\Committee;
 use AppBundle\Collection\AdherentCollection;
 use AppBundle\Committee\CommitteeManager;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadCommitteeMembershipHistoryData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\CommitteeMembership;
@@ -345,11 +344,6 @@ class CommitteeManagerTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadCommitteeMembershipHistoryData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->committeeManager = new CommitteeManager(

--- a/tests/Committee/Feed/CommitteeFeedManagerTest.php
+++ b/tests/Committee/Feed/CommitteeFeedManagerTest.php
@@ -68,11 +68,8 @@ class CommitteeFeedManagerTest extends WebTestCase
 
     public function setUp()
     {
-        $this->loadFixtures([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
 
-        $this->container = $this->getContainer();
         $this->committeeFeedManager = $this->get('app.committee.feed_manager');
         $this->committeeRepository = $this->getCommitteeRepository();
         $this->committeeMembershipRepository = $this->getCommitteeMembershipRepository();

--- a/tests/Controller/Admin/AdminCommitteeControllerTest.php
+++ b/tests/Controller/Admin/AdminCommitteeControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\Mailer\Message\CommitteeApprovalConfirmationMessage;
 use AppBundle\Mailer\Message\CommitteeApprovalReferentMessage;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,10 +44,7 @@ class AdminCommitteeControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadAdherentData::class,
-        ]);
+        $this->init();
 
         $this->committeeRepository = $this->getCommitteeRepository();
     }

--- a/tests/Controller/Admin/AdminIdeaControllerTest.php
+++ b/tests/Controller/Admin/AdminIdeaControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadIdeaData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\Entity\IdeasWorkshop\Idea;
 use AppBundle\Repository\IdeaRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -64,10 +63,7 @@ class AdminIdeaControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadIdeaData::class,
-        ]);
+        $this->init();
 
         $this->ideaRepository = $this->getIdeaRepository();
     }

--- a/tests/Controller/Admin/AdminThreadCommentControllerTest.php
+++ b/tests/Controller/Admin/AdminThreadCommentControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadIdeaThreadCommentData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\Entity\IdeasWorkshop\ThreadComment;
 use AppBundle\Repository\ThreadCommentRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -64,10 +63,7 @@ class AdminThreadCommentControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadIdeaThreadCommentData::class,
-        ]);
+        $this->init();
 
         $this->threadCommentRepository = $this->getThreadCommentRepository();
     }

--- a/tests/Controller/Admin/AdminThreadControllerTest.php
+++ b/tests/Controller/Admin/AdminThreadControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadIdeaThreadData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\Entity\IdeasWorkshop\Thread;
 use AppBundle\Repository\ThreadRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -64,10 +63,7 @@ class AdminThreadControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadIdeaThreadData::class,
-        ]);
+        $this->init();
 
         $this->threadRepository = $this->getThreadRepository();
     }

--- a/tests/Controller/Admin/AdminTimelineMeasureControllerTest.php
+++ b/tests/Controller/Admin/AdminTimelineMeasureControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Admin;
 
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\DataFixtures\ORM\LoadTimelineData;
 use AppBundle\Entity\Timeline\Measure;
 use AppBundle\Entity\Timeline\Profile;
@@ -209,10 +208,7 @@ class AdminTimelineMeasureControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadTimelineData::class,
-        ]);
+        $this->init();
 
         $this->get('doctrine.orm.entity_manager')->getFilters()->disable('oneLocale');
 

--- a/tests/Controller/Admin/ClientAdminControllerTest.php
+++ b/tests/Controller/Admin/ClientAdminControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Admin;
 
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use AppBundle\DataFixtures\ORM\LoadClientData;
 use AppBundle\Entity\OAuth\AccessToken;
 use AppBundle\Entity\OAuth\Client;
@@ -86,10 +85,7 @@ class ClientAdminControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadClientData::class,
-        ]);
+        $this->init();
 
         $this->authenticateAsAdmin($this->client);
     }

--- a/tests/Controller/Amp/AmpControllerTest.php
+++ b/tests/Controller/Amp/AmpControllerTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Amp;
 
-use AppBundle\DataFixtures\ORM\LoadArticleData;
-use AppBundle\DataFixtures\ORM\LoadOrderArticleData;
-use AppBundle\DataFixtures\ORM\LoadOrderSectionData;
-use AppBundle\DataFixtures\ORM\LoadProposalData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -117,12 +113,7 @@ class AmpControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadOrderSectionData::class,
-            LoadOrderArticleData::class,
-            LoadArticleData::class,
-            LoadProposalData::class,
-        ], 'amp');
+        $this->init('amp');
     }
 
     protected function tearDown()

--- a/tests/Controller/Api/CommitteesControllerTest.php
+++ b/tests/Controller/Api/CommitteesControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Api;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ApiControllerTestTrait;
@@ -40,9 +39,7 @@ class CommitteesControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     public function tearDown()

--- a/tests/Controller/Api/EventsControllerTest.php
+++ b/tests/Controller/Api/EventsControllerTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\AppBundle\Controller\Api;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Entity\EventCategory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -80,11 +78,7 @@ class EventsControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
     }
 
     public function tearDown()

--- a/tests/Controller/Api/FormControllerTest.php
+++ b/tests/Controller/Api/FormControllerTest.php
@@ -180,7 +180,7 @@ class FormControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([]);
+        $this->init();
     }
 
     public function tearDown()

--- a/tests/Controller/Api/LegislativesControllerTest.php
+++ b/tests/Controller/Api/LegislativesControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Api;
 
-use AppBundle\DataFixtures\ORM\LoadLegislativesData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ApiControllerTestTrait;
@@ -41,9 +40,7 @@ class LegislativesControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadLegislativesData::class,
-        ]);
+        $this->init();
     }
 
     public function tearDown()

--- a/tests/Controller/Api/OAuthServerControllerTest.php
+++ b/tests/Controller/Api/OAuthServerControllerTest.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Tests\Controller\Front;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadOAuthTokenData;
 use AppBundle\Entity\OAuth\AccessToken;
 use AppBundle\Entity\OAuth\AuthorizationCode;
 use AppBundle\OAuth\Model\Client;
@@ -427,9 +426,7 @@ class OAuthServerControllerTest extends WebTestCase
         $this->encryptionKey = $this->getContainer()->getParameter('env(SSL_ENCRYPTION_KEY)');
         $this->privateCryptKey = new CryptKey($this->getContainer()->getParameter('env(SSL_PRIVATE_KEY)'));
 
-        $this->init([
-            LoadOAuthTokenData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/Api/ReferentsControllerTest.php
+++ b/tests/Controller/Api/ReferentsControllerTest.php
@@ -37,7 +37,7 @@ class ReferentsControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([]);
+        $this->init();
     }
 
     public function tearDown()

--- a/tests/Controller/Api/StatsControllerTest.php
+++ b/tests/Controller/Api/StatsControllerTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Api;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadUserData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -40,11 +37,7 @@ class StatsControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadUserData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/ControllerTestTrait.php
+++ b/tests/Controller/ControllerTestTrait.php
@@ -5,7 +5,6 @@ namespace Tests\AppBundle\Controller;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\EventCategory;
 use AppBundle\Entity\ReferentTag;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use Symfony\Bundle\FrameworkBundle\Client;
@@ -187,14 +186,13 @@ trait ControllerTestTrait
         self::assertSame($referentTag->getCode(), $code);
     }
 
-    protected function init(array $fixtures = [], string $host = 'app')
+    protected function init(string $host = 'app')
     {
         $this->container = $this->getContainer();
         $this->manager = $this->container->get('doctrine.orm.entity_manager');
 
-        $this->manager->getConnection()->executeUpdate('SET foreign_key_checks = 0;');
-        $this->loadFixtures($fixtures, null, 'doctrine', ORMPurger::PURGE_MODE_TRUNCATE);
-        $this->manager->getConnection()->executeUpdate('SET foreign_key_checks = 1;');
+        // delete all scheduled emails
+        $this->getEmailRepository()->createQueryBuilder('e')->delete()->getQuery()->execute();
 
         $this->hosts = [
             'scheme' => $this->container->getParameter('router.request_context.scheme'),

--- a/tests/Controller/EnMarche/AdherentControllerTest.php
+++ b/tests/Controller/EnMarche/AdherentControllerTest.php
@@ -3,19 +3,9 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadDistrictData;
-use AppBundle\DataFixtures\ORM\LoadEmailSubscriptionHistoryData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectCommentData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use AppBundle\DataFixtures\ORM\LoadIdeaData;
 use AppBundle\DataFixtures\ORM\LoadIdeaThreadCommentData;
 use AppBundle\DataFixtures\ORM\LoadIdeaThreadData;
-use AppBundle\DataFixtures\ORM\LoadIdeaVoteData;
-use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
-use AppBundle\DataFixtures\ORM\LoadTurnkeyProjectData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\CitizenProject;
@@ -73,12 +63,14 @@ class AdherentControllerTest extends WebTestCase
 
         $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
 
-        $this->assertSame(4, $crawler->filter('.event-registration')->count());
+        $this->assertSame(6, $crawler->filter('.event-registration')->count());
 
         $titles = $crawler->filter('.event-registration h2 a');
         $this->assertSame('Meeting de New York City', trim($titles->first()->text()));
-        $this->assertSame('Réunion de réflexion parisienne', trim($titles->eq(1)->text()));
-        $this->assertSame('Réunion de réflexion dammarienne', trim($titles->eq(2)->text()));
+        $this->assertSame('Projet citoyen #3', trim($titles->eq(1)->text()));
+        $this->assertSame('Réunion de réflexion parisienne', trim($titles->eq(2)->text()));
+        $this->assertSame('Réunion de réflexion dammarienne', trim($titles->eq(3)->text()));
+        $this->assertSame('Projet citoyen Paris-18', trim($titles->eq(4)->text()));
         $this->assertSame('Réunion de réflexion parisienne annulé', trim($titles->last()->text()));
 
         $crawler = $this->client->click($crawler->selectLink('Événements passés')->link());
@@ -1170,21 +1162,7 @@ class AdherentControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadHomeBlockData::class,
-            LoadLiveLinkData::class,
-            LoadAdherentData::class,
-            LoadDistrictData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-            LoadCitizenProjectData::class,
-            LoadCitizenProjectCommentData::class,
-            LoadEmailSubscriptionHistoryData::class,
-            LoadTurnkeyProjectData::class,
-            LoadIdeaData::class,
-            LoadIdeaThreadCommentData::class,
-            LoadIdeaVoteData::class,
-        ]);
+        $this->init();
 
         $this->committeeRepository = $this->getCommitteeRepository();
         $this->emailRepository = $this->getEmailRepository();

--- a/tests/Controller/EnMarche/ArticleControllerTest.php
+++ b/tests/Controller/EnMarche/ArticleControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\Controller\EnMarche\ArticleController;
-use AppBundle\DataFixtures\ORM\LoadArticleData;
-use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -122,10 +120,7 @@ class ArticleControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadArticleData::class,
-            LoadLiveLinkData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/BiographyControllerTest.php
+++ b/tests/Controller/EnMarche/BiographyControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadExecutiveOfficeMemberData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -74,9 +73,7 @@ class BiographyControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadExecutiveOfficeMemberData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/BoardMemberControllerTest.php
+++ b/tests/Controller/EnMarche/BoardMemberControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadBoardMemberRoleData;
 use AppBundle\Mailer\Message\BoardMemberMessage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -311,10 +309,7 @@ class BoardMemberControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadBoardMemberRoleData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/CitizenActionControllerTest.php
+++ b/tests/Controller/EnMarche/CitizenActionControllerTest.php
@@ -3,13 +3,7 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadCitizenActionCategoryData;
 use AppBundle\DataFixtures\ORM\LoadCitizenActionData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectCategoryData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectCategorySkillData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectSkillData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
 use AppBundle\Entity\CitizenAction;
 use AppBundle\Entity\EventRegistration;
 use Symfony\Component\HttpFoundation\Request;
@@ -229,16 +223,7 @@ CONTENT;
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadCitizenProjectCategoryData::class,
-            LoadCitizenProjectCategorySkillData::class,
-            LoadCitizenProjectSkillData::class,
-            LoadCitizenProjectData::class,
-            LoadCitizenActionCategoryData::class,
-            LoadCitizenActionData::class,
-        ]);
+        $this->init();
 
         $this->repository = $this->getEventRegistrationRepository();
     }

--- a/tests/Controller/EnMarche/CitizenActionManagerControllerTest.php
+++ b/tests/Controller/EnMarche/CitizenActionManagerControllerTest.php
@@ -2,10 +2,7 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadCitizenActionCategoryData;
 use AppBundle\DataFixtures\ORM\LoadCitizenActionData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectData;
 use AppBundle\Entity\CitizenAction;
 use AppBundle\Mailer\Message\CitizenActionCancellationMessage;
 use AppBundle\Mailer\Message\CitizenActionContactParticipantsMessage;
@@ -363,12 +360,7 @@ class CitizenActionManagerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadCitizenProjectData::class,
-            LoadCitizenActionCategoryData::class,
-            LoadCitizenActionData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/CitizenProjectControllerTest.php
+++ b/tests/Controller/EnMarche/CitizenProjectControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadCitizenActionData;
-use AppBundle\DataFixtures\ORM\LoadCitizenProjectCommentData;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadCitizenProjectData;
 use AppBundle\Entity\CitizenProject;
@@ -308,6 +306,8 @@ class CitizenProjectControllerTest extends AbstractGroupControllerTest
 
     public function testCitizenProjectContactActors()
     {
+        $this->disableRepublicanSilence();
+
         // Authenticate as the administrator (host)
         $this->authenticateAsAdherent($this->client, 'lolodie.dutemps@hotnix.tld');
         $crawler = $this->client->request(Request::METHOD_GET, '/evenements');
@@ -536,12 +536,7 @@ class CitizenProjectControllerTest extends AbstractGroupControllerTest
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadCitizenProjectData::class,
-            LoadCitizenProjectCommentData::class,
-            LoadCitizenActionData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/CommitteeControllerTest.php
+++ b/tests/Controller/EnMarche/CommitteeControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Entity\CommitteeFeedItem;
 use AppBundle\Mailer\Message\CommitteeNewFollowerMessage;
 use AppBundle\Entity\Committee;
@@ -542,11 +540,7 @@ class CommitteeControllerTest extends AbstractGroupControllerTest
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
 
         $this->committeeRepository = $this->getCommitteeRepository();
     }

--- a/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
+++ b/tests/Controller/EnMarche/CommitteeManagerControllerTest.php
@@ -5,7 +5,6 @@ namespace Tests\AppBundle\Controller\EnMarche;
 use AppBundle\Committee\CommitteeManager;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\CommitteeMembership;
 use AppBundle\Entity\Event;
@@ -790,11 +789,7 @@ class CommitteeManagerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
 
         $this->committeeEventRepository = $this->getEventRepository();
         $this->committeeFeedItemRepository = $this->getCommitteeFeedItemRepository();

--- a/tests/Controller/EnMarche/CoordinatorControllerTest.php
+++ b/tests/Controller/EnMarche/CoordinatorControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -162,9 +161,7 @@ class CoordinatorControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/DeputyControllerTest.php
+++ b/tests/Controller/EnMarche/DeputyControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadDistrictData;
 use AppBundle\Entity\DeputyManagedUsersMessage;
 use AppBundle\Repository\DeputyManagedUsersMessageRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -69,10 +67,7 @@ class DeputyControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadDistrictData::class,
-        ]);
+        $this->init();
 
         $this->deputyMessageRepository = $this->manager->getRepository(DeputyManagedUsersMessage::class);
     }

--- a/tests/Controller/EnMarche/DocumentsControllerTest.php
+++ b/tests/Controller/EnMarche/DocumentsControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -181,9 +180,7 @@ class DocumentsControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/DonationControllerTest.php
+++ b/tests/Controller/EnMarche/DonationControllerTest.php
@@ -406,7 +406,10 @@ class DonationControllerTest extends WebTestCase
         parent::setUp();
 
         $this->init();
-        $this->loadFixtures([]);
+
+        // Delete all donations for tests
+        $this->getRepository(Transaction::class)->createQueryBuilder('t')->delete()->getQuery()->execute();
+        $this->getDonationRepository()->createQueryBuilder('d')->delete()->getQuery()->execute();
 
         $this->payboxClient = new PayboxClient();
         $this->donationRepository = $this->getDonationRepository();

--- a/tests/Controller/EnMarche/EventControllerTest.php
+++ b/tests/Controller/EnMarche/EventControllerTest.php
@@ -5,7 +5,6 @@ namespace Tests\AppBundle\Controller\EnMarche;
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
 use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use AppBundle\Entity\EventInvite;
 use AppBundle\Entity\EventRegistration;
 use AppBundle\Mailer\Message\EventInvitationMessage;
@@ -430,12 +429,7 @@ class EventControllerTest extends AbstractEventControllerTest
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-            LoadHomeBlockData::class,
-        ]);
+        $this->init();
 
         $this->repository = $this->getEventRegistrationRepository();
     }

--- a/tests/Controller/EnMarche/EventManagerControllerTest.php
+++ b/tests/Controller/EnMarche/EventManagerControllerTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Mailer\Message\EventCancellationMessage;
 use AppBundle\Mailer\Message\EventContactMembersMessage;
 use Ramsey\Uuid\Uuid;
@@ -376,11 +374,7 @@ class EventManagerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ExplainerControllerTest.php
+++ b/tests/Controller/EnMarche/ExplainerControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadOrderSectionData;
-use AppBundle\DataFixtures\ORM\LoadPageData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -25,7 +23,7 @@ class ExplainerControllerTest extends WebTestCase
         $crawler = $this->client->request(Request::METHOD_GET, $path);
 
         $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
-        $this->assertSame(4, $crawler->filter('.explainer__articles li')->count());
+        $this->assertSame(4, $crawler->filter('.explainer__articles > ul > li')->count());
     }
 
     public function provideActions()
@@ -37,10 +35,7 @@ class ExplainerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadPageData::class,
-            LoadOrderSectionData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/HomeControllerTest.php
+++ b/tests/Controller/EnMarche/HomeControllerTest.php
@@ -2,12 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadArticleData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
-use AppBundle\DataFixtures\ORM\LoadLiveLinkData;
-use AppBundle\DataFixtures\ORM\LoadPageData;
-use AppBundle\DataFixtures\ORM\LoadRedirectionData;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -128,14 +122,7 @@ class HomeControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadHomeBlockData::class,
-            LoadLiveLinkData::class,
-            LoadRedirectionData::class,
-            LoadEventData::class,
-            LoadPageData::class,
-            LoadArticleData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/InteractiveControllerTest.php
+++ b/tests/Controller/EnMarche/InteractiveControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadPurchasingPowerData;
 use AppBundle\Entity\PurchasingPowerChoice;
 use AppBundle\Repository\EmailRepository;
 use AppBundle\Repository\PurchasingPowerChoiceRepository;
@@ -50,11 +49,11 @@ class InteractiveControllerTest extends WebTestCase
             'purchasing_power[friendFirstName]' => $purchasingPower->friendFirstName = 'Mylène',
             'purchasing_power[friendAge]' => '26',
             'purchasing_power[friendGender]' => $purchasingPower->friendGender = 'female',
-            'purchasing_power[friendPosition]' => '5',
+            'purchasing_power[friendPosition]' => '31',
         ]));
 
         $purchasingPower->friendAge = 26;
-        $purchasingPower->friendPosition = $this->getChoice(5);
+        $purchasingPower->friendPosition = $this->getChoice(31);
         $purchasingPower->marking = PurchasingPowerProcessor::STATE_NEEDS_FRIEND_CASES;
 
         $this->assertEquals($purchasingPower, $this->getCurrentPurchasingPower());
@@ -72,7 +71,7 @@ class InteractiveControllerTest extends WebTestCase
             'purchasing_power[friendFirstName]' => 'Mylène',
             'purchasing_power[friendAge]' => '26',
             'purchasing_power[friendGender]' => 'female',
-            'purchasing_power[friendPosition]' => '5',
+            'purchasing_power[friendPosition]' => '31',
         ]));
 
         $this->assertResponseStatusCode(Response::HTTP_FOUND, $this->client->getResponse());
@@ -88,9 +87,7 @@ class InteractiveControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadPurchasingPowerData::class,
-        ]);
+        $this->init();
 
         $this->PurchasingPowerChoiceRepository = $this->getPurchasingPowerChoiceRepository();
         $this->PurchasingPowerInvitationRepository = $this->getPurchasingPowerInvitationRepository();

--- a/tests/Controller/EnMarche/JeMarcheControllerTest.php
+++ b/tests/Controller/EnMarche/JeMarcheControllerTest.php
@@ -99,7 +99,7 @@ class JeMarcheControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([]);
+        $this->init();
 
         $this->jeMarcheReportRepostitory = $this->getJeMarcheReportRepository();
     }

--- a/tests/Controller/EnMarche/LegislativesControllerTest.php
+++ b/tests/Controller/EnMarche/LegislativesControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Mailer\Message\LegislativeCampaignContactMessage;
 use AppBundle\Repository\EmailRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -125,9 +124,7 @@ class LegislativesControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
 
         $this->emailRepository = $this->getEmailRepository();
     }

--- a/tests/Controller/EnMarche/MapControllerTest.php
+++ b/tests/Controller/EnMarche/MapControllerTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadUserData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -43,12 +39,7 @@ class MapControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadUserData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/MembershipControllerTest.php
+++ b/tests/Controller/EnMarche/MembershipControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadBannedAdherentData;
-use AppBundle\DataFixtures\ORM\LoadUserData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\AdherentActivationToken;
 use AppBundle\Mailer\Message\AdherentAccountActivationMessage;
@@ -301,11 +299,7 @@ class MembershipControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadUserData::class,
-            LoadBannedAdherentData::class,
-        ]);
+        $this->init();
 
         $this->adherentRepository = $this->getAdherentRepository();
         $this->activationTokenRepository = $this->getActivationTokenRepository();

--- a/tests/Controller/EnMarche/NewsletterControllerTest.php
+++ b/tests/Controller/EnMarche/NewsletterControllerTest.php
@@ -2,14 +2,12 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadNewsletterSubscriptionData;
 use AppBundle\Entity\NewsletterSubscription;
 use AppBundle\Mailer\Message\NewsletterInvitationMessage;
 use AppBundle\Mailer\Message\NewsletterSubscriptionMessage;
 use AppBundle\Repository\EmailRepository;
 use AppBundle\Repository\NewsletterInviteRepository;
 use AppBundle\Repository\NewsletterSubscriptionRepository;
-use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -211,10 +209,7 @@ class NewsletterControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadHomeBlockData::class,
-            LoadNewsletterSubscriptionData::class,
-        ]);
+        $this->init();
 
         $this->subscriptionsRepository = $this->getNewsletterSubscriptionRepository();
         $this->newsletterInviteRepository = $this->getNewsletterInvitationRepository();

--- a/tests/Controller/EnMarche/PageControllerTest.php
+++ b/tests/Controller/EnMarche/PageControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadFacebookVideoData;
-use AppBundle\DataFixtures\ORM\LoadPageData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -74,10 +72,7 @@ class PageControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadFacebookVideoData::class,
-            LoadPageData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ProcurationControllerTest.php
+++ b/tests/Controller/EnMarche/ProcurationControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadElectionData;
-use AppBundle\DataFixtures\ORM\LoadProcurationData;
 use AppBundle\Entity\ElectionRound;
 use AppBundle\Entity\ProcurationProxy;
 use AppBundle\Entity\ProcurationRequest;
@@ -100,7 +98,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->assertCount(1, $error = $crawler->filter('.form__error'));
         $this->assertSame('Vous devez choisir au moins une élection.', $error->text());
 
-        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [3]]));
+        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [5]]));
 
         $this->assertClientIsRedirectedTo('/procuration/je-demande/'.ProcurationRequest::STEP_URI_VOTE, $this->client);
         $this->assertTrue(
@@ -139,7 +137,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->assertCount(1, $error = $crawler->filter('.form__error'));
         $this->assertSame('Vous devez choisir au moins une élection.', $error->text());
 
-        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [3]]));
+        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [5]]));
 
         $this->assertClientIsRedirectedTo('/procuration/je-propose', $this->client);
         $this->assertTrue(
@@ -298,7 +296,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->client->submit($crawler->selectButton('Je continue')->form([
             'g-recaptcha-response' => 'dummy',
             'app_procuration_request' => [
-                'electionRounds' => ['5'],
+                'electionRounds' => ['9'],
                 'reason' => ProcurationRequest::REASON_HEALTH,
                 'authorization' => true,
             ],
@@ -328,7 +326,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->assertSame('69001', $request->getPostalCode());
         $this->assertSame('Lyon 1er', $request->getCityName());
         $this->assertSame('6 rue Neyret', $request->getAddress());
-        $this->assertEquals([$this->getRepository(ElectionRound::class)->find(5)], $request->getElectionRounds()->toArray());
+        $this->assertEquals([$this->getRepository(ElectionRound::class)->find(9)], $request->getElectionRounds()->toArray());
         $this->assertSame(ProcurationRequest::REASON_HEALTH, $request->getReason());
     }
 
@@ -469,7 +467,7 @@ class ProcurationControllerTest extends WebTestCase
                 'voteCity' => '92110-92024',
                 'voteCityName' => '',
                 'voteOffice' => 'TestOfficeName',
-                'electionRounds' => ['5'],
+                'electionRounds' => ['9'],
                 'conditions' => true,
             ],
         ]));
@@ -496,7 +494,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->assertSame('69001', $proposal->getPostalCode());
         $this->assertSame('Lyon 1er', $proposal->getCityName());
         $this->assertSame('6 rue Neyret', $proposal->getAddress());
-        $this->assertEquals([$this->getRepository(ElectionRound::class)->find(5)], $proposal->getElectionRounds()->toArray());
+        $this->assertEquals([$this->getRepository(ElectionRound::class)->find(9)], $proposal->getElectionRounds()->toArray());
     }
 
     public function testProcurationRequestNotUniqueEmailBirthDate()
@@ -562,7 +560,7 @@ class ProcurationControllerTest extends WebTestCase
         $this->client->submit($crawler->selectButton('Je continue')->form([
             'g-recaptcha-response' => 'dummy',
             'app_procuration_request' => [
-                'electionRounds' => ['5'],
+                'electionRounds' => ['9'],
                 'reason' => ProcurationRequest::REASON_HEALTH,
                 'authorization' => true,
             ],
@@ -616,7 +614,7 @@ class ProcurationControllerTest extends WebTestCase
                 'voteCity' => '75018-75120',
                 'voteCityName' => '',
                 'voteOffice' => 'Mairie',
-                'electionRounds' => ['5'],
+                'electionRounds' => ['9'],
                 'conditions' => true,
                 'authorization' => true,
             ],
@@ -673,11 +671,7 @@ class ProcurationControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadElectionData::class,
-            LoadProcurationData::class,
-        ]);
+        $this->init();
 
         $this->procurationRequestRepostitory = $this->getProcurationRequestRepository();
         $this->procurationProxyRepostitory = $this->getProcurationProxyRepository();
@@ -701,7 +695,7 @@ class ProcurationControllerTest extends WebTestCase
 
         $crawler = $this->client->request(Request::METHOD_GET, "/procuration/choisir/$action");
 
-        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [3]]));
+        $this->client->submit($crawler->selectButton('Continuer')->form(['election_context[elections]' => [5]]));
 
         $path = ElectionContext::ACTION_REQUEST === $action ? 'je-demande/'.ProcurationRequest::STEP_URI_VOTE : 'je-propose';
 

--- a/tests/Controller/EnMarche/ProcurationManagerControllerTest.php
+++ b/tests/Controller/EnMarche/ProcurationManagerControllerTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadElectionData;
-use AppBundle\DataFixtures\ORM\LoadProcurationData;
 use AppBundle\Procuration\Filter\ProcurationProxyProposalFilters;
 use AppBundle\Procuration\Filter\ProcurationRequestFilters;
 use Symfony\Component\DomCrawler\Crawler;
@@ -245,7 +242,7 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
 
-        $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationRequestFilters::PARAMETER_ELECTION_ROUND => 5]));
+        $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationRequestFilters::PARAMETER_ELECTION_ROUND => 9]));
 
         $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
 
@@ -307,7 +304,7 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
 
-        $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationProxyProposalFilters::PARAMETER_ELECTION_ROUND => 6]));
+        $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationProxyProposalFilters::PARAMETER_ELECTION_ROUND => 10]));
 
         $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
 
@@ -320,11 +317,7 @@ class ProcurationManagerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadElectionData::class,
-            LoadProcurationData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ProgramControllerTest.php
+++ b/tests/Controller/EnMarche/ProgramControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadPageData;
-use AppBundle\DataFixtures\ORM\LoadProposalData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -60,10 +58,7 @@ class ProgramControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadPageData::class,
-            LoadProposalData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ReferentControllerTest.php
+++ b/tests/Controller/EnMarche/ReferentControllerTest.php
@@ -3,10 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\Address\GeoCoder;
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadNewsletterSubscriptionData;
-use AppBundle\DataFixtures\ORM\LoadReferentManagedUserData;
 use AppBundle\Entity\Event;
 use AppBundle\Entity\ReferentManagedUsersMessage;
 use AppBundle\Mailer\Message\EventRegistrationConfirmationMessage;
@@ -464,14 +460,11 @@ class ReferentControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadNewsletterSubscriptionData::class,
-            LoadReferentManagedUserData::class,
-        ]);
+        $this->init();
 
         $this->referentMessageRepository = $this->manager->getRepository(ReferentManagedUsersMessage::class);
+
+        $this->disableRepublicanSilence();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ReferentNominationControllerTest.php
+++ b/tests/Controller/EnMarche/ReferentNominationControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadReferentData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -53,9 +52,7 @@ class ReferentNominationControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadReferentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/ReportControllerTest.php
+++ b/tests/Controller/EnMarche/ReportControllerTest.php
@@ -29,12 +29,7 @@ class ReportControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadCitizenActionData::class,
-            LoadCitizenProjectData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/SearchControllerTest.php
+++ b/tests/Controller/EnMarche/SearchControllerTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadCitizenActionData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\Event;
 use AppBundle\Search\SearchParametersFilter;
@@ -116,11 +113,7 @@ class SearchControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadEventData::class,
-            LoadCitizenActionData::class,
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/Security/AdherentSecurityControllerTest.php
+++ b/tests/Controller/EnMarche/Security/AdherentSecurityControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche\Security;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadUserData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Mailer\Message\AdherentResetPasswordMessage;
 use AppBundle\Mailer\Message\AdherentResetPasswordConfirmationMessage;
@@ -224,10 +223,7 @@ class AdherentSecurityControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadUserData::class,
-            LoadAdherentData::class,
-        ]);
+        $this->init();
 
         $this->adherentRepository = $this->getAdherentRepository();
         $this->emailRepository = $this->getEmailRepository();

--- a/tests/Controller/EnMarche/Security/AdminSecurityControllerTest.php
+++ b/tests/Controller/EnMarche/Security/AdminSecurityControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche\Security;
 
-use AppBundle\DataFixtures\ORM\LoadAdminData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -102,9 +101,7 @@ class AdminSecurityControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/Security/JWTAuthenticationTest.php
+++ b/tests/Controller/EnMarche/Security/JWTAuthenticationTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche\Security;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -55,9 +54,7 @@ class JWTAuthenticationTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/SocialShareControllerTest.php
+++ b/tests/Controller/EnMarche/SocialShareControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadSocialShareData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -34,9 +33,7 @@ class SocialShareControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadSocialShareData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/SummaryControllerTest.php
+++ b/tests/Controller/EnMarche/SummaryControllerTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadMissionTypeData;
-use AppBundle\DataFixtures\ORM\LoadSkillData;
-use AppBundle\DataFixtures\ORM\LoadSummaryData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -83,12 +79,7 @@ class SummaryControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadMissionTypeData::class,
-            LoadSkillData::class,
-            LoadSummaryData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/SummaryManagerControllerTest.php
+++ b/tests/Controller/EnMarche/SummaryManagerControllerTest.php
@@ -3,9 +3,6 @@
 namespace Tests\AppBundle\Controller\EnMarche;
 
 use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadMissionTypeData;
-use AppBundle\DataFixtures\ORM\LoadSkillData;
-use AppBundle\DataFixtures\ORM\LoadSummaryData;
 use AppBundle\Entity\MemberSummary\Language;
 use AppBundle\Form\SummaryType;
 use AppBundle\Membership\ActivityPositions;
@@ -880,10 +877,15 @@ class SummaryManagerControllerTest extends WebTestCase
 
         $missions = $this->getSummarySection($crawler, self::SECTION_MISSIONS);
 
-        $this->assertCount(3, $missions->filter('.summary-wish'));
-        $this->assertSame('Me former à l\'action politique et citoyenne', trim($missions->filter('.summary-wish')->eq(0)->text()));
-        $this->assertSame('Faire remonter les opinions du terrain', trim($missions->filter('.summary-wish')->eq(1)->text()));
-        $this->assertSame('Expérimenter des projets concrets', trim($missions->filter('.summary-wish')->eq(2)->text()));
+        $this->assertCount(3, $wishes = $missions->filter('.summary-wish'));
+
+        for ($i = 0; $i < $wishes->count(); ++$i) {
+            $this->assertContains(trim($wishes->eq($i)->text()), [
+                'Me former à l\'action politique et citoyenne',
+                'Faire remonter les opinions du terrain',
+                'Expérimenter des projets concrets',
+            ]);
+        }
     }
 
     /**
@@ -1281,12 +1283,7 @@ class SummaryManagerControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadMissionTypeData::class,
-            LoadSkillData::class,
-            LoadSummaryData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/EnMarche/TonMacronControllerTest.php
+++ b/tests/Controller/EnMarche/TonMacronControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadTonMacronData;
 use AppBundle\Entity\Email;
 use AppBundle\Entity\TonMacronChoice;
 use AppBundle\Entity\TonMacronFriendInvitation;
@@ -187,9 +186,7 @@ class TonMacronControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadTonMacronData::class,
-        ]);
+        $this->init();
 
         $this->tonMacronChoiceRepository = $this->getTonMacronChoiceRepository();
         $this->tonMacronInvitationRepository = $this->getTonMacronInvitationRepository();

--- a/tests/Controller/EnMarche/UserControllerTest.php
+++ b/tests/Controller/EnMarche/UserControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\EnMarche;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\AdherentChangeEmailToken;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -72,9 +71,7 @@ class UserControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/Legislatives/HomeControllerTest.php
+++ b/tests/Controller/Legislatives/HomeControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Legislatives;
 
-use AppBundle\DataFixtures\ORM\LoadLegislativesData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -84,9 +83,7 @@ class HomeControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadLegislativesData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/Controller/Legislatives/MapsControllerTest.php
+++ b/tests/Controller/Legislatives/MapsControllerTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests\AppBundle\Controller\Legislatives;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadLegislativesData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -37,12 +33,7 @@ class MapsControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadLegislativesData::class,
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ], 'legislatives');
+        $this->init('legislatives');
     }
 
     protected function tearDown()

--- a/tests/Donation/TransactionSubscriberTest.php
+++ b/tests/Donation/TransactionSubscriberTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Donation;
 
-use AppBundle\DataFixtures\ORM\LoadDonationData;
 use AppBundle\Repository\DonationRepository;
 use AppBundle\Repository\TransactionRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -94,9 +93,7 @@ class TransactionSubscriberTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadDonationData::class,
-        ]);
+        $this->init();
 
         $this->donationRepository = $this->getDonationRepository();
         $this->transactionRepository = $this->getTransactionRepository();

--- a/tests/Redirection/Dynamic/RedirectionManagerTest.php
+++ b/tests/Redirection/Dynamic/RedirectionManagerTest.php
@@ -67,7 +67,6 @@ class RedirectionManagerTest extends WebTestCase
 
     protected function setUp()
     {
-        $this->loadFixtures([]);
         $this->getContainer()->get('app.cache.redirection')->clear();
     }
 

--- a/tests/Referent/ManagedEventsExporterTest.php
+++ b/tests/Referent/ManagedEventsExporterTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Referent;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
 use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Referent\ManagedEventsExporter;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -51,11 +49,7 @@ class ManagedEventsExporterTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
 
         $this->exporter = $this->container->get(ManagedEventsExporter::class);
     }

--- a/tests/Repository/AdherentRepositoryTest.php
+++ b/tests/Repository/AdherentRepositoryTest.php
@@ -3,11 +3,6 @@
 namespace Tests\AppBundle\Repository;
 
 use AppBundle\BoardMember\BoardMemberFilter;
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadBoardMemberRoleData;
-use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
-use AppBundle\DataFixtures\ORM\LoadReferentTagData;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\CitizenProject;
 use AppBundle\Entity\Committee;
@@ -264,15 +259,8 @@ class AdherentRepositoryTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadBoardMemberRoleData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-            LoadReferentTagData::class,
-        ]);
+        $this->init();
 
-        $this->container = $this->getContainer();
         $this->adherentRepository = $this->getAdherentRepository();
         $this->referentTagRepository = $this->getRepository(ReferentTag::class);
     }

--- a/tests/Repository/CommitteeMembershipRepositoryTest.php
+++ b/tests/Repository/CommitteeMembershipRepositoryTest.php
@@ -74,10 +74,6 @@ class CommitteeMembershipRepositoryTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->loadFixtures([
-            LoadAdherentData::class,
-        ]);
-
         $this->container = $this->getContainer();
         $this->repository = $this->getCommitteeMembershipRepository();
     }

--- a/tests/Repository/CommitteeRepositoryTest.php
+++ b/tests/Repository/CommitteeRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
 use AppBundle\Repository\CommitteeRepository;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -32,10 +31,6 @@ class CommitteeRepositoryTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadAdherentData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->repository = $this->getCommitteeRepository();

--- a/tests/Repository/EventRepositoryTest.php
+++ b/tests/Repository/EventRepositoryTest.php
@@ -2,10 +2,7 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadCitizenActionData;
 use AppBundle\DataFixtures\ORM\LoadEventCategoryData;
-use AppBundle\DataFixtures\ORM\LoadEventData;
 use AppBundle\Repository\EventRepository;
 use AppBundle\Search\SearchParametersFilter;
 use Symfony\Component\HttpFoundation\Request;
@@ -83,12 +80,7 @@ class EventRepositoryTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdherentData::class,
-            LoadCitizenActionData::class,
-            LoadEventCategoryData::class,
-            LoadEventData::class,
-        ]);
+        $this->init();
 
         $this->repository = $this->getEventRepository();
     }

--- a/tests/Repository/NewsletterSubscriptionRepositoryTest.php
+++ b/tests/Repository/NewsletterSubscriptionRepositoryTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadNewsletterSubscriptionData;
 use AppBundle\Repository\NewsletterSubscriptionRepository;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
@@ -33,11 +31,6 @@ class NewsletterSubscriptionRepositoryTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadNewsletterSubscriptionData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->repository = $this->getNewsletterSubscriptionRepository();

--- a/tests/Repository/Projection/ReferentManagedUserRepositoryTest.php
+++ b/tests/Repository/Projection/ReferentManagedUserRepositoryTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadNewsletterSubscriptionData;
-use AppBundle\DataFixtures\ORM\LoadReferentManagedUserData;
 use AppBundle\Entity\Projection\ReferentManagedUser;
 use AppBundle\Entity\ReferentTag;
 use AppBundle\Referent\ManagedUsersFilter;
@@ -115,12 +112,6 @@ class ReferentManagedUserRepositoryTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadAdherentData::class,
-            LoadNewsletterSubscriptionData::class,
-            LoadReferentManagedUserData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->referentManagedUserRepository = $this->getRepository(ReferentManagedUser::class);

--- a/tests/Repository/PurchasingPowerChoiceRepositoryTest.php
+++ b/tests/Repository/PurchasingPowerChoiceRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadPurchasingPowerData;
 use AppBundle\Entity\PurchasingPowerChoice;
 use AppBundle\Repository\PurchasingPowerChoiceRepository;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -41,10 +40,6 @@ class PurchasingPowerChoiceRepositoryTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadPurchasingPowerData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->repository = $this->getPurchasingPowerChoiceRepository();

--- a/tests/Repository/TonMacronChoiceRepositoryTest.php
+++ b/tests/Repository/TonMacronChoiceRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadTonMacronData;
 use AppBundle\Entity\TonMacronChoice;
 use AppBundle\Repository\TonMacronChoiceRepository;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -36,10 +35,6 @@ class TonMacronChoiceRepositoryTest extends WebTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        $this->loadFixtures([
-            LoadTonMacronData::class,
-        ]);
 
         $this->container = $this->getContainer();
         $this->repository = $this->getTonMacronChoiceRepository();

--- a/tests/Repository/TransactionRepositoryTest.php
+++ b/tests/Repository/TransactionRepositoryTest.php
@@ -2,9 +2,8 @@
 
 namespace Tests\AppBundle\Repository;
 
-use AppBundle\DataFixtures\ORM\LoadDonationData;
+use AppBundle\Entity\Transaction;
 use AppBundle\Repository\TransactionRepository;
-use Cake\Chronos\Chronos;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Tests\AppBundle\Controller\ControllerTestTrait;
 
@@ -19,6 +18,18 @@ class TransactionRepositoryTest extends WebTestCase
 
     public function testGetTotalAmountCurrentYearByEmail(): void
     {
+        // Update all transactions to start of this year
+        // so we can test by counting the amount of all transactions
+        $this
+            ->manager
+            ->createQueryBuilder()
+            ->update(Transaction::class, 't')
+            ->set('t.payboxDateTime', ':donatedAt')
+            ->setParameter('donatedAt', new \DateTime('first day of january this year'), 'datetime')
+            ->getQuery()
+            ->execute()
+        ;
+
         static::assertSame(25000, $this->transactionRepository->getTotalAmountInCentsByEmail('jacques.picard@en-marche.fr'));
     }
 
@@ -26,13 +37,8 @@ class TransactionRepositoryTest extends WebTestCase
     {
         parent::setUp();
 
-        Chronos::setTestNow(Chronos::createFromFormat('Y/m/d H:i:s', '2018/06/15 15:16:17'));
+        $this->init();
 
-        $this->loadFixtures([
-            LoadDonationData::class,
-        ]);
-
-        $this->container = $this->getContainer();
         $this->transactionRepository = $this->getTransactionRepository();
     }
 

--- a/tests/Security/InactiveAdminDisconnectionTest.php
+++ b/tests/Security/InactiveAdminDisconnectionTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\AppBundle\Security;
 
-use AppBundle\DataFixtures\ORM\LoadAdherentData;
-use AppBundle\DataFixtures\ORM\LoadAdminData;
-use AppBundle\DataFixtures\ORM\LoadHomeBlockData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;
@@ -55,11 +52,7 @@ class InactiveAdminDisconnectionTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->init([
-            LoadAdminData::class,
-            LoadAdherentData::class,
-            LoadHomeBlockData::class,
-        ]);
+        $this->init();
     }
 
     protected function tearDown()

--- a/tests/TestHelperTrait.php
+++ b/tests/TestHelperTrait.php
@@ -32,6 +32,7 @@ use AppBundle\Entity\ProcurationRequest;
 use AppBundle\Entity\PurchasingPowerChoice;
 use AppBundle\Entity\PurchasingPowerInvitation;
 use AppBundle\Entity\Reporting\CommitteeMembershipHistory;
+use AppBundle\Entity\RepublicanSilence;
 use AppBundle\Entity\SubscriptionType;
 use AppBundle\Entity\Summary;
 use AppBundle\Entity\TonMacronChoice;
@@ -397,5 +398,16 @@ trait TestHelperTrait
         }
 
         $property->setValue($container, null);
+    }
+
+    protected function disableRepublicanSilence(): void
+    {
+        $this
+            ->getRepository(RepublicanSilence::class)
+            ->createQueryBuilder('r')
+            ->delete()
+            ->getQuery()
+            ->execute()
+        ;
     }
 }

--- a/tests/Utils/GroupUtilsTest.php
+++ b/tests/Utils/GroupUtilsTest.php
@@ -118,10 +118,6 @@ class GroupUtilsTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->loadFixtures([
-            LoadAdherentData::class,
-        ]);
-
         $this->container = $this->getContainer();
     }
 


### PR DESCRIPTION
fyi: I introduced a new target :`make test-debug` that will run any test with `@group debug` in the testsuite.

Before:
- testsuite starts with an empty DB
- each scenario loads the specified fixtures (dropping the related table before, but not touching the others tables..)

Now:
- testsuite starts with all the fixtures loaded
- each scenario starts by starting a sql transaction
- each scenario ends by rollbacking the sql transaction

Note that:
- we do not need (and can't) load fixtures in phpunit tests anymore, since the DB is already loaded
- transactions cannot be open in phpunit tests because of how this bundle works.

Having all the fixtures loaded by default makes tests faster, but more importantly stronger: it showed up we had 2 bugs in our code, this PR also fixes them.


Maybe we should consider adopting the same strategy for our behat testsuite :)