### PR TITLE
[ADI] Add validation on mandatory questions

### DIFF
--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -435,6 +435,7 @@
             <argument key="$mailer" type="service" id="app.mailer.transactional"/>
             <tag name="messenger.message_handler"/>
         </service>
+        <service id="AppBundle\Validator\MandatoryQuestionValidator" />
 
         <!-- ParamConverter -->
         <service id="AppBundle\ParamConverter\DoctrineQueryStringParamConverter">
@@ -547,7 +548,7 @@
             <argument type="service" id="logger" on-invalid="ignore"/>
             <argument type="collection"><argument key="status"/></argument>
             <call method="setIdeaRepository">
-                <argument type="service" id="AppBundle\Repository\IdeaRepository" />
+                <argument type="service" id="AppBundle\Repository\IdeasWorkshop\IdeaRepository" />
             </call>
         </service>
     </services>

--- a/src/Admin/AdherentAdmin.php
+++ b/src/Admin/AdherentAdmin.php
@@ -19,7 +19,7 @@ use AppBundle\Intl\UnitedNationsBundle;
 use AppBundle\Membership\Mandates;
 use AppBundle\Membership\UserEvent;
 use AppBundle\Membership\UserEvents;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Admin/IdeaDatagrid.php
+++ b/src/Admin/IdeaDatagrid.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Admin;
 
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
 class IdeaDatagrid extends DatagridDecorator

--- a/src/Admin/IdeasWorkshopIdeaAdmin.php
+++ b/src/Admin/IdeasWorkshopIdeaAdmin.php
@@ -4,7 +4,7 @@ namespace AppBundle\Admin;
 
 use AppBundle\Entity\IdeasWorkshop\AuthorCategoryEnum;
 use AppBundle\Entity\IdeasWorkshop\IdeaStatusEnum;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;

--- a/src/Command/NotifyIdeaAuthorAboutContributionsCommand.php
+++ b/src/Command/NotifyIdeaAuthorAboutContributionsCommand.php
@@ -5,7 +5,7 @@ namespace AppBundle\Command;
 use AppBundle\Entity\IdeasWorkshop\Idea;
 use AppBundle\Mailer\MailerService;
 use AppBundle\Mailer\Message\IdeaContributionsMessage;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/NotifyIdeaAuthorCommand.php
+++ b/src/Command/NotifyIdeaAuthorCommand.php
@@ -5,7 +5,7 @@ namespace AppBundle\Command;
 use AppBundle\Entity\IdeasWorkshop\Idea;
 use AppBundle\Mailer\MailerService;
 use AppBundle\Mailer\Message\IdeaFinalizeMessage;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Controller/Admin/AdminIdeaController.php
+++ b/src/Controller/Admin/AdminIdeaController.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Controller\Admin;
 
 use AppBundle\Entity\IdeasWorkshop\Idea;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;

--- a/src/DataFixtures/ORM/LoadIdeaQuestionData.php
+++ b/src/DataFixtures/ORM/LoadIdeaQuestionData.php
@@ -98,7 +98,7 @@ class LoadIdeaQuestionData extends AbstractFixture implements DependentFixtureIn
             'Masquée',
             'Elle n\'est pas affichée.',
             9,
-            false,
+            true,
             false
         );
         $guidelineImplementation->addQuestion($questionDisabled);

--- a/src/Entity/IdeasWorkshop/Idea.php
+++ b/src/Entity/IdeasWorkshop/Idea.php
@@ -18,6 +18,7 @@ use AppBundle\Filter\IdeaStatusFilter;
 use AppBundle\Filter\ContributorsCountFilter;
 use AppBundle\Report\ReportType;
 use AppBundle\Validator\CommitteeMember;
+use AppBundle\Validator\MandatoryQuestion;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -177,7 +178,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
  * })
  * @ApiFilter(OrderFilter::class, properties={"publishedAt", "votesCount", "commentsCount"})
  *
- * @ORM\Entity(repositoryClass="AppBundle\Repository\IdeaRepository")
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\IdeasWorkshop\IdeaRepository")
  *
  * @ORM\Table(
  *     name="ideas_workshop_idea",
@@ -314,8 +315,9 @@ class Idea implements AuthorInterface, ReportableInterface, EnabledInterface
     /**
      * @ORM\OneToMany(targetEntity="Answer", mappedBy="idea", cascade={"all"}, orphanRemoval=true)
      *
-     * @Assert\Count(min=1, minMessage="idea.answers.min_count", groups={"idea_publish"})
      * @Assert\Valid
+     *
+     * @MandatoryQuestion(groups={"idea_publish"})
      *
      * @SymfonySerializer\Groups({"idea_write", "idea_read", "with_answers"})
      */

--- a/src/Filter/IdeaStatusFilter.php
+++ b/src/Filter/IdeaStatusFilter.php
@@ -6,7 +6,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use AppBundle\Entity\IdeasWorkshop\Idea;
 use AppBundle\Entity\IdeasWorkshop\IdeaStatusEnum;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Doctrine\ORM\QueryBuilder;
 
 final class IdeaStatusFilter extends AbstractFilter

--- a/src/Normalizer/IdeaNormalizer.php
+++ b/src/Normalizer/IdeaNormalizer.php
@@ -4,7 +4,7 @@ namespace AppBundle\Normalizer;
 
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\IdeasWorkshop\Idea;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/src/Repository/IdeasWorkshop/IdeaRepository.php
+++ b/src/Repository/IdeasWorkshop/IdeaRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Repository;
+namespace AppBundle\Repository\IdeasWorkshop;
 
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\IdeasWorkshop\Answer;
@@ -10,6 +10,7 @@ use AppBundle\Entity\IdeasWorkshop\IdeaStatusEnum;
 use AppBundle\Entity\IdeasWorkshop\Thread;
 use AppBundle\Entity\IdeasWorkshop\ThreadComment;
 use AppBundle\Entity\IdeasWorkshop\VoteTypeEnum;
+use AppBundle\Repository\UuidEntityRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Repository/IdeasWorkshop/QuestionRepository.php
+++ b/src/Repository/IdeasWorkshop/QuestionRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AppBundle\Repository\IdeasWorkshop;
+
+use AppBundle\Entity\IdeasWorkshop\Question;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class QuestionRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Question::class);
+    }
+
+    public function findMandatoryQuestions()
+    {
+        return $this->createQueryBuilder('question')
+            ->innerJoin('question.guideline', 'guideline')
+            ->where('question.required = 1')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/src/Validator/MandatoryQuestion.php
+++ b/src/Validator/MandatoryQuestion.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AppBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "ANNOTATION"})
+ */
+class MandatoryQuestion extends Constraint
+{
+    public $message = 'idea.question.mandatory';
+}

--- a/src/Validator/MandatoryQuestionValidator.php
+++ b/src/Validator/MandatoryQuestionValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AppBundle\Validator;
+
+use AppBundle\Repository\IdeasWorkshop\QuestionRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class MandatoryQuestionValidator extends ConstraintValidator
+{
+    private $questionRepository;
+
+    public function __construct(QuestionRepository $questionRepository)
+    {
+        $this->questionRepository = $questionRepository;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof MandatoryQuestion) {
+            throw new UnexpectedTypeException($constraint, MandatoryQuestion::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        $mandatoryQuestions = [];
+
+        foreach ($value as $answer) {
+            if ($answer->getQuestion()->isRequired()) {
+                $mandatoryQuestions[] = $answer->getQuestion();
+            }
+        }
+
+        if (
+            array_diff(
+                $this->questionRepository->findMandatoryQuestions(),
+                $mandatoryQuestions
+            )
+        ) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->addViolation()
+            ;
+        }
+    }
+}

--- a/tests/Controller/Admin/AdminIdeaControllerTest.php
+++ b/tests/Controller/Admin/AdminIdeaControllerTest.php
@@ -4,7 +4,7 @@ namespace Tests\AppBundle\Controller\Admin;
 
 use AppBundle\DataFixtures\ORM\LoadIdeaData;
 use AppBundle\Entity\IdeasWorkshop\Idea;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\ControllerTestTrait;

--- a/tests/TestHelperTrait.php
+++ b/tests/TestHelperTrait.php
@@ -55,7 +55,7 @@ use AppBundle\Repository\EmailRepository;
 use AppBundle\Repository\EmailSubscriptionHistoryRepository;
 use AppBundle\Repository\EventRegistrationRepository;
 use AppBundle\Repository\EventRepository;
-use AppBundle\Repository\IdeaRepository;
+use AppBundle\Repository\IdeasWorkshop\IdeaRepository;
 use AppBundle\Repository\InvitationRepository;
 use AppBundle\Repository\JeMarcheReportRepository;
 use AppBundle\Repository\NewsletterInviteRepository;

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -299,5 +299,4 @@ idea.theme.min_count: |
   ]1,Inf[ Pour publier votre idée, vous devez préciser au minimum {{ limit }} thèmes.
 idea.category.not_blank: Pour publier votre idée, sa catégorie devrait être remplie.
 idea.author.not_null: L'idée doit avoir un autheur.
-idea.answers.min_count: Pour publier votre idée, vous devez apporter des réponses aux questions obligatoires.
-
+idea.question.mandatory: Pour publier votre idée, vous devez apporter des réponses aux questions obligatoires.


### PR DESCRIPTION
- Add new validator to test if all mandatory questions have been answered
- Move ADI repositories to IdeasWorkshop directory
- Add `QuestionRepository` to have the `enabled` doctrine filter in queries (for question and guideline)

Request from Profiler
```sql
SELECT i0_.id AS id_0, i0_.placeholder AS placeholder_1, i0_.position AS position_2, i0_.category AS category_3, i0_.name AS name_4, i0_.required AS required_5, i0_.enabled AS enabled_6, i0_.guideline_id AS guideline_id_7 FROM ideas_workshop_question i0_ LEFT JOIN ideas_workshop_guideline i1_ ON i0_.guideline_id = i1_.id AND (i1_.enabled = 1) WHERE (i0_.required = 1) AND (i0_.enabled = 1)
```