### PR TITLE
Test new config circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
     phpunit:
         <<: *working_directory
         <<: *configure_base
-        parallelism: 3
         steps:
             - *attach_workspace
             - *generate_docker_hashes
@@ -109,23 +108,7 @@ jobs:
                 mkdir -p ./phpunit
                 make tfp-rabbitmq tfp-db
 
-                GROUP1='adherent,amp,article,boardMember,citizenProject'
-                GROUP2='api,admin,address,citizenAction,command,committee,committeeManager,coordinator,documents,donation,invitation,jeMarche,legislatives,map,membership,security,eventManager,procuration'
-
-                case $CIRCLE_NODE_INDEX in
-                    0)
-                        $DOCKER_COMPOSE exec app ./vendor/bin/phpunit --group $GROUP1 --log-junit ./phpunit/junit.xml
-                        ;;
-                    1)
-                        $DOCKER_COMPOSE exec app ./vendor/bin/phpunit --group $GROUP2 --log-junit ./phpunit/junit.xml
-                        ;;
-                    2)
-                        $DOCKER_COMPOSE exec app ./vendor/bin/phpunit --exclude-group $GROUP1,$GROUP2 --log-junit ./phpunit/junit.xml
-                        ;;
-                    *)
-                        echo "Too many parallelism instances configured\n"
-                        exit 1
-                esac
+                $DOCKER_COMPOSE exec app ./vendor/bin/phpunit --log-junit ./phpunit/junit.xml
             - store_test_results:
                 path: ./phpunit
 


### PR DESCRIPTION
Based on `testsuite` branch after phpunit refacto:
same time as before, but we only use 4* containers max now.

how can we reduce the `build` job?
