### PR TITLE
[ADI] Add extend action for ideas

### DIFF
--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -430,6 +430,7 @@
         <service id="AppBundle\IdeasWorkshop\ThemeManager" />
         <service id="AppBundle\Validator\CommitteeMemberValidator" />
         <service id="AppBundle\IdeasWorkshop\Listener\IdeaPublishListener" />
+        <service id="AppBundle\IdeasWorkshop\Listener\IdeaExtendListener" />
         <service id="AppBundle\IdeasWorkshop\Listener\ApproveThreadCommentListener" />
         <service id="AppBundle\IdeasWorkshop\Listener\EnableThreadListener" />
         <service id="AppBundle\IdeasWorkshop\Handler\SendMailForApprovedThreadCommentHandler">
@@ -437,6 +438,10 @@
             <tag name="messenger.message_handler"/>
         </service>
         <service id="AppBundle\IdeasWorkshop\Handler\SendMailForPublishedIdeaHandler">
+            <argument key="$mailer" type="service" id="app.mailer.transactional"/>
+            <tag name="messenger.message_handler"/>
+        </service>
+        <service id="AppBundle\IdeasWorkshop\Handler\SendMailForExtendedIdeaHandler">
             <argument key="$mailer" type="service" id="app.mailer.transactional"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/app/migrations/Version20190304170145.php
+++ b/app/migrations/Version20190304170145.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20190304170145 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE 
+          ideas_workshop_idea 
+        ADD 
+          extensions_count SMALLINT UNSIGNED NOT NULL, 
+        ADD 
+          last_extension_date DATE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ideas_workshop_idea DROP extensions_count, DROP last_extension_date');
+    }
+}

--- a/features/admin/ideas_workshop_ideas.feature
+++ b/features/admin/ideas_workshop_ideas.feature
@@ -11,5 +11,5 @@ Feature: Manage idea from admin panel
     When I am on "/admin/app/ideasworkshop-idea/list"
     Then the response status code should be 200
     And I should see 8 "tbody tr" elements
-    And I should see 10 "thead tr th" elements
+    And I should see 11 "thead tr th" elements
     And I should see 6 "ul.navbar-right li.sonata-actions ul.dropdown-menu li" elements

--- a/features/api/ideas_workshop_ideas.feature
+++ b/features/api/ideas_workshop_ideas.feature
@@ -473,6 +473,54 @@ Feature:
     }
     """
 
+  Scenario: As a logged-in user I can extend my idea which is in FINALIZE state only 2 times
+    Given I am logged as "jacques.picard@en-marche.fr"
+    And I add "Content-Type" header equal to "application/json"
+    When I send a "PUT" request to "/api/ideas-workshop/ideas/c14937d6-fd42-465c-8419-ced37f3e6194/extend"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON nodes should match:
+      | name   | Réduire le gaspillage |
+      | status | PENDING               |
+    When I send a "PUT" request to "/api/ideas-workshop/ideas/c14937d6-fd42-465c-8419-ced37f3e6194/extend"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON nodes should match:
+      | name   | Réduire le gaspillage |
+      | status | PENDING               |
+    When I send a "PUT" request to "/api/ideas-workshop/ideas/c14937d6-fd42-465c-8419-ced37f3e6194/extend"
+    Then the response status code should be 400
+
+  Scenario: As a logged-in user I can extend my idea which is in PENDING state
+    Given I am logged as "jacques.picard@en-marche.fr"
+    And I add "Content-Type" header equal to "application/json"
+    When I send a "PUT" request to "/api/ideas-workshop/ideas/e4ac3efc-b539-40ac-9417-b60df432bdc5/extend"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON nodes should match:
+      | name   | Faire la paix |
+      | status | PENDING       |
+    And I should have 1 email "IdeaExtendMessage" for "jacques.picard@en-marche.fr" with payload:
+    """
+    {
+      "FromEmail": "atelier-des-idees@en-marche.fr",
+      "FromName": "La République En Marche !",
+      "Subject": "Votre proposition a 10 jours supplémentaires pour des contributions !",
+      "MJ-TemplateID": "716215",
+      "MJ-TemplateLanguage": true,
+      "Recipients": [
+          {
+              "Email": "jacques.picard@en-marche.fr",
+              "Name": "Jacques Picard",
+              "Vars": {
+                  "first_name": "Jacques",
+                  "idea_link": "http://test.enmarche.code/atelier-des-idees/proposition/e4ac3efc-b539-40ac-9417-b60df432bdc5"
+              }
+          }
+      ]
+    }
+    """
+
   Scenario: As a logged-in user I can get full information about one idea
     Given I am logged as "benjyd@aol.com"
     And I add "Accept" header equal to "application/json"
@@ -765,7 +813,8 @@ Feature:
         },
         "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec maximus convallis dolor, id ultricies lorem lobortis et. Vivamus bibendum leo et ullamcorper dapibus.",
         "created_at": "@string@.isDateTime()",
-        "status": "PENDING"
+        "status": "PENDING",
+        "extendable": true
     }
     """
 

--- a/src/Admin/IdeasWorkshopIdeaAdmin.php
+++ b/src/Admin/IdeasWorkshopIdeaAdmin.php
@@ -201,6 +201,10 @@ class IdeasWorkshopIdeaAdmin extends AbstractAdmin
             ->add('needs', null, [
                 'label' => 'Besoins',
             ])
+            ->add('extensionsCountAndLastExtensionDate', null, [
+                'label' => 'Prolongation',
+                'template' => 'admin/ideas_workshop/idea/list_extensions.html.twig',
+            ])
             ->add('status', null, [
                 'label' => 'Statut',
                 'header_style' => 'width:125px;',
@@ -222,6 +226,9 @@ class IdeasWorkshopIdeaAdmin extends AbstractAdmin
                     ],
                     'finalize' => [
                         'template' => 'admin/ideas_workshop/idea/list_action_finalize.html.twig',
+                    ],
+                    'extend' => [
+                        'template' => 'admin/ideas_workshop/idea/list_action_extend.html.twig',
                     ],
                     'delete' => [],
                 ],

--- a/src/Controller/Admin/AdminIdeaController.php
+++ b/src/Controller/Admin/AdminIdeaController.php
@@ -106,4 +106,22 @@ class AdminIdeaController extends Controller
 
         return $this->redirectToRoute('admin_app_ideasworkshop_idea_list');
     }
+
+    /**
+     * @Route("/{id}/extend", name="app_admin_idea_extend", methods={"GET"})
+     */
+    public function extendAction(Idea $idea, ObjectManager $manager): Response
+    {
+        if ($idea->isDraft()) {
+            $this->addFlash('warning', 'La proposition est un brouillon');
+        } else {
+            $idea->publish();
+
+            $manager->flush();
+
+            $this->addFlash('success', 'La proposition a bien été prolongée');
+        }
+
+        return $this->redirectToRoute('admin_app_ideasworkshop_idea_list');
+    }
 }

--- a/src/Controller/Api/IdeasWorkshop/IdeaController.php
+++ b/src/Controller/Api/IdeasWorkshop/IdeaController.php
@@ -6,9 +6,9 @@ use AppBundle\Entity\IdeasWorkshop\Idea;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-class IdeaPublishController
+class IdeaController
 {
-    public function __invoke(Request $request): Idea
+    public function publish(Request $request): Idea
     {
         /** @var Idea $idea */
         $idea = $request->attributes->get('data');
@@ -18,6 +18,20 @@ class IdeaPublishController
         }
 
         $idea->publish();
+
+        return $idea;
+    }
+
+    public function extend(Request $request): Idea
+    {
+        /** @var Idea $idea */
+        $idea = $request->attributes->get('data');
+
+        if (!$idea->isExtendable()) {
+            throw new BadRequestHttpException(sprintf('You can extend only PENDING or FINALIZED idea and do it %d times', Idea::EXTEND_COUNT_LIMIT));
+        }
+
+        $idea->extend();
 
         return $idea;
     }

--- a/src/IdeasWorkshop/Command/SendMailForExtendedIdeaCommand.php
+++ b/src/IdeasWorkshop/Command/SendMailForExtendedIdeaCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AppBundle\IdeasWorkshop\Command;
+
+use AppBundle\Entity\IdeasWorkshop\Idea;
+
+class SendMailForExtendedIdeaCommand
+{
+    private $idea;
+
+    public function __construct(Idea $idea)
+    {
+        $this->idea = $idea;
+    }
+
+    public function getIdea(): Idea
+    {
+        return $this->idea;
+    }
+}

--- a/src/IdeasWorkshop/Handler/SendMailForExtendedIdeaHandler.php
+++ b/src/IdeasWorkshop/Handler/SendMailForExtendedIdeaHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AppBundle\IdeasWorkshop\Handler;
+
+use AppBundle\IdeasWorkshop\Command\SendMailForExtendedIdeaCommand;
+use AppBundle\Mailer\MailerService;
+use AppBundle\Mailer\Message\IdeaExtendMessage;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class SendMailForExtendedIdeaHandler implements MessageHandlerInterface
+{
+    private $mailer;
+    private $urlGenerator;
+
+    public function __construct(MailerService $mailer, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->mailer = $mailer;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function __invoke(SendMailForExtendedIdeaCommand $command): void
+    {
+        $idea = $command->getIdea();
+
+        $this->mailer->sendMessage(IdeaExtendMessage::create(
+            $idea->getAuthor(),
+            $this->urlGenerator->generate(
+                'react_app_ideas_workshop_proposition',
+                ['id' => $idea->getUuidAsString()],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+        ));
+    }
+}

--- a/src/IdeasWorkshop/Listener/IdeaExtendListener.php
+++ b/src/IdeasWorkshop/Listener/IdeaExtendListener.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AppBundle\IdeasWorkshop\Listener;
+
+use ApiPlatform\Core\EventListener\EventPriorities;
+use AppBundle\Entity\IdeasWorkshop\Idea;
+use AppBundle\IdeasWorkshop\Command\SendMailForExtendedIdeaCommand;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class IdeaExtendListener implements EventSubscriberInterface
+{
+    private $bus;
+
+    public function __construct(MessageBusInterface $bus)
+    {
+        $this->bus = $bus;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::VIEW => ['sendExtendMail', EventPriorities::POST_WRITE],
+        ];
+    }
+
+    public function sendExtendMail(GetResponseForControllerResultEvent $event): void
+    {
+        $object = $event->getControllerResult();
+
+        if ($object instanceof Idea && 'extend' === $event->getRequest()->attributes->get('_api_item_operation_name')) {
+            $this->bus->dispatch(new SendMailForExtendedIdeaCommand($object));
+        }
+    }
+}

--- a/src/Mailer/Message/IdeaExtendMessage.php
+++ b/src/Mailer/Message/IdeaExtendMessage.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Mailer\Message;
+
+use AppBundle\Entity\Adherent;
+use Ramsey\Uuid\Uuid;
+
+final class IdeaExtendMessage extends Message
+{
+    public static function create(Adherent $adherent, string $ideaLink): self
+    {
+        $message = new self(
+            Uuid::uuid4(),
+            '716215',
+            $adherent->getEmailAddress(),
+            $adherent->getFullName(),
+            'Votre proposition a 10 jours supplémentaires pour des contributions !',
+            [
+                'first_name' => $adherent->getFirstName(),
+                'idea_link' => $ideaLink,
+            ]
+        );
+
+        $message->setSenderEmail('atelier-des-idees@en-marche.fr');
+        $message->setSenderName('La République En Marche !');
+
+        return $message;
+    }
+}

--- a/templates/admin/ideas_workshop/idea/list_action_extend.html.twig
+++ b/templates/admin/ideas_workshop/idea/list_action_extend.html.twig
@@ -1,0 +1,7 @@
+{% if (object.isFinalized or object.isPending) and object.enabled %}
+    <a href="{{ path('app_admin_idea_extend', { id: object.id }) }}" class="btn btn-sm btn-default view_link"
+       title="Prolonger" rel="noopener noreferrer">
+        <i class="fa fa-calendar-plus-o" aria-hidden="true"></i>
+        Prolonger
+    </a>
+{% endif %}

--- a/templates/admin/ideas_workshop/idea/list_extensions.html.twig
+++ b/templates/admin/ideas_workshop/idea/list_extensions.html.twig
@@ -1,0 +1,9 @@
+{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+
+{% block field %}
+    {% if object.extensionsCount > 0 %}
+        {{ 'common.ordinal_number_feminine'|transchoice(object.extensionsCount) }} : {{ object.lastExtensionDate|date('d/m/Y') }}
+    {% else %}
+        -
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Add extend action as `PUT` on the `Idea` class
This action should extends to 10 days a published or finalized idea
Idea will be back as `published` if `finalized`
Admin must be able to do it as many times he wants (no date update, no incrementation) 
An email is send when user extend his idea, but none when admin do it 