### PR TITLE
PHP CS Fixer new rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,8 +21,9 @@ return PhpCsFixer\Config::create()
         'native_constant_invocation' => true,
         'native_function_invocation' => ['include' => ['@compiler_optimized']],
         'array_syntax' => ['syntax' => 'short'],
-        'PedroTroller/line_break_between_method_arguments' => [ 'max-args' => 20, 'max-length' => 120, 'automatic-argument-merge' => true ],
+        'PedroTroller/line_break_between_method_arguments' => [ 'max-args' => 20 ],
         'PedroTroller/line_break_between_statements' => true,
+        'PedroTroller/useless_comment' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -20,9 +20,13 @@ return PhpCsFixer\Config::create()
         'phpdoc_to_comment' => false,
         'native_constant_invocation' => true,
         'native_function_invocation' => ['include' => ['@compiler_optimized']],
-        'array_syntax' => ['syntax' => 'short']
+        'array_syntax' => ['syntax' => 'short'],
+        'PedroTroller/line_break_between_method_arguments' => [ 'max-args' => 20, 'max-length' => 120, 'automatic-argument-merge' => true ],
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)
     ->setCacheFile(__DIR__.'/var/.php_cs.cache')
+    ->registerCustomFixers(
+        new PedroTroller\CS\Fixer\Fixers()
+    )
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,6 +22,7 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => ['include' => ['@compiler_optimized']],
         'array_syntax' => ['syntax' => 'short'],
         'PedroTroller/line_break_between_method_arguments' => [ 'max-args' => 20, 'max-length' => 120, 'automatic-argument-merge' => true ],
+        'PedroTroller/line_break_between_statements' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)

--- a/app/migrations/Version20180108120001.php
+++ b/app/migrations/Version20180108120001.php
@@ -151,6 +151,7 @@ INTRODUCTION
         foreach ($this->requestsToRounds as $r) {
             $this->updateLegacyRoundField(self::REQUESTS_TABLE, $this->roundIds[$r['election_round_id']], $r[self::REQUEST_JOIN_FIELD]);
         }
+
         foreach ($this->proposalsToRounds as $r) {
             $this->updateLegacyRoundField(self::PROXIES_TABLE, $this->roundIds[$r['election_round_id']], $r[self::PROXY_JOIN_FIELD]);
         }

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         "fabpot/goutte": "^3.2",
         "friendsofphp/php-cs-fixer": "^2.10.0",
         "liip/functional-test-bundle": "^1.8",
+        "pedrotroller/php-cs-custom-fixer": "2.11.0",
         "phpunit/phpunit": "^6.2",
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce01bd1e0650c871e96c71ea8d331e1a",
+    "content-hash": "cfe721480e2c2f89f4cefc4466ac7518",
     "packages": [
         {
             "name": "a2lix/i18n-doctrine-bundle",
@@ -11434,6 +11434,46 @@
                 "xml conversion"
             ],
             "time": "2015-09-16T18:59:23+00:00"
+        },
+        {
+            "name": "pedrotroller/php-cs-custom-fixer",
+            "version": "v2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PedroTroller/PhpCSFixer-Custom-Fixers.git",
+                "reference": "c2551866a8a1511cde989f04d4862c095796e042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PedroTroller/PhpCSFixer-Custom-Fixers/zipball/c2551866a8a1511cde989f04d4862c095796e042",
+                "reference": "c2551866a8a1511cde989f04d4862c095796e042",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "~2.0",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "mustache/mustache": "^2.12",
+                "webmozart/assert": "^1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PedroTroller\\CS\\": "src/PedroTroller/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP-CS-FIXER : my custom fixers",
+            "time": "2018-07-05T12:14:38+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/src/AdherentMessage/AdherentMessageFactory.php
+++ b/src/AdherentMessage/AdherentMessageFactory.php
@@ -10,8 +10,11 @@ use Ramsey\Uuid\Uuid;
 
 class AdherentMessageFactory
 {
-    public static function create(Adherent $adherent, AdherentMessageDataObject $dataObject, string $type): AdherentMessageInterface
-    {
+    public static function create(
+        Adherent $adherent,
+        AdherentMessageDataObject $dataObject,
+        string $type
+    ): AdherentMessageInterface {
         switch ($type) {
             case AdherentMessageTypeEnum::DEPUTY:
                 $message = new DeputyAdherentMessage(Uuid::uuid4(), $adherent);

--- a/src/AdherentMessage/Filter/FilterFormFactory.php
+++ b/src/AdherentMessage/Filter/FilterFormFactory.php
@@ -27,6 +27,7 @@ class FilterFormFactory
                 if ($data instanceof ReferentUserFilter) {
                     return $this->formFactory->create(AdherentMessageReferentFilterType::class, $data);
                 }
+
                 if ($data instanceof AdherentZoneFilter) {
                     return $this->formFactory->create(AdherentMessageReferentZoneFilterType::class, $data);
                 }

--- a/src/Admin/AdherentAdmin.php
+++ b/src/Admin/AdherentAdmin.php
@@ -452,6 +452,7 @@ class AdherentAdmin extends AbstractAdmin
                         if (\in_array(AdherentRoleEnum::COMMITTEE_SUPERVISOR, $committeeRoles, true)) {
                             $privileges[] = CommitteeMembership::COMMITTEE_SUPERVISOR;
                         }
+
                         if (\in_array(AdherentRoleEnum::COMMITTEE_HOST, $committeeRoles, true)) {
                             $privileges[] = CommitteeMembership::COMMITTEE_HOST;
                         }

--- a/src/Admin/CommitteeAdmin.php
+++ b/src/Admin/CommitteeAdmin.php
@@ -43,8 +43,14 @@ class CommitteeAdmin extends AbstractAdmin
     private $adherentRepository;
     private $dispatcher;
 
-    public function __construct($code, $class, $baseControllerName, CommitteeManager $manager, ObjectManager $om, EventDispatcherInterface $dispatcher)
-    {
+    public function __construct(
+        $code,
+        $class,
+        $baseControllerName,
+        CommitteeManager $manager,
+        ObjectManager $om,
+        EventDispatcherInterface $dispatcher
+    ) {
         parent::__construct($code, $class, $baseControllerName);
 
         $this->manager = $manager;

--- a/src/Admin/MoocAdmin.php
+++ b/src/Admin/MoocAdmin.php
@@ -23,12 +23,8 @@ class MoocAdmin extends AbstractAdmin
      */
     private $moocManager;
 
-    public function __construct(
-        string $code,
-        string $class,
-        string $baseControllerName,
-        MoocManager $moocManager
-    ) {
+    public function __construct(string $code, string $class, string $baseControllerName, MoocManager $moocManager)
+    {
         parent::__construct($code, $class, $baseControllerName);
 
         $this->moocManager = $moocManager;

--- a/src/Admin/OrganizationalChartItemAdmin.php
+++ b/src/Admin/OrganizationalChartItemAdmin.php
@@ -14,8 +14,12 @@ class OrganizationalChartItemAdmin extends AbstractAdmin
     public $OCItems = [];
     private $organizationalChartItemRepository;
 
-    public function __construct(string $code, string $class, string $baseControllerName, OrganizationalChartItemRepository $organizationalChartItemRepository)
-    {
+    public function __construct(
+        string $code,
+        string $class,
+        string $baseControllerName,
+        OrganizationalChartItemRepository $organizationalChartItemRepository
+    ) {
         parent::__construct($code, $class, $baseControllerName);
 
         $this->organizationalChartItemRepository = $organizationalChartItemRepository;

--- a/src/Admin/ReferentAdmin.php
+++ b/src/Admin/ReferentAdmin.php
@@ -34,8 +34,13 @@ class ReferentAdmin extends AbstractAdmin
     private $dataTransformer;
     private $organizationalChartItemRepository;
 
-    public function __construct(string $code, string $class, string $baseControllerName, DataTransformerInterface $dataTransformer, OrganizationalChartItemRepository $organizationalChartItemRepository)
-    {
+    public function __construct(
+        string $code,
+        string $class,
+        string $baseControllerName,
+        DataTransformerInterface $dataTransformer,
+        OrganizationalChartItemRepository $organizationalChartItemRepository
+    ) {
         parent::__construct($code, $class, $baseControllerName);
 
         $this->dataTransformer = $dataTransformer;

--- a/src/Admin/ReportAdmin.php
+++ b/src/Admin/ReportAdmin.php
@@ -34,8 +34,12 @@ class ReportAdmin extends AbstractAdmin
     ];
     private $reportRepository;
 
-    public function __construct(string $code, string $class, string $baseControllerName, ReportRepository $reportRepository)
-    {
+    public function __construct(
+        string $code,
+        string $class,
+        string $baseControllerName,
+        ReportRepository $reportRepository
+    ) {
         parent::__construct($code, $class, $baseControllerName);
 
         $this->reportRepository = $reportRepository;

--- a/src/Api/LegislativeCandidateProvider.php
+++ b/src/Api/LegislativeCandidateProvider.php
@@ -13,8 +13,11 @@ class LegislativeCandidateProvider
     private $asset;
     private $urlGenerator;
 
-    public function __construct(LegislativeCandidateRepository $repository, AssetRuntime $asset, UrlGeneratorInterface $urlGenerator)
-    {
+    public function __construct(
+        LegislativeCandidateRepository $repository,
+        AssetRuntime $asset,
+        UrlGeneratorInterface $urlGenerator
+    ) {
         $this->repository = $repository;
         $this->asset = $asset;
         $this->urlGenerator = $urlGenerator;

--- a/src/CitizenAction/CitizenActionCommandHandler.php
+++ b/src/CitizenAction/CitizenActionCommandHandler.php
@@ -14,11 +14,8 @@ class CitizenActionCommandHandler
     private $factory;
     private $manager;
 
-    public function __construct(
-        EventDispatcherInterface $dispatcher,
-        EventFactory $factory,
-        ObjectManager $manager
-    ) {
+    public function __construct(EventDispatcherInterface $dispatcher, EventFactory $factory, ObjectManager $manager)
+    {
         $this->dispatcher = $dispatcher;
         $this->manager = $manager;
         $this->factory = $factory;

--- a/src/CitizenAction/CitizenActionManager.php
+++ b/src/CitizenAction/CitizenActionManager.php
@@ -37,8 +37,10 @@ class CitizenActionManager
         return $this->eventRegistrationRepository->findByEvent($citizenAction);
     }
 
-    public function populateRegistrationWithAdherentsInformations(EventRegistrationCollection $registrations, ArrayCollection $citizenProjectAdministrators): array
-    {
+    public function populateRegistrationWithAdherentsInformations(
+        EventRegistrationCollection $registrations,
+        ArrayCollection $citizenProjectAdministrators
+    ): array {
         $adherentsEmails = [];
         $eventsRegistrationHydrated = [];
         $administrators = [];

--- a/src/CitizenAction/CitizenActionMessageNotifier.php
+++ b/src/CitizenAction/CitizenActionMessageNotifier.php
@@ -77,8 +77,11 @@ class CitizenActionMessageNotifier implements EventSubscriberInterface
         ];
     }
 
-    private function createMessage(array $followers, CitizenAction $citizenAction, Adherent $host): CitizenActionNotificationMessage
-    {
+    private function createMessage(
+        array $followers,
+        CitizenAction $citizenAction,
+        Adherent $host
+    ): CitizenActionNotificationMessage {
         return CitizenActionNotificationMessage::create(
             $followers,
             $host,
@@ -89,8 +92,11 @@ class CitizenActionMessageNotifier implements EventSubscriberInterface
         );
     }
 
-    private function createCancelMessage(array $registered, CitizenAction $citizenAction, Adherent $host): CitizenActionCancellationMessage
-    {
+    private function createCancelMessage(
+        array $registered,
+        CitizenAction $citizenAction,
+        Adherent $host
+    ): CitizenActionCancellationMessage {
         return CitizenActionCancellationMessage::create(
             $registered,
             $host,

--- a/src/CitizenProject/CitizenProjectAuthority.php
+++ b/src/CitizenProject/CitizenProjectAuthority.php
@@ -48,6 +48,7 @@ class CitizenProjectAuthority
         if (!$membership = $this->getCitizenProjectMembership($adherent, $citizenProject)) {
             return;
         }
+
         if (CitizenProjectMembership::CITIZEN_PROJECT_ADMINISTRATOR === $privilege) {
             $membershipAdmins = $this->membershipRepository->findPrivilegedMemberships(
                 $citizenProject,

--- a/src/CitizenProject/CitizenProjectAuthority.php
+++ b/src/CitizenProject/CitizenProjectAuthority.php
@@ -15,8 +15,10 @@ class CitizenProjectAuthority
     private $membershipRepository;
     private $dispatcher;
 
-    public function __construct(CitizenProjectMembershipRepository $membershipRepository, EventDispatcherInterface $dispatcher)
-    {
+    public function __construct(
+        CitizenProjectMembershipRepository $membershipRepository,
+        EventDispatcherInterface $dispatcher
+    ) {
         $this->membershipRepository = $membershipRepository;
         $this->dispatcher = $dispatcher;
     }
@@ -61,8 +63,10 @@ class CitizenProjectAuthority
         $this->dispatcher->dispatch(UserEvents::USER_UPDATE_CITIZEN_PROJECT_PRIVILEGE, new UserEvent($adherent));
     }
 
-    private function getCitizenProjectMembership(Adherent $adherent, CitizenProject $citizenProject): ?CitizenProjectMembership
-    {
+    private function getCitizenProjectMembership(
+        Adherent $adherent,
+        CitizenProject $citizenProject
+    ): ?CitizenProjectMembership {
         // Optimization to prevent a SQL query if the current adherent already
         // has a loaded list of related citizen project memberships entities.
         if ($adherent->hasLoadedCitizenProjectMemberships()) {

--- a/src/CitizenProject/CitizenProjectCommand.php
+++ b/src/CitizenProject/CitizenProjectCommand.php
@@ -239,9 +239,6 @@ class CitizenProjectCommand
         return $this->citizenProject && $this->citizenProject->isApproved();
     }
 
-    /**
-     * @return null|UploadedFile
-     */
     public function getImage(): ?UploadedFile
     {
         return $this->image;

--- a/src/CitizenProject/CitizenProjectFactory.php
+++ b/src/CitizenProject/CitizenProjectFactory.php
@@ -13,10 +13,8 @@ class CitizenProjectFactory
     private $addressFactory;
     private $referentTagManager;
 
-    public function __construct(
-        ReferentTagManager $referentTagManager,
-        PostAddressFactory $addressFactory = null
-    ) {
+    public function __construct(ReferentTagManager $referentTagManager, PostAddressFactory $addressFactory = null)
+    {
         $this->referentTagManager = $referentTagManager;
         $this->addressFactory = $addressFactory ?: new PostAddressFactory();
     }

--- a/src/CitizenProject/CitizenProjectManagementAuthority.php
+++ b/src/CitizenProject/CitizenProjectManagementAuthority.php
@@ -12,10 +12,8 @@ class CitizenProjectManagementAuthority
     private $manager;
     private $eventDispatcher;
 
-    public function __construct(
-        CitizenProjectManager $manager,
-        EventDispatcherInterface $eventDispatcher
-    ) {
+    public function __construct(CitizenProjectManager $manager, EventDispatcherInterface $eventDispatcher)
+    {
         $this->manager = $manager;
         $this->eventDispatcher = $eventDispatcher;
     }

--- a/src/CitizenProject/CitizenProjectManager.php
+++ b/src/CitizenProject/CitizenProjectManager.php
@@ -40,8 +40,11 @@ class CitizenProjectManager
      */
     private $glide;
 
-    public function __construct(RegistryInterface $registry, Filesystem $storage, CitizenProjectAuthority $projectAuthority)
-    {
+    public function __construct(
+        RegistryInterface $registry,
+        Filesystem $storage,
+        CitizenProjectAuthority $projectAuthority
+    ) {
         $this->registry = $registry;
         $this->storage = $storage;
         $this->projectAuthority = $projectAuthority;
@@ -140,8 +143,10 @@ class CitizenProjectManager
         return $this->getCitizenProjectMembershipRepository()->findMembers($citizenProject);
     }
 
-    public function getCitizenProjectFollowers(CitizenProject $citizenProject, bool $withHosts = false): AdherentCollection
-    {
+    public function getCitizenProjectFollowers(
+        CitizenProject $citizenProject,
+        bool $withHosts = false
+    ): AdherentCollection {
         return $this
             ->getCitizenProjectMembershipRepository()
             ->findFollowers($citizenProject, $withHosts)
@@ -259,13 +264,20 @@ class CitizenProjectManager
         }
     }
 
-    public function findAdherentNearCitizenProjectOrAcceptAllNotification(CitizenProject $citizenProject, int $offset = 0, bool $excludeSupervisor = true, int $radius = CitizenProjectMessageNotifier::RADIUS_NOTIFICATION_NEAR_PROJECT_CITIZEN): Paginator
-    {
+    public function findAdherentNearCitizenProjectOrAcceptAllNotification(
+        CitizenProject $citizenProject,
+        int $offset = 0,
+        bool $excludeSupervisor = true,
+        int $radius = CitizenProjectMessageNotifier::RADIUS_NOTIFICATION_NEAR_PROJECT_CITIZEN
+    ): Paginator {
         return $this->getAdherentRepository()->findByNearCitizenProjectOrAcceptAllNotification($citizenProject, $offset, $excludeSupervisor, $radius);
     }
 
-    public function approveCommitteeSupport(Committee $committee, CitizenProject $citizenProject, bool $flush = true): void
-    {
+    public function approveCommitteeSupport(
+        Committee $committee,
+        CitizenProject $citizenProject,
+        bool $flush = true
+    ): void {
         if (!$citizenProject->isApproved()) {
             throw new CitizenProjectNotApprovedException($citizenProject);
         }
@@ -288,8 +300,11 @@ class CitizenProjectManager
         }
     }
 
-    public function deleteCommitteeSupport(Committee $committee, CitizenProject $citizenProject, bool $flush = true): void
-    {
+    public function deleteCommitteeSupport(
+        Committee $committee,
+        CitizenProject $citizenProject,
+        bool $flush = true
+    ): void {
         if (!$committeeSupport = $this->findCommitteeSupport($committee, $citizenProject)) {
             throw new \RuntimeException('No CommitteeSupport found for committee '.$committee->getName());
         }

--- a/src/CitizenProject/CitizenProjectMessageNotifier.php
+++ b/src/CitizenProject/CitizenProjectMessageNotifier.php
@@ -73,8 +73,11 @@ class CitizenProjectMessageNotifier implements EventSubscriberInterface
         ));
     }
 
-    public function sendAdherentNotificationCreation(Adherent $adherent, CitizenProject $citizenProject, Adherent $creator): void
-    {
+    public function sendAdherentNotificationCreation(
+        Adherent $adherent,
+        CitizenProject $citizenProject,
+        Adherent $creator
+    ): void {
         $this->mailer->sendMessage(CitizenProjectCreationNotificationMessage::create($adherent, $citizenProject, $creator));
     }
 

--- a/src/Command/DonationUpdateReferenceCommand.php
+++ b/src/Command/DonationUpdateReferenceCommand.php
@@ -19,10 +19,8 @@ class DonationUpdateReferenceCommand extends Command
     private $em;
     private $donationRequestUtils;
 
-    public function __construct(
-        EntityManagerInterface $em,
-        DonationRequestUtils $donationRequestUtils
-    ) {
+    public function __construct(EntityManagerInterface $em, DonationRequestUtils $donationRequestUtils)
+    {
         $this->em = $em;
         $this->donationRequestUtils = $donationRequestUtils;
 

--- a/src/Command/ImportBoardMemberCommand.php
+++ b/src/Command/ImportBoardMemberCommand.php
@@ -186,6 +186,7 @@ class ImportBoardMemberCommand extends ContainerAwareCommand
 
                 continue;
             }
+
             if ($adherent->isBoardMember()) {
                 continue;
             }

--- a/src/Command/ImportReferentNominationCommand.php
+++ b/src/Command/ImportReferentNominationCommand.php
@@ -182,6 +182,7 @@ class ImportReferentNominationCommand extends ContainerAwareCommand
                 if (false !== strpos($row['area_code'], ',')) {
                     $parisDistrictZip = explode(',', $row['area_code']);
                 }
+
                 foreach ($parisDistrictZip as $zipCode) {
                     $areas[$zipCode] = [
                           'name' => sprintf(

--- a/src/Command/LegislativesLoadDistrictZonesCommand.php
+++ b/src/Command/LegislativesLoadDistrictZonesCommand.php
@@ -108,8 +108,11 @@ class LegislativesLoadDistrictZonesCommand extends ContainerAwareCommand
         }
     }
 
-    private function createCandidate(LegislativeDistrictZone $district, string $areaNumber, array $data): LegislativeCandidate
-    {
+    private function createCandidate(
+        LegislativeDistrictZone $district,
+        string $areaNumber,
+        array $data
+    ): LegislativeCandidate {
         $slugifier = $this->getContainer()->get('sonata.core.slugify.cocur');
 
         $position = ((int) $district->getZoneNumber()) * 100 + ((int) $areaNumber);

--- a/src/Command/MailchimpSyncAllAdherentsCommand.php
+++ b/src/Command/MailchimpSyncAllAdherentsCommand.php
@@ -25,8 +25,11 @@ class MailchimpSyncAllAdherentsCommand extends Command
     /** @var SymfonyStyle */
     private $io;
 
-    public function __construct(AdherentRepository $adherentRepository, ObjectManager $entityManager, MessageBusInterface $bus)
-    {
+    public function __construct(
+        AdherentRepository $adherentRepository,
+        ObjectManager $entityManager,
+        MessageBusInterface $bus
+    ) {
         $this->adherentRepository = $adherentRepository;
         $this->entityManager = $entityManager;
         $this->bus = $bus;

--- a/src/Committee/CommitteeCommand.php
+++ b/src/Committee/CommitteeCommand.php
@@ -133,9 +133,6 @@ class CommitteeCommand
         return $this->address;
     }
 
-    /**
-     * @return null|UploadedFile
-     */
     public function getPhoto(): ?UploadedFile
     {
         return $this->photo;

--- a/src/Committee/CommitteeFactory.php
+++ b/src/Committee/CommitteeFactory.php
@@ -13,10 +13,8 @@ class CommitteeFactory
     private $addressFactory;
     private $referentTagManager;
 
-    public function __construct(
-        ReferentTagManager $referentTagManager,
-        PostAddressFactory $addressFactory = null
-    ) {
+    public function __construct(ReferentTagManager $referentTagManager, PostAddressFactory $addressFactory = null)
+    {
         $this->referentTagManager = $referentTagManager;
         $this->addressFactory = $addressFactory ?: new PostAddressFactory();
     }

--- a/src/Committee/CommitteeManager.php
+++ b/src/Committee/CommitteeManager.php
@@ -144,8 +144,10 @@ class CommitteeManager
         return $this->getAdherentRepository()->findReferentsByCommittee($committee);
     }
 
-    public function getCommitteeFollowers(Committee $committee, bool $withHosts = self::INCLUDE_HOSTS): AdherentCollection
-    {
+    public function getCommitteeFollowers(
+        Committee $committee,
+        bool $withHosts = self::INCLUDE_HOSTS
+    ): AdherentCollection {
         return $this->getMembershipRepository()->findFollowers($committee, $withHosts);
     }
 
@@ -416,8 +418,12 @@ class CommitteeManager
         return $this->getCommitteeRepository()->countApprovedCommittees();
     }
 
-    public function changePrivilege(Adherent $adherent, Committee $committee, string $privilege, bool $flush = true): void
-    {
+    public function changePrivilege(
+        Adherent $adherent,
+        Committee $committee,
+        string $privilege,
+        bool $flush = true
+    ): void {
         if (!$committeeMembership = $this->getCommitteeMembership($adherent, $committee)) {
             return;
         }
@@ -471,8 +477,10 @@ class CommitteeManager
         return $this->getCommitteeRepository()->findLastApprovedCommittees($count);
     }
 
-    private function createCommitteeMembershipHistory(CommitteeMembership $membership, CommitteeMembershipAction $action): CommitteeMembershipHistory
-    {
+    private function createCommitteeMembershipHistory(
+        CommitteeMembership $membership,
+        CommitteeMembershipAction $action
+    ): CommitteeMembershipHistory {
         return new CommitteeMembershipHistory($membership, $action);
     }
 

--- a/src/Committee/Feed/CommitteeFeedManager.php
+++ b/src/Committee/Feed/CommitteeFeedManager.php
@@ -17,8 +17,12 @@ class CommitteeFeedManager
     private $mailer;
     private $urlGenerator;
 
-    public function __construct(ObjectManager $manager, CommitteeManager $committeeManager, MailerService $mailer, UrlGeneratorInterface $urlGenerator)
-    {
+    public function __construct(
+        ObjectManager $manager,
+        CommitteeManager $committeeManager,
+        MailerService $mailer,
+        UrlGeneratorInterface $urlGenerator
+    ) {
         $this->manager = $manager;
         $this->committeeManager = $committeeManager;
         $this->mailer = $mailer;

--- a/src/Consumer/DeputyMessageDispatcherConsumer.php
+++ b/src/Consumer/DeputyMessageDispatcherConsumer.php
@@ -82,8 +82,12 @@ class DeputyMessageDispatcherConsumer extends AbstractConsumer
         }
     }
 
-    public function sendMessage(DeputyManagedUsersMessage $savedMessage, DeputyMessage $message, array $recipients, int $count)
-    {
+    public function sendMessage(
+        DeputyManagedUsersMessage $savedMessage,
+        DeputyMessage $message,
+        array $recipients,
+        int $count
+    ) {
         $delivered = $this->getMailer()->sendMessage(Message::create($message, $recipients));
 
         if ($delivered) {
@@ -116,8 +120,9 @@ class DeputyMessageDispatcherConsumer extends AbstractConsumer
         return $this->adherentRepository;
     }
 
-    public function setDeputyManagedUsersMessageRepository(DeputyManagedUsersMessageRepository $deputyManagedUsersMessageRepository): void
-    {
+    public function setDeputyManagedUsersMessageRepository(
+        DeputyManagedUsersMessageRepository $deputyManagedUsersMessageRepository
+    ): void {
         $this->deputyManagedUsersMessageRepository = $deputyManagedUsersMessageRepository;
     }
 

--- a/src/Consumer/ReferentMessageDispatcherConsumer.php
+++ b/src/Consumer/ReferentMessageDispatcherConsumer.php
@@ -82,8 +82,12 @@ class ReferentMessageDispatcherConsumer extends AbstractConsumer
         }
     }
 
-    public function sendMessage(ReferentManagedUsersMessage $savedMessage, ReferentMessage $message, array $recipients, int $count)
-    {
+    public function sendMessage(
+        ReferentManagedUsersMessage $savedMessage,
+        ReferentMessage $message,
+        array $recipients,
+        int $count
+    ) {
         $delivered = $this->getMailer()->sendMessage(Message::createFromModel($message, $recipients));
 
         if ($delivered) {

--- a/src/Contact/ContactMessage.php
+++ b/src/Contact/ContactMessage.php
@@ -37,8 +37,12 @@ class ContactMessage
         $this->content = $content;
     }
 
-    public static function createWithCaptcha(string $recaptcha, Adherent $from, Adherent $to, string $content = null): self
-    {
+    public static function createWithCaptcha(
+        string $recaptcha,
+        Adherent $from,
+        Adherent $to,
+        string $content = null
+    ): self {
         $message = new self($from, $to, $content);
         $message->recaptcha = $recaptcha;
 

--- a/src/Controller/Admin/AdminCitizenProjectController.php
+++ b/src/Controller/Admin/AdminCitizenProjectController.php
@@ -74,8 +74,13 @@ class AdminCitizenProjectController extends Controller
      * @Route("/{citizenProject}/members/{adherent}/set-privilege/{privilege}", name="app_admin_citizenproject_change_privilege")
      * @Method("GET")
      */
-    public function changePrivilegeAction(Request $request, CitizenProject $citizenProject, Adherent $adherent, string $privilege, CitizenProjectAuthority $authority): Response
-    {
+    public function changePrivilegeAction(
+        Request $request,
+        CitizenProject $citizenProject,
+        Adherent $adherent,
+        string $privilege,
+        CitizenProjectAuthority $authority
+    ): Response {
         if (!$this->isCsrfTokenValid(sprintf('citizen_project.change_privilege.%s', $adherent->getId()), $request->query->get('token'))) {
             throw new BadRequestHttpException('Invalid Csrf token provided.');
         }

--- a/src/Controller/Admin/AdminCommitteeController.php
+++ b/src/Controller/Admin/AdminCommitteeController.php
@@ -95,8 +95,12 @@ class AdminCommitteeController extends Controller
      * @Method("GET")
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
-    public function changePrivilegeAction(Request $request, Committee $committee, Adherent $adherent, string $privilege): Response
-    {
+    public function changePrivilegeAction(
+        Request $request,
+        Committee $committee,
+        Adherent $adherent,
+        string $privilege
+    ): Response {
         if (!$committee->isApproved()) {
             throw new BadRequestHttpException('Committee must be approved to change member privileges.');
         }

--- a/src/Controller/Admin/AdminProcurationController.php
+++ b/src/Controller/Admin/AdminProcurationController.php
@@ -39,8 +39,10 @@ class AdminProcurationController extends Controller
      * @Route("/export")
      * @Method("GET")
      */
-    public function exportMailsAction(ProcurationRequestRepository $repository, ProcurationRequestSerializer $serializer): Response
-    {
+    public function exportMailsAction(
+        ProcurationRequestRepository $repository,
+        ProcurationRequestSerializer $serializer
+    ): Response {
         return new Response($serializer->serialize($repository->findAllForExport()), 200, [
             'Content-Type' => 'text/csv',
             'Content-Disposition' => 'attachment; filename="procurations-matched.csv"',

--- a/src/Controller/Admin/AdminReferentExportsController.php
+++ b/src/Controller/Admin/AdminReferentExportsController.php
@@ -19,8 +19,11 @@ class AdminReferentExportsController extends Controller
      * @Route("/{id}/equipe-departementale", name="app_admin_referent_exports_departemental_team")
      * @Method("GET")
      */
-    public function exportDepartementaleTeam(ReferentPersonLinkExport $referentPersonLinkExport, ReferentPersonLinkRepository $referentPersonLinkRepository, Referent $referent): Response
-    {
+    public function exportDepartementaleTeam(
+        ReferentPersonLinkExport $referentPersonLinkExport,
+        ReferentPersonLinkRepository $referentPersonLinkRepository,
+        Referent $referent
+    ): Response {
         return $referentPersonLinkExport->createResponse(
             $referentPersonLinkExport->exportToXlsx(
                 $referentPersonLinkRepository->findByReferentOrdered($referent)

--- a/src/Controller/Admin/AdminThreadCommentController.php
+++ b/src/Controller/Admin/AdminThreadCommentController.php
@@ -28,8 +28,12 @@ class AdminThreadCommentController extends Controller
      *
      * @Route("/disable", methods={"GET"}, name="app_admin_thread_comment_disable")
      */
-    public function disableAction(Request $request, ThreadComment $comment, ObjectManager $manager, EventDispatcherInterface $dispatcher): Response
-    {
+    public function disableAction(
+        Request $request,
+        ThreadComment $comment,
+        ObjectManager $manager,
+        EventDispatcherInterface $dispatcher
+    ): Response {
         $comment->disable();
 
         $dispatcher->dispatch(Events::THREAD_COMMENT_DISABLE, new GenericEvent($comment));
@@ -46,8 +50,12 @@ class AdminThreadCommentController extends Controller
      *
      * @Route("/enable", methods={"GET"}, name="app_admin_thread_comment_enable")
      */
-    public function enableAction(Request $request, ThreadComment $comment, ObjectManager $manager, EventDispatcherInterface $dispatcher): Response
-    {
+    public function enableAction(
+        Request $request,
+        ThreadComment $comment,
+        ObjectManager $manager,
+        EventDispatcherInterface $dispatcher
+    ): Response {
         $comment->enable();
 
         $dispatcher->dispatch(Events::THREAD_COMMENT_ENABLE, new GenericEvent($comment));

--- a/src/Controller/Admin/AdminThreadController.php
+++ b/src/Controller/Admin/AdminThreadController.php
@@ -28,8 +28,12 @@ class AdminThreadController extends Controller
      *
      * @Route("/disable", methods={"GET"}, name="app_admin_thread_disable")
      */
-    public function disableAction(Request $request, Thread $thread, ObjectManager $manager, EventDispatcherInterface $dispatcher): Response
-    {
+    public function disableAction(
+        Request $request,
+        Thread $thread,
+        ObjectManager $manager,
+        EventDispatcherInterface $dispatcher
+    ): Response {
         $thread->disable();
 
         $dispatcher->dispatch(Events::THREAD_DISABLE, new GenericEvent($thread));
@@ -46,8 +50,12 @@ class AdminThreadController extends Controller
      *
      * @Route("/enable", methods={"GET"}, name="app_admin_thread_enable")
      */
-    public function enableAction(Request $request, Thread $thread, ObjectManager $manager, EventDispatcherInterface $dispatcher): Response
-    {
+    public function enableAction(
+        Request $request,
+        Thread $thread,
+        ObjectManager $manager,
+        EventDispatcherInterface $dispatcher
+    ): Response {
         $thread->enable();
 
         $dispatcher->dispatch(Events::THREAD_ENABLE, new GenericEvent($thread));

--- a/src/Controller/Admin/AdminTurnkeyProjectController.php
+++ b/src/Controller/Admin/AdminTurnkeyProjectController.php
@@ -22,8 +22,11 @@ class AdminTurnkeyProjectController extends Controller
      * @Method("GET")
      * @Security("has_role('ROLE_ADMIN_TURNKEY_PROJECTS')")
      */
-    public function removeImageAction(Request $request, TurnkeyProject $turnkeyProject, TurnkeyProjectManager $turnkeyProjectManager): Response
-    {
+    public function removeImageAction(
+        Request $request,
+        TurnkeyProject $turnkeyProject,
+        TurnkeyProjectManager $turnkeyProjectManager
+    ): Response {
         if (!$this->isCsrfTokenValid(sprintf('turnkey_project.remove_image.%s', $turnkeyProject->getId()), $request->query->get('token'))) {
             throw new BadRequestHttpException('Invalid Csrf token provided.');
         }

--- a/src/Controller/Api/ReferentController.php
+++ b/src/Controller/Api/ReferentController.php
@@ -37,8 +37,12 @@ class ReferentController extends Controller
      *
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      */
-    public function searchAutocompleteAction(Adherent $referent, Request $request, CommitteeRepository $committeeRepository, EventRepository $eventRepository): Response
-    {
+    public function searchAutocompleteAction(
+        Adherent $referent,
+        Request $request,
+        CommitteeRepository $committeeRepository,
+        EventRepository $eventRepository
+    ): Response {
         // parameter `type` should have a value different from an empty string, but parameter `value` can be an empty string
         if (!($type = $request->query->get('type')) || !$request->query->has('value')) {
             throw new BadRequestHttpException('The parameters "type" and "value" are required.');

--- a/src/Controller/Api/ReferentTagController.php
+++ b/src/Controller/Api/ReferentTagController.php
@@ -18,8 +18,11 @@ class ReferentTagController extends Controller
      * @Route("/referent-tags", name="api_referent_tag")
      * @Method("GET")
      */
-    public function getReferentTagsAction(Request $request, ReferentTagRepository $repository, SerializerInterface $serializer): Response
-    {
+    public function getReferentTagsAction(
+        Request $request,
+        ReferentTagRepository $repository,
+        SerializerInterface $serializer
+    ): Response {
         $limit = $request->query->getInt('_per_page', 10);
         $offset = ($request->query->getInt('_page', 1) - 1) * $limit;
 

--- a/src/Controller/Api/TurnkeyProjectController.php
+++ b/src/Controller/Api/TurnkeyProjectController.php
@@ -22,8 +22,10 @@ class TurnkeyProjectController extends Controller
      * @Route(name="api_approved_turnkey_projects")
      * @Method("GET")
      */
-    public function getApprovedTurnkeyProjectAction(TurnkeyProjectRepository $repository, Serializer $serializer): Response
-    {
+    public function getApprovedTurnkeyProjectAction(
+        TurnkeyProjectRepository $repository,
+        Serializer $serializer
+    ): Response {
         return new JsonResponse(
             $serializer->serialize($repository->findApprovedOrdered(), 'json', SerializationContext::create()->setGroups(['turnkey_project_list'])),
             JsonResponse::HTTP_OK,
@@ -48,8 +50,10 @@ class TurnkeyProjectController extends Controller
      * @Route("/pinned", name="api_pinned_turnkey_project")
      * @Method("GET")
      */
-    public function getPinnedTurnkeyProjectAction(TurnkeyProjectRepository $repository, Serializer $serializer): Response
-    {
+    public function getPinnedTurnkeyProjectAction(
+        TurnkeyProjectRepository $repository,
+        Serializer $serializer
+    ): Response {
         return new JsonResponse(
             $serializer->serialize($repository->findPinned(), 'json', SerializationContext::create()->setGroups(['turnkey_project_read'])),
             JsonResponse::HTTP_OK,

--- a/src/Controller/EnMarche/AdherentController.php
+++ b/src/Controller/EnMarche/AdherentController.php
@@ -54,8 +54,12 @@ class AdherentController extends Controller
      * @Route("/accueil", name="app_adherent_home")
      * @Method("GET")
      */
-    public function homeAction(Request $request, AdherentRepository $adherentRepository, SearchResultsProvidersManager $searchResultsProvidersManager, SearchParametersFilter $searchParametersFilter): Response
-    {
+    public function homeAction(
+        Request $request,
+        AdherentRepository $adherentRepository,
+        SearchResultsProvidersManager $searchResultsProvidersManager,
+        SearchParametersFilter $searchParametersFilter
+    ): Response {
         $user = $this->getUser();
         $searchParametersFilter->setCity(sprintf('%s, %s', $user->getCityName(), $user->getCountryName()));
         $searchParametersFilter->setMaxResults(3);
@@ -306,16 +310,19 @@ class AdherentController extends Controller
         ]);
     }
 
-    public function listMyCitizenProjectsAction(CitizenProjectRepository $citizenProjectRepository, string $noResultMessage = null): Response
-    {
+    public function listMyCitizenProjectsAction(
+        CitizenProjectRepository $citizenProjectRepository,
+        string $noResultMessage = null
+    ): Response {
         return $this->render('adherent/list_my_citizen_projects.html.twig', [
             'citizen_projects' => $citizenProjectRepository->findAllRegisteredCitizenProjectsForAdherent($this->getUser()),
             'no_result_message' => $noResultMessage,
         ]);
     }
 
-    public function listMyAdministratedCitizenProjectsAction(CitizenProjectRepository $citizenProjectRepository): Response
-    {
+    public function listMyAdministratedCitizenProjectsAction(
+        CitizenProjectRepository $citizenProjectRepository
+    ): Response {
         return $this->render('adherent/list_my_administrated_citizen_projects.html.twig', [
             'administrated_citizen_projects' => $citizenProjectRepository->findAllRegisteredCitizenProjectsForAdherent($this->getUser(), true),
         ]);

--- a/src/Controller/EnMarche/AdherentController.php
+++ b/src/Controller/EnMarche/AdherentController.php
@@ -74,6 +74,7 @@ class AdherentController extends Controller
             } catch (GeocodingException $exception) {
             }
         }
+
         if ($request->query->getBoolean('from_activation')) {
             $this->addFlash('info', 'adherent.activation.success');
         }
@@ -186,6 +187,7 @@ class AdherentController extends Controller
         } else {
             $command = CitizenProjectCreationCommand::createFromAdherent($user = $this->getUser());
         }
+
         if ($name = $request->query->get('name', false)) {
             $command->name = $name;
         }

--- a/src/Controller/EnMarche/ArticleController.php
+++ b/src/Controller/EnMarche/ArticleController.php
@@ -98,8 +98,11 @@ class ArticleController extends Controller
         return new Response($cachedRenderedFeed->get(), Response::HTTP_OK, ['Content-Type' => 'application/rss+xml']);
     }
 
-    private function isPaginationValid(int $articlesCount, int $requestedPageNumber, int $itemsPerPage = self::PER_PAGE): bool
-    {
+    private function isPaginationValid(
+        int $articlesCount,
+        int $requestedPageNumber,
+        int $itemsPerPage = self::PER_PAGE
+    ): bool {
         if (!$articlesCount) {
             return false;
         }

--- a/src/Controller/EnMarche/CitizenActionManagerController.php
+++ b/src/Controller/EnMarche/CitizenActionManagerController.php
@@ -91,8 +91,12 @@ class CitizenActionManagerController extends Controller
      * @Method("GET|POST")
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
-    public function editAction(Request $request, CitizenProject $project, CitizenAction $action, CitizenProjectManager $citizenProjectManager): Response
-    {
+    public function editAction(
+        Request $request,
+        CitizenProject $project,
+        CitizenAction $action,
+        CitizenProjectManager $citizenProjectManager
+    ): Response {
         $command = CitizenActionCommand::createFromCitizenAction($action);
         $form = $this->createForm(CitizenActionCommandType::class, $command)
             ->handleRequest($request)
@@ -182,8 +186,12 @@ class CitizenActionManagerController extends Controller
      * @Method("POST")
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
-    public function contactParticipantsAction(Request $request, CitizenAction $citizenAction, CitizenProject $project, CitizenActionManager $citizenActionManager): Response
-    {
+    public function contactParticipantsAction(
+        Request $request,
+        CitizenAction $citizenAction,
+        CitizenProject $project,
+        CitizenActionManager $citizenActionManager
+    ): Response {
         $registrations = $this->getRegistrations($request, $citizenAction, self::ACTION_CONTACT);
 
         if (0 == $registrations->count()) {
@@ -254,8 +262,11 @@ class CitizenActionManagerController extends Controller
         );
     }
 
-    private function getRegistrations(Request $request, CitizenAction $citizenAction, string $action): EventRegistrationCollection
-    {
+    private function getRegistrations(
+        Request $request,
+        CitizenAction $citizenAction,
+        string $action
+    ): EventRegistrationCollection {
         if (!\in_array($action, self::ACTIONS)) {
             throw new \InvalidArgumentException("Action '$action' is not allowed.");
         }

--- a/src/Controller/EnMarche/CitizenProjectController.php
+++ b/src/Controller/EnMarche/CitizenProjectController.php
@@ -41,8 +41,11 @@ class CitizenProjectController extends Controller
      * @Method("GET")
      * @Security("is_granted('SHOW_CITIZEN_PROJECT', citizenProject)")
      */
-    public function showAction(Request $request, CitizenProject $citizenProject, CitizenProjectManager $citizenProjectManager): Response
-    {
+    public function showAction(
+        Request $request,
+        CitizenProject $citizenProject,
+        CitizenProjectManager $citizenProjectManager
+    ): Response {
         if ($this->isGranted('IS_ANONYMOUS')
             && $authenticate = $this->get(AnonymousFollowerSession::class)->start($request)
         ) {
@@ -123,8 +126,11 @@ class CitizenProjectController extends Controller
      * @Security("is_granted('ROLE_SUPERVISOR')")
      * @Method("GET|POST")
      */
-    public function committeeSupportAction(Request $request, CitizenProject $citizenProject, CitizenProjectManager $citizenProjectManager): Response
-    {
+    public function committeeSupportAction(
+        Request $request,
+        CitizenProject $citizenProject,
+        CitizenProjectManager $citizenProjectManager
+    ): Response {
         $form = $this->createForm(FormType::class);
         $form->handleRequest($request);
 
@@ -172,8 +178,10 @@ class CitizenProjectController extends Controller
      * @Method("GET")
      * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
      */
-    public function listActorsAction(CitizenProject $citizenProject, CitizenProjectManager $citizenProjectManager): Response
-    {
+    public function listActorsAction(
+        CitizenProject $citizenProject,
+        CitizenProjectManager $citizenProjectManager
+    ): Response {
         return $this->render('citizen_project/list_actors.html.twig', [
             'citizen_project' => $citizenProject,
             'administrators' => $citizenProjectManager->getCitizenProjectAdministrators($citizenProject),

--- a/src/Controller/EnMarche/CitizenProjectManagerController.php
+++ b/src/Controller/EnMarche/CitizenProjectManagerController.php
@@ -29,8 +29,11 @@ class CitizenProjectManagerController extends Controller
      * @Route("/editer", name="app_citizen_project_manager_edit")
      * @Method("GET|POST")
      */
-    public function editAction(Request $request, CitizenProject $citizenProject, CitizenProjectManager $manager): Response
-    {
+    public function editAction(
+        Request $request,
+        CitizenProject $citizenProject,
+        CitizenProjectManager $manager
+    ): Response {
         $command = CitizenProjectUpdateCommand::createFromCitizenProject($citizenProject);
         $form = $this->createForm(CitizenProjectCommandType::class, $command, [
             'from_turnkey_project' => $citizenProject->isFromTurnkeyProject(),
@@ -59,8 +62,11 @@ class CitizenProjectManagerController extends Controller
      * @Route("/acteurs/contact", name="app_citizen_project_contact_actors")
      * @Method("POST")
      */
-    public function contactActorsAction(Request $request, CitizenProject $citizenProject, CitizenProjectManager $citizenProjectManager): Response
-    {
+    public function contactActorsAction(
+        Request $request,
+        CitizenProject $citizenProject,
+        CitizenProjectManager $citizenProjectManager
+    ): Response {
         if (!$this->isCsrfTokenValid('citizen_project.contact_actors', $request->request->get('token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF protection token to contact actors.');
         }

--- a/src/Controller/EnMarche/CommitteeController.php
+++ b/src/Controller/EnMarche/CommitteeController.php
@@ -81,8 +81,11 @@ class CommitteeController extends Controller
      * @Method("GET|POST")
      * @Security("is_granted('ADMIN_FEED_COMMITTEE', committeeFeedItem)")
      */
-    public function timelineEditAction(Request $request, Committee $committee, CommitteeFeedItem $committeeFeedItem): Response
-    {
+    public function timelineEditAction(
+        Request $request,
+        Committee $committee,
+        CommitteeFeedItem $committeeFeedItem
+    ): Response {
         $form = $this
             ->createForm(CommitteeFeedItemMessageType::class, $committeeFeedItem)
             ->handleRequest($request)
@@ -115,8 +118,11 @@ class CommitteeController extends Controller
      * @Method("DELETE")
      * @Security("is_granted('ADMIN_FEED_COMMITTEE', committeeFeedItem)")
      */
-    public function timelineDeleteAction(Request $request, Committee $committee, CommitteeFeedItem $committeeFeedItem): Response
-    {
+    public function timelineDeleteAction(
+        Request $request,
+        Committee $committee,
+        CommitteeFeedItem $committeeFeedItem
+    ): Response {
         $form = $this->createDeleteForm('', 'committee_feed_delete', $request);
 
         if (!$form->isSubmitted() || !$form->isValid()) {

--- a/src/Controller/EnMarche/DeputyController.php
+++ b/src/Controller/EnMarche/DeputyController.php
@@ -71,8 +71,10 @@ class DeputyController extends Controller
      * @Route("/comites", name="app_deputy_committees")
      * @Method("GET")
      */
-    public function listCommitteesAction(CommitteeRepository $committeeRepository, ManagedCommitteesExporter $committeesExporter): Response
-    {
+    public function listCommitteesAction(
+        CommitteeRepository $committeeRepository,
+        ManagedCommitteesExporter $committeesExporter
+    ): Response {
         $this->disableInProduction();
 
         return $this->render('deputy/committees_list.html.twig', [

--- a/src/Controller/EnMarche/EventController.php
+++ b/src/Controller/EnMarche/EventController.php
@@ -181,8 +181,11 @@ class EventController extends Controller
      * @Route("/desinscription", name="app_event_unregistration", condition="request.isXmlHttpRequest()")
      * @Method("GET|POST")
      */
-    public function unregistrationAction(Request $request, Event $event, EventRegistrationManager $eventRegistrationManager): JsonResponse
-    {
+    public function unregistrationAction(
+        Request $request,
+        Event $event,
+        EventRegistrationManager $eventRegistrationManager
+    ): JsonResponse {
         if (!$this->isCsrfTokenValid('event.unregistration', $token = $request->request->get('token'))) {
             throw new BadRequestHttpException('Invalid CSRF protection token to unregister from the citizen action.');
         }

--- a/src/Controller/EnMarche/MembershipController.php
+++ b/src/Controller/EnMarche/MembershipController.php
@@ -42,8 +42,12 @@ class MembershipController extends Controller
      * @Route("/inscription-utilisateur", name="app_membership_register")
      * @Method("GET|POST")
      */
-    public function registerAction(Request $request, GeoCoder $geoCoder, AuthorizationChecker $authorizationChecker, CallbackManager $callbackManager): Response
-    {
+    public function registerAction(
+        Request $request,
+        GeoCoder $geoCoder,
+        AuthorizationChecker $authorizationChecker,
+        CallbackManager $callbackManager
+    ): Response {
         if ($authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $callbackManager->redirectToClientIfValid();
         }

--- a/src/Controller/EnMarche/ProcurationController.php
+++ b/src/Controller/EnMarche/ProcurationController.php
@@ -44,8 +44,11 @@ class ProcurationController extends Controller
      * )
      * @Method("GET|POST")
      */
-    public function chooseElectionAction(Request $request, string $action, ProcurationSession $procurationSession): Response
-    {
+    public function chooseElectionAction(
+        Request $request,
+        string $action,
+        ProcurationSession $procurationSession
+    ): Response {
         $form = $this->createForm(ElectionContextType::class)
             ->handleRequest($request)
         ;
@@ -75,8 +78,12 @@ class ProcurationController extends Controller
      * )
      * @Method("GET|POST")
      */
-    public function requestAction(Request $request, ProcurationSession $procurationSession, ?string $step, string $_route): Response
-    {
+    public function requestAction(
+        Request $request,
+        ProcurationSession $procurationSession,
+        ?string $step,
+        string $_route
+    ): Response {
         if ('app_procuration_index_legacy' === $_route) {
             return $this->redirectToRoute('app_procuration_request', ['step' => ProcurationRequest::STEP_URI_VOTE], Response::HTTP_MOVED_PERMANENTLY);
         }

--- a/src/Controller/EnMarche/ProcurationManagerController.php
+++ b/src/Controller/EnMarche/ProcurationManagerController.php
@@ -167,8 +167,12 @@ class ProcurationManagerController extends Controller
      * )
      * @Method("GET")
      */
-    public function requestTransformAction(int $id, string $action, string $token, ProcurationManager $manager): Response
-    {
+    public function requestTransformAction(
+        int $id,
+        string $action,
+        string $token,
+        ProcurationManager $manager
+    ): Response {
         if (!$this->isCsrfTokenValid('request_action', $token)) {
             throw $this->createNotFoundException('Invalid token.');
         }
@@ -197,8 +201,11 @@ class ProcurationManagerController extends Controller
      * @Method("GET|POST")
      * @ParamConverter("proxy", class="AppBundle\Entity\ProcurationProxy", options={"id": "proxyId"})
      */
-    public function requestAssociateAction(Request $sfRequest, ProcurationRequest $request, ProcurationProxy $proxy): Response
-    {
+    public function requestAssociateAction(
+        Request $sfRequest,
+        ProcurationRequest $request,
+        ProcurationProxy $proxy
+    ): Response {
         $manager = $this->getDoctrine()->getManager();
 
         if (!$manager->getRepository(ProcurationRequest::class)->isManagedBy($this->getUser(), $request)) {
@@ -240,8 +247,11 @@ class ProcurationManagerController extends Controller
      * )
      * @Method("GET|POST")
      */
-    public function requestDessociateAction(Request $sfRequest, ProcurationRequest $request, ProcurationRequestRepository $repository): Response
-    {
+    public function requestDessociateAction(
+        Request $sfRequest,
+        ProcurationRequest $request,
+        ProcurationRequestRepository $repository
+    ): Response {
         if (!$request->hasFoundProxy()) {
             throw $this->createNotFoundException('This request has no proxy.');
         }
@@ -269,8 +279,11 @@ class ProcurationManagerController extends Controller
         ]);
     }
 
-    private function tryRedirectCatchingDeadLock(callable $try, string $retryRoute, array $retryParams): RedirectResponse
-    {
+    private function tryRedirectCatchingDeadLock(
+        callable $try,
+        string $retryRoute,
+        array $retryParams
+    ): RedirectResponse {
         try {
             return $try();
         } catch (DriverException $e) {

--- a/src/Controller/EnMarche/ReferentController.php
+++ b/src/Controller/EnMarche/ReferentController.php
@@ -164,8 +164,8 @@ class ReferentController extends Controller
      */
     public function institutionalEventsAction(
         InstitutionalEventRepository $institutionalEventRepository,
-        ManagedInstitutionalEventsExporter $exporter): Response
-    {
+        ManagedInstitutionalEventsExporter $exporter
+    ): Response {
         return $this->render('referent/institutional_events/list.html.twig', [
             'managedInstitutionalEventsJson' => $exporter->exportAsJson(
                 $institutionalEventRepository->findByOrganizer($this->getUser())
@@ -180,8 +180,8 @@ class ReferentController extends Controller
     public function institutionalEventsCreateAction(
         Request $request,
         InstitutionalEventCommandHandler $institutionalEventCommandHandler,
-        GeoCoder $geoCoder): Response
-    {
+        GeoCoder $geoCoder
+    ): Response {
         $command = new InstitutionalEventCommand($this->getUser());
         $command->setTimeZone($geoCoder->getTimezoneFromIp($request->getClientIp()));
 
@@ -269,8 +269,10 @@ class ReferentController extends Controller
      * @Route("/comites", name="app_referent_committees")
      * @Method("GET")
      */
-    public function committeesAction(CommitteeRepository $committeeRepository, ManagedCommitteesExporter $committeesExporter): Response
-    {
+    public function committeesAction(
+        CommitteeRepository $committeeRepository,
+        ManagedCommitteesExporter $committeesExporter
+    ): Response {
         return $this->render('referent/committees_list.html.twig', [
             'managedCommitteesJson' => $committeesExporter->exportAsJson($committeeRepository->findManagedBy($this->getUser())),
         ]);
@@ -427,8 +429,10 @@ class ReferentController extends Controller
      * @Route("/organigramme", name="app_referent_organizational_chart")
      * @Security("is_granted('IS_ROOT_REFERENT')")
      */
-    public function organizationalChartAction(OrganizationalChartItemRepository $organizationalChartItemRepository, ReferentRepository $referentRepository)
-    {
+    public function organizationalChartAction(
+        OrganizationalChartItemRepository $organizationalChartItemRepository,
+        ReferentRepository $referentRepository
+    ) {
         return $this->render('referent/organizational_chart.html.twig', [
             'organization_chart_items' => $organizationalChartItemRepository->getRootNodes(),
             'referent' => $referentRepository->findOneByEmailAndSelectPersonOrgaChart($this->getUser()->getEmailAddress()),
@@ -439,8 +443,12 @@ class ReferentController extends Controller
      * @Route("/organigramme/{id}", name="app_referent_referent_person_link_edit")
      * @Security("is_granted('IS_ROOT_REFERENT')")
      */
-    public function editReferentPersonLink(Request $request, ReferentPersonLinkRepository $referentPersonLinkRepository, ReferentRepository $referentRepository, PersonOrganizationalChartItem $personOrganizationalChartItem)
-    {
+    public function editReferentPersonLink(
+        Request $request,
+        ReferentPersonLinkRepository $referentPersonLinkRepository,
+        ReferentRepository $referentRepository,
+        PersonOrganizationalChartItem $personOrganizationalChartItem
+    ) {
         $form = $this->createForm(
             ReferentPersonLinkType::class,
             $referentPersonLinkRepository->findOrCreateByOrgaItemAndReferent(
@@ -484,10 +492,8 @@ class ReferentController extends Controller
      *
      * @Security("is_granted('IS_AUTHOR_OF', survey)")
      */
-    public function jecouteSurveyStatsDownloadAction(
-        Survey $survey,
-        StatisticsExporter $statisticsExporter
-    ): Response {
+    public function jecouteSurveyStatsDownloadAction(Survey $survey, StatisticsExporter $statisticsExporter): Response
+    {
         $dataFile = $statisticsExporter->export($survey);
 
         return new Response($dataFile['content'], Response::HTTP_OK, [

--- a/src/Controller/EnMarche/Security/SecurityController.php
+++ b/src/Controller/EnMarche/Security/SecurityController.php
@@ -109,8 +109,11 @@ class SecurityController extends Controller
      * @Entity("adherent", expr="repository.findOneByUuid(adherent_uuid)")
      * @Entity("resetPasswordToken", expr="repository.findByToken(reset_password_token)")
      */
-    public function resetPasswordAction(Request $request, Adherent $adherent, AdherentResetPasswordToken $resetPasswordToken)
-    {
+    public function resetPasswordAction(
+        Request $request,
+        Adherent $adherent,
+        AdherentResetPasswordToken $resetPasswordToken
+    ) {
         if ($this->getUser()) {
             return $this->redirectToRoute('app_search_events');
         }
@@ -143,8 +146,11 @@ class SecurityController extends Controller
      * @Route("/renvoyer-validation", name="adherent_resend_validation")
      * @Method("GET")
      */
-    public function resendValidationEmailAction(MembershipRequestHandler $membershipRequestHandler, AuthenticationUtils $authenticationUtils, AdherentRepository $adherentRepository): Response
-    {
+    public function resendValidationEmailAction(
+        MembershipRequestHandler $membershipRequestHandler,
+        AuthenticationUtils $authenticationUtils,
+        AdherentRepository $adherentRepository
+    ): Response {
         /** @var Adherent $adherent */
         $adherent = $adherentRepository->loadUserByUsername($authenticationUtils->getLastUsername());
 

--- a/src/Controller/EnMarche/UserController.php
+++ b/src/Controller/EnMarche/UserController.php
@@ -51,8 +51,10 @@ class UserController extends Controller
      * @Route("/mes-dons", name="app_user_profile_donation")
      * @Method("GET")
      */
-    public function profileDonationAction(DonationRepository $donationRepository, TransactionRepository $transactionRepository): Response
-    {
+    public function profileDonationAction(
+        DonationRepository $donationRepository,
+        TransactionRepository $transactionRepository
+    ): Response {
         $userEmail = $this->getUser()->getEmailAddress();
 
         return $this->render('user/my_donation.html.twig', [

--- a/src/Controller/OAuth/OAuthServerController.php
+++ b/src/Controller/OAuth/OAuthServerController.php
@@ -24,10 +24,8 @@ class OAuthServerController extends Controller
     private $authorizationServer;
     private $httpFoundationFactory;
 
-    public function __construct(
-        AuthorizationServer $authorizationServer,
-        HttpFoundationFactory $httpFoundationFactory
-    ) {
+    public function __construct(AuthorizationServer $authorizationServer, HttpFoundationFactory $httpFoundationFactory)
+    {
         $this->authorizationServer = $authorizationServer;
         $this->httpFoundationFactory = $httpFoundationFactory;
     }

--- a/src/DataFixtures/ORM/LoadCommitteeMembershipHistoryData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeMembershipHistoryData.php
@@ -38,18 +38,28 @@ class LoadCommitteeMembershipHistoryData extends Fixture
         $manager->flush();
     }
 
-    private function createJoinHistory(Adherent $adherent, Committee $committee, string $date): CommitteeMembershipHistory
-    {
+    private function createJoinHistory(
+        Adherent $adherent,
+        Committee $committee,
+        string $date
+    ): CommitteeMembershipHistory {
         return $this->createHistory(CommitteeMembershipAction::JOIN(), $adherent, $committee, $date);
     }
 
-    private function createLeaveHistory(Adherent $adherent, Committee $committee, string $date): CommitteeMembershipHistory
-    {
+    private function createLeaveHistory(
+        Adherent $adherent,
+        Committee $committee,
+        string $date
+    ): CommitteeMembershipHistory {
         return $this->createHistory(CommitteeMembershipAction::LEAVE(), $adherent, $committee, $date);
     }
 
-    private function createHistory(CommitteeMembershipAction $action, Adherent $adherent, Committee $committee, string $date): CommitteeMembershipHistory
-    {
+    private function createHistory(
+        CommitteeMembershipAction $action,
+        Adherent $adherent,
+        Committee $committee,
+        string $date
+    ): CommitteeMembershipHistory {
         $membership = $adherent->getMembershipFor($committee);
 
         return new CommitteeMembershipHistory($membership, $action, new Chronos($date));

--- a/src/DataFixtures/ORM/LoadDonationData.php
+++ b/src/DataFixtures/ORM/LoadDonationData.php
@@ -72,8 +72,11 @@ class LoadDonationData extends Fixture
         $manager->flush();
     }
 
-    public function createDonation(Adherent $adherent, float $amount = 50.0, int $duration = PayboxPaymentSubscription::NONE): Donation
-    {
+    public function createDonation(
+        Adherent $adherent,
+        float $amount = 50.0,
+        int $duration = PayboxPaymentSubscription::NONE
+    ): Donation {
         $donation = new Donation(
             $uuid = Uuid::uuid4(),
             $uuid->toString().'_'.$this->slugify->slugify($adherent->getFullName()),

--- a/src/DataFixtures/ORM/LoadEventData.php
+++ b/src/DataFixtures/ORM/LoadEventData.php
@@ -467,8 +467,13 @@ class LoadEventData implements FixtureInterface, ContainerAwareInterface, Depend
         $this->publishCommitteeEvent($event1);
     }
 
-    private function publishCommitteeMessage(Committee $committee, Adherent $author, string $subject, string $text, string $createdAt = 'now')
-    {
+    private function publishCommitteeMessage(
+        Committee $committee,
+        Adherent $author,
+        string $subject,
+        string $text,
+        string $createdAt = 'now'
+    ) {
         return $this->getCommitteeFeedManager()->createMessage(
             new CommitteeMessage($author, $committee, $subject, $text, true, $createdAt)
         );

--- a/src/DataFixtures/ORM/LoadOAuthTokenData.php
+++ b/src/DataFixtures/ORM/LoadOAuthTokenData.php
@@ -91,8 +91,12 @@ class LoadOAuthTokenData extends AbstractFixture implements DependentFixtureInte
         $manager->flush();
     }
 
-    private function createAuthorizationCode(string $identifier, string $userUuid, string $clientUuid, string $expiryDateTime): AuthorizationCode
-    {
+    private function createAuthorizationCode(
+        string $identifier,
+        string $userUuid,
+        string $clientUuid,
+        string $expiryDateTime
+    ): AuthorizationCode {
         return new AuthorizationCode(
             Uuid::uuid5(Uuid::NAMESPACE_OID, $identifier),
             $this->adherentRepository->findByUuid(Uuid::fromString($userUuid)),
@@ -103,8 +107,12 @@ class LoadOAuthTokenData extends AbstractFixture implements DependentFixtureInte
         );
     }
 
-    private function createAccessToken(string $identifier, string $userUuid, string $clientUuid, string $expiryDateTime): AccessToken
-    {
+    private function createAccessToken(
+        string $identifier,
+        string $userUuid,
+        string $clientUuid,
+        string $expiryDateTime
+    ): AccessToken {
         return new AccessToken(
             Uuid::uuid5(Uuid::NAMESPACE_OID, $identifier),
             $this->adherentRepository->findByUuid(Uuid::fromString($userUuid)),
@@ -114,8 +122,11 @@ class LoadOAuthTokenData extends AbstractFixture implements DependentFixtureInte
         );
     }
 
-    private function createRefreshToken(AccessToken $accessToken, string $identifier, string $expiryDateTime): RefreshToken
-    {
+    private function createRefreshToken(
+        AccessToken $accessToken,
+        string $identifier,
+        string $expiryDateTime
+    ): RefreshToken {
         return new RefreshToken(
             Uuid::uuid5(Uuid::NAMESPACE_OID, $identifier),
             $accessToken,

--- a/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
+++ b/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
@@ -129,15 +129,21 @@ class LoadOrganizationalChartItemData extends Fixture
         $manager->flush();
     }
 
-    private function createTree(ObjectManager $manager, array $mapping, AbstractOrganizationalChartItem $parent = null): void
-    {
+    private function createTree(
+        ObjectManager $manager,
+        array $mapping,
+        AbstractOrganizationalChartItem $parent = null
+    ): void {
         foreach ($mapping as $item) {
             $this->createItem($manager, $item, $parent);
         }
     }
 
-    private function createItem(ObjectManager $manager, array $item, AbstractOrganizationalChartItem $parent = null): AbstractOrganizationalChartItem
-    {
+    private function createItem(
+        ObjectManager $manager,
+        array $item,
+        AbstractOrganizationalChartItem $parent = null
+    ): AbstractOrganizationalChartItem {
         /** @var AbstractOrganizationalChartItem $orgaChartItem */
         $orgaChartItem = new $item['class']($item['label'], $parent);
         if (isset($item['referent_person_link'])) {

--- a/src/DataFixtures/ORM/LoadPurchasingPowerData.php
+++ b/src/DataFixtures/ORM/LoadPurchasingPowerData.php
@@ -184,28 +184,49 @@ class LoadPurchasingPowerData implements FixtureInterface
         return $choices;
     }
 
-    private static function createNoStepChoice(string $uuid, string $key, string $label, string $content): PurchasingPowerChoice
-    {
+    private static function createNoStepChoice(
+        string $uuid,
+        string $key,
+        string $label,
+        string $content
+    ): PurchasingPowerChoice {
         return static::createChoice($uuid, 0, $key, $label, $content);
     }
 
-    private static function createFirstStepChoice(string $uuid, string $key, string $label, string $content): PurchasingPowerChoice
-    {
+    private static function createFirstStepChoice(
+        string $uuid,
+        string $key,
+        string $label,
+        string $content
+    ): PurchasingPowerChoice {
         return static::createChoice($uuid, 1, $key, $label, $content);
     }
 
-    private static function createSecondStepChoice(string $uuid, string $key, string $label, string $content): PurchasingPowerChoice
-    {
+    private static function createSecondStepChoice(
+        string $uuid,
+        string $key,
+        string $label,
+        string $content
+    ): PurchasingPowerChoice {
         return static::createChoice($uuid, 2, $key, $label, $content);
     }
 
-    private static function createThirdStepChoice(string $uuid, string $key, string $label, string $content): PurchasingPowerChoice
-    {
+    private static function createThirdStepChoice(
+        string $uuid,
+        string $key,
+        string $label,
+        string $content
+    ): PurchasingPowerChoice {
         return static::createChoice($uuid, 3, $key, $label, $content);
     }
 
-    private static function createChoice(string $uuid, int $step, string $key, string $label, string $content): PurchasingPowerChoice
-    {
+    private static function createChoice(
+        string $uuid,
+        int $step,
+        string $key,
+        string $label,
+        string $content
+    ): PurchasingPowerChoice {
         return new PurchasingPowerChoice(Uuid::fromString($uuid), $step, $key, $label, $content);
     }
 }

--- a/src/DataFixtures/ORM/LoadTonMacronData.php
+++ b/src/DataFixtures/ORM/LoadTonMacronData.php
@@ -504,8 +504,13 @@ class LoadTonMacronData implements FixtureInterface
         return static::createChoice($uuid, 4, $key, $label, $content);
     }
 
-    private static function createChoice(string $uuid, int $step, string $key, string $label, string $content): TonMacronChoice
-    {
+    private static function createChoice(
+        string $uuid,
+        int $step,
+        string $key,
+        string $label,
+        string $content
+    ): TonMacronChoice {
         return new TonMacronChoice(Uuid::fromString($uuid), $step, $key, $label, $content);
     }
 }

--- a/src/Deputy/Subscriber/BindAdherentDistrictSubscriber.php
+++ b/src/Deputy/Subscriber/BindAdherentDistrictSubscriber.php
@@ -37,6 +37,7 @@ class BindAdherentDistrictSubscriber implements EventSubscriberInterface
                     if (!\in_array($adherent->getCountry(), $district->getCountries())) {
                         continue;
                     }
+
                     if (!$adherent->getReferentTags()->contains($district->getReferentTag())) {
                         $adherent->addReferentTag($district->getReferentTag());
                     }

--- a/src/Doctrine/ConsultationExtension.php
+++ b/src/Doctrine/ConsultationExtension.php
@@ -9,8 +9,13 @@ use Doctrine\ORM\QueryBuilder;
 
 class ConsultationExtension implements ContextAwareQueryCollectionExtensionInterface
 {
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
-    {
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $operationName = null,
+        array $context = []
+    ) {
         if (Consultation::class === $resourceClass) {
             $queryBuilder
                 ->andWhere(sprintf('%s.endedAt >= :now', $queryBuilder->getRootAliases()[0]))

--- a/src/Doctrine/Hydrators/EventHydrator.php
+++ b/src/Doctrine/Hydrators/EventHydrator.php
@@ -92,13 +92,23 @@ class EventHydrator extends AbstractHydrator
         $result[] = $event;
     }
 
-    private function createFrenchAddress(?string $street, ?string $cityCode, ?float $latitude, ?float $longitude): PostAddress
-    {
+    private function createFrenchAddress(
+        ?string $street,
+        ?string $cityCode,
+        ?float $latitude,
+        ?float $longitude
+    ): PostAddress {
         return PostAddress::createFrenchAddress($street ?? '', $cityCode ?? '-', $latitude, $longitude);
     }
 
-    private function createForeignAddress(?string $country, ?string $zipCode, ?string $cityName, ?string $street, ?float $latitude, ?float $longitude): PostAddress
-    {
+    private function createForeignAddress(
+        ?string $country,
+        ?string $zipCode,
+        ?string $cityName,
+        ?string $street,
+        ?float $latitude,
+        ?float $longitude
+    ): PostAddress {
         return PostAddress::createForeignAddress($country ?? '', $zipCode ?? '', $cityName, $street ?? '', $latitude, $longitude);
     }
 }

--- a/src/Doctrine/IdeaExtension.php
+++ b/src/Doctrine/IdeaExtension.php
@@ -9,8 +9,13 @@ use Doctrine\ORM\QueryBuilder;
 
 class IdeaExtension implements ContextAwareQueryCollectionExtensionInterface
 {
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
-    {
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $operationName = null,
+        array $context = []
+    ) {
         if (Idea::class === $resourceClass && !isset($context['filters']['author.uuid'])) {
             $queryBuilder
                 ->andWhere(sprintf('%s.publishedAt IS NOT NULL', $queryBuilder->getRootAliases()[0]))

--- a/src/Doctrine/MyIdeaContributionExtension.php
+++ b/src/Doctrine/MyIdeaContributionExtension.php
@@ -17,8 +17,12 @@ class MyIdeaContributionExtension implements QueryCollectionExtensionInterface
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
-    {
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $operationName = null
+    ) {
         if ('get_my_contributions' === $operationName && Idea::class === $resourceClass) {
             $alias = $queryBuilder->getRootAliases()[0];
 

--- a/src/Doctrine/VisibleStatusesExtension.php
+++ b/src/Doctrine/VisibleStatusesExtension.php
@@ -10,8 +10,13 @@ use Doctrine\ORM\QueryBuilder;
 
 class VisibleStatusesExtension implements ContextAwareQueryCollectionExtensionInterface
 {
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null, array $context = [])
-    {
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $operationName = null,
+        array $context = []
+    ) {
         if (Idea::class !== $resourceClass || !isset($context['filters']['author.uuid'])) {
             $this->modifyQuery($queryBuilder, $resourceClass);
         }

--- a/src/Donation/PayboxFormFactory.php
+++ b/src/Donation/PayboxFormFactory.php
@@ -14,8 +14,12 @@ class PayboxFormFactory
     private $router;
     private $donationRequestUtils;
 
-    public function __construct(string $environment, LexikRequestHandler $requestHandler, Router $router, DonationRequestUtils $donationRequestUtils)
-    {
+    public function __construct(
+        string $environment,
+        LexikRequestHandler $requestHandler,
+        Router $router,
+        DonationRequestUtils $donationRequestUtils
+    ) {
         $this->environment = $environment;
         $this->requestHandler = $requestHandler;
         $this->router = $router;

--- a/src/Entity/Adherent.php
+++ b/src/Entity/Adherent.php
@@ -840,8 +840,11 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
         return $this->joinCommittee($committee, CommitteeMembership::COMMITTEE_FOLLOWER, $subscriptionDate);
     }
 
-    private function joinCommittee(Committee $committee, string $privilege, string $subscriptionDate): CommitteeMembership
-    {
+    private function joinCommittee(
+        Committee $committee,
+        string $privilege,
+        string $subscriptionDate
+    ): CommitteeMembership {
         $committee->incrementMembersCount();
 
         return CommitteeMembership::createForAdherent($committee, $this, $privilege, $subscriptionDate);
@@ -850,21 +853,28 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
     /**
      * Joins a citizen project as a ADMINISTRATOR privileged person.
      */
-    public function administrateCitizenProject(CitizenProject $citizenProject, string $subscriptionDate = 'now'): CitizenProjectMembership
-    {
+    public function administrateCitizenProject(
+        CitizenProject $citizenProject,
+        string $subscriptionDate = 'now'
+    ): CitizenProjectMembership {
         return $this->joinCitizenProject($citizenProject, CitizenProjectMembership::CITIZEN_PROJECT_ADMINISTRATOR, $subscriptionDate);
     }
 
     /**
      * Joins a citizen project as a simple FOLLOWER privileged person.
      */
-    public function followCitizenProject(CitizenProject $citizenProject, string $subscriptionDate = 'now'): CitizenProjectMembership
-    {
+    public function followCitizenProject(
+        CitizenProject $citizenProject,
+        string $subscriptionDate = 'now'
+    ): CitizenProjectMembership {
         return $this->joinCitizenProject($citizenProject, CitizenProjectMembership::CITIZEN_PROJECT_FOLLOWER, $subscriptionDate);
     }
 
-    private function joinCitizenProject(CitizenProject $citizenProject, string $privilege, string $subscriptionDate): CitizenProjectMembership
-    {
+    private function joinCitizenProject(
+        CitizenProject $citizenProject,
+        string $privilege,
+        string $subscriptionDate
+    ): CitizenProjectMembership {
         $citizenProject->incrementMembersCount();
 
         $memberShip = CitizenProjectMembership::createForAdherent($citizenProject, $this, $privilege, $subscriptionDate);
@@ -1276,8 +1286,9 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
         return $this->citizenProjectCreationEmailSubscriptionRadius;
     }
 
-    public function setCitizenProjectCreationEmailSubscriptionRadius(int $citizenProjectCreationEmailSubscriptionRadius): void
-    {
+    public function setCitizenProjectCreationEmailSubscriptionRadius(
+        int $citizenProjectCreationEmailSubscriptionRadius
+    ): void {
         $this->citizenProjectCreationEmailSubscriptionRadius = $citizenProjectCreationEmailSubscriptionRadius;
     }
 

--- a/src/Entity/CitizenProjectCategorySkill.php
+++ b/src/Entity/CitizenProjectCategorySkill.php
@@ -49,8 +49,11 @@ class CitizenProjectCategorySkill
      */
     private $promotion;
 
-    public function __construct(?CitizenProjectCategory $category = null, ?CitizenProjectSkill $skill = null, ?bool $promotion = false)
-    {
+    public function __construct(
+        ?CitizenProjectCategory $category = null,
+        ?CitizenProjectSkill $skill = null,
+        ?bool $promotion = false
+    ) {
         $this->category = $category;
         $this->skill = $skill;
         $this->promotion = $promotion;

--- a/src/Entity/CitizenProjectMembership.php
+++ b/src/Entity/CitizenProjectMembership.php
@@ -91,8 +91,11 @@ class CitizenProjectMembership
         $this->joinedAt = new \DateTime($subscriptionDate);
     }
 
-    public static function createForAdministrator(CitizenProject $citizenProject, Adherent $administrator, string $subscriptionDate = 'now'): self
-    {
+    public static function createForAdministrator(
+        CitizenProject $citizenProject,
+        Adherent $administrator,
+        string $subscriptionDate = 'now'
+    ): self {
         return static::createForAdherent(
             $citizenProject,
             $administrator,

--- a/src/Entity/CoachingRequest.php
+++ b/src/Entity/CoachingRequest.php
@@ -37,8 +37,11 @@ class CoachingRequest
      */
     private $requiredMeans;
 
-    public function __construct(string $problemDescription = '', string $proposedSolution = '', string $requiredMeans = '')
-    {
+    public function __construct(
+        string $problemDescription = '',
+        string $proposedSolution = '',
+        string $requiredMeans = ''
+    ) {
         $this->problemDescription = $problemDescription;
         $this->proposedSolution = $proposedSolution;
         $this->requiredMeans = $requiredMeans;

--- a/src/Entity/Committee.php
+++ b/src/Entity/Committee.php
@@ -249,8 +249,15 @@ class Committee extends BaseGroup implements SynchronizedEntity, ReferentTaggabl
         $this->photoUploaded = $photoUploaded;
     }
 
-    public static function createSimple(UuidInterface $uuid, string $creatorUuid, string $name, string $description, PostAddress $address, PhoneNumber $phone, string $createdAt = 'now'): self
-    {
+    public static function createSimple(
+        UuidInterface $uuid,
+        string $creatorUuid,
+        string $name,
+        string $description,
+        PostAddress $address,
+        PhoneNumber $phone,
+        string $createdAt = 'now'
+    ): self {
         $committee = new self(
             $uuid,
             Uuid::fromString($creatorUuid),
@@ -264,8 +271,14 @@ class Committee extends BaseGroup implements SynchronizedEntity, ReferentTaggabl
         return $committee;
     }
 
-    public static function createForAdherent(Adherent $adherent, string $name, string $description, PostAddress $address, PhoneNumber $phone, string $createdAt = 'now'): self
-    {
+    public static function createForAdherent(
+        Adherent $adherent,
+        string $name,
+        string $description,
+        PostAddress $address,
+        PhoneNumber $phone,
+        string $createdAt = 'now'
+    ): self {
         $committee = new self(
             self::createUuid($name),
             clone $adherent->getUuid(),

--- a/src/Entity/CommitteeMembership.php
+++ b/src/Entity/CommitteeMembership.php
@@ -97,8 +97,11 @@ class CommitteeMembership
         return [self::COMMITTEE_SUPERVISOR, self::COMMITTEE_HOST];
     }
 
-    public static function createForSupervisor(Committee $committee, Adherent $supervisor, string $subscriptionDate = 'now'): self
-    {
+    public static function createForSupervisor(
+        Committee $committee,
+        Adherent $supervisor,
+        string $subscriptionDate = 'now'
+    ): self {
         return static::createForAdherent($committee, $supervisor, self::COMMITTEE_SUPERVISOR, $subscriptionDate);
     }
 

--- a/src/Entity/Email.php
+++ b/src/Entity/Email.php
@@ -56,8 +56,13 @@ class Email
      */
     private $deliveredAt;
 
-    public function __construct(UuidInterface $uuid, string $messageClass, string $sender, array $recipients, string $requestPayload)
-    {
+    public function __construct(
+        UuidInterface $uuid,
+        string $messageClass,
+        string $sender,
+        array $recipients,
+        string $requestPayload
+    ) {
         $this->uuid = $uuid;
         $this->messageClass = $messageClass;
         $this->sender = $sender;

--- a/src/Entity/EntitySpanTrait.php
+++ b/src/Entity/EntitySpanTrait.php
@@ -76,6 +76,7 @@ trait EntitySpanTrait
         if ($period->y) {
             $length .= $period->y.' an'.($period->y > 1 ? 's' : '');
         }
+
         if ($period->m) {
             $length .= ($period->y ? ' et ' : '').$period->m.' mois';
         }

--- a/src/Entity/InteractiveChoice.php
+++ b/src/Entity/InteractiveChoice.php
@@ -45,8 +45,13 @@ abstract class InteractiveChoice
      */
     protected $content;
 
-    public function __construct(UuidInterface $uuid = null, string $step = null, string $contentKey = null, string $label = null, string $content = null)
-    {
+    public function __construct(
+        UuidInterface $uuid = null,
+        string $step = null,
+        string $contentKey = null,
+        string $label = null,
+        string $content = null
+    ) {
         $this->uuid = $uuid ?: Uuid::uuid4();
         $this->step = $step;
         $this->contentKey = $contentKey;

--- a/src/Entity/InteractiveInvitation.php
+++ b/src/Entity/InteractiveInvitation.php
@@ -95,8 +95,13 @@ abstract class InteractiveInvitation
      */
     protected $choices;
 
-    public function __construct(UuidInterface $uuid, string $friendFirstName, string $friendAge, string $friendGender, string $createdAt = 'now')
-    {
+    public function __construct(
+        UuidInterface $uuid,
+        string $friendFirstName,
+        string $friendAge,
+        string $friendGender,
+        string $createdAt = 'now'
+    ) {
         $this->uuid = $uuid;
         $this->friendFirstName = $friendFirstName;
         $this->friendAge = $friendAge;

--- a/src/Entity/MemberSummary/Language.php
+++ b/src/Entity/MemberSummary/Language.php
@@ -126,6 +126,7 @@ class Language
                 if (!$language instanceof self) {
                     throw new \InvalidArgumentException(sprintf('Expected an instance of self "%s", got "%s."', __CLASS__, \is_object($language) ? \get_class($language) : \gettype($language)));
                 }
+
                 if ($level === $language->level) {
                     yield $language->id => $language;
                 }

--- a/src/Entity/OAuth/RefreshToken.php
+++ b/src/Entity/OAuth/RefreshToken.php
@@ -23,8 +23,12 @@ class RefreshToken extends AbstractToken
      */
     private $accessToken;
 
-    public function __construct(UuidInterface $uuid, AccessToken $accessToken, string $identifier, \DateTime $expiryDateTime)
-    {
+    public function __construct(
+        UuidInterface $uuid,
+        AccessToken $accessToken,
+        string $identifier,
+        \DateTime $expiryDateTime
+    ) {
         parent::__construct($uuid, $identifier, $expiryDateTime);
 
         $this->accessToken = $accessToken;

--- a/src/Entity/OAuth/UserAuthorization.php
+++ b/src/Entity/OAuth/UserAuthorization.php
@@ -52,12 +52,8 @@ class UserAuthorization
      *
      * @throws \LogicException $scopes does not contain the right object
      */
-    public function __construct(
-        ?UuidInterface $uuid,
-        Adherent $user,
-        Client $client,
-        array $scopes = []
-    ) {
+    public function __construct(?UuidInterface $uuid, Adherent $user, Client $client, array $scopes = [])
+    {
         $this->uuid = $uuid ?: Uuid::uuid4();
         $this->user = $user;
         $this->client = $client;

--- a/src/Entity/ReferentManagedArea.php
+++ b/src/Entity/ReferentManagedArea.php
@@ -48,11 +48,8 @@ class ReferentManagedArea
      */
     private $markerLongitude;
 
-    public function __construct(
-        array $tags = [],
-        string $latitude = null,
-        string $longitude = null
-    ) {
+    public function __construct(array $tags = [], string $latitude = null, string $longitude = null)
+    {
         $this->markerLatitude = $latitude;
         $this->markerLongitude = $longitude;
         $this->tags = new ArrayCollection($tags);

--- a/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
+++ b/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
@@ -148,8 +148,9 @@ class ReferentPersonLink
         return $this->personOrganizationalChartItem;
     }
 
-    public function setPersonOrganizationalChartItem(?PersonOrganizationalChartItem $personOrganizationalChartItem): void
-    {
+    public function setPersonOrganizationalChartItem(
+        ?PersonOrganizationalChartItem $personOrganizationalChartItem
+    ): void {
         $this->personOrganizationalChartItem = $personOrganizationalChartItem;
     }
 

--- a/src/Entity/Reporting/CommitteeMembershipHistory.php
+++ b/src/Entity/Reporting/CommitteeMembershipHistory.php
@@ -84,8 +84,11 @@ class CommitteeMembershipHistory
      */
     private $date;
 
-    public function __construct(CommitteeMembership $committeeMembership, CommitteeMembershipAction $action, \DateTimeImmutable $date = null)
-    {
+    public function __construct(
+        CommitteeMembership $committeeMembership,
+        CommitteeMembershipAction $action,
+        \DateTimeImmutable $date = null
+    ) {
         $this->adherentUuid = $committeeMembership->getAdherentUuid();
         $this->committee = $committeeMembership->getCommittee();
         $this->referentTags = $this->committee->getReferentTags();

--- a/src/Entity/Summary.php
+++ b/src/Entity/Summary.php
@@ -647,42 +647,55 @@ class Summary
         if ($this->member->getPosition()) {
             ++$complete;
         }
+
         if ($this->contributionWish) {
             ++$complete;
         }
+
         if (0 < \count($this->availabilities)) {
             ++$complete;
         }
+
         if (0 < \count($this->jobLocations)) {
             ++$complete;
         }
+
         if ($this->professionalSynopsis) {
             ++$complete;
         }
+
         if (0 < \count($this->missionTypeWishes)) {
             ++$complete;
         }
+
         if ($this->motivation) {
             ++$complete;
         }
+
         if (0 < $this->experiences->count()) {
             ++$complete;
         }
+
         if (0 < $this->skills->count()) {
             ++$complete;
         }
+
         if (0 < $this->languages->count()) {
             ++$complete;
         }
+
         if (0 < $this->trainings->count()) {
             ++$complete;
         }
+
         if (0 < \count($this->member->getInterests())) {
             ++$complete;
         }
+
         if ($this->contactEmail) {
             ++$complete;
         }
+
         if ($this->hasPictureUploaded()) {
             ++$complete;
         }

--- a/src/Entity/TonMacronChoice.php
+++ b/src/Entity/TonMacronChoice.php
@@ -70,8 +70,13 @@ class TonMacronChoice
         ];
     }
 
-    public function __construct(UuidInterface $uuid = null, string $step = null, string $contentKey = null, string $label = null, string $content = null)
-    {
+    public function __construct(
+        UuidInterface $uuid = null,
+        string $step = null,
+        string $contentKey = null,
+        string $label = null,
+        string $content = null
+    ) {
         $this->uuid = $uuid ?: Uuid::uuid4();
         $this->step = $step;
         $this->contentKey = $contentKey;

--- a/src/Entity/TonMacronFriendInvitation.php
+++ b/src/Entity/TonMacronFriendInvitation.php
@@ -91,8 +91,13 @@ class TonMacronFriendInvitation
      */
     private $choices;
 
-    public function __construct(UuidInterface $uuid, string $friendFirstName, string $friendAge, string $friendGender, string $createdAt = 'now')
-    {
+    public function __construct(
+        UuidInterface $uuid,
+        string $friendFirstName,
+        string $friendAge,
+        string $friendGender,
+        string $createdAt = 'now'
+    ) {
         $this->uuid = $uuid;
         $this->friendFirstName = $friendFirstName;
         $this->friendAge = $friendAge;

--- a/src/Entity/UserDocument.php
+++ b/src/Entity/UserDocument.php
@@ -94,13 +94,8 @@ class UserDocument
      */
     private $createdAt;
 
-    private function __construct(
-        string $type,
-        string $name,
-        string $extension,
-        int $size,
-        string $createdAt = 'now'
-    ) {
+    private function __construct(string $type, string $name, string $extension, int $size, string $createdAt = 'now')
+    {
         $this->uuid = Uuid::uuid4();
         $this->originalName = $name;
         $this->extension = $extension;
@@ -198,8 +193,14 @@ class UserDocument
         );
     }
 
-    public static function create(UuidInterface $uuid, string $type, string $mimeType, string $name, string $extension, int $size): self
-    {
+    public static function create(
+        UuidInterface $uuid,
+        string $type,
+        string $mimeType,
+        string $name,
+        string $extension,
+        int $size
+    ): self {
         $document = new self(
             $mimeType,
             $name,

--- a/src/Entity/WebHook/WebHook.php
+++ b/src/Entity/WebHook/WebHook.php
@@ -63,8 +63,12 @@ class WebHook
      */
     private $callbacks = [];
 
-    public function __construct(Client $client = null, Event $event = null, array $callbacks = [], Service $service = null)
-    {
+    public function __construct(
+        Client $client = null,
+        Event $event = null,
+        array $callbacks = [],
+        Service $service = null
+    ) {
         $this->uuid = Uuid::uuid4();
         $this->client = $client;
         $this->event = $event ? $event->getValue() : null;

--- a/src/Event/BaseEventCommand.php
+++ b/src/Event/BaseEventCommand.php
@@ -61,7 +61,8 @@ class BaseEventCommand
     private $address;
 
     protected function __construct(
-        ?Adherent $author, // Author may be null if unregistered when editing an event
+        ?Adherent $author,
+        // Author may be null if unregistered when editing an event
         UuidInterface $uuid = null,
         Address $address = null,
         \DateTimeInterface $beginAt = null,

--- a/src/Event/EventCommandHandler.php
+++ b/src/Event/EventCommandHandler.php
@@ -14,11 +14,8 @@ class EventCommandHandler
     private $factory;
     private $manager;
 
-    public function __construct(
-        EventDispatcherInterface $dispatcher,
-        EventFactory $factory,
-        ObjectManager $manager
-    ) {
+    public function __construct(EventDispatcherInterface $dispatcher, EventFactory $factory, ObjectManager $manager)
+    {
         $this->dispatcher = $dispatcher;
         $this->factory = $factory;
         $this->manager = $manager;

--- a/src/Event/EventFactory.php
+++ b/src/Event/EventFactory.php
@@ -18,10 +18,8 @@ class EventFactory
     private $addressFactory;
     private $referentTagManager;
 
-    public function __construct(
-        ReferentTagManager $referentTagManager,
-        PostAddressFactory $addressFactory = null
-    ) {
+    public function __construct(ReferentTagManager $referentTagManager, PostAddressFactory $addressFactory = null)
+    {
         $this->addressFactory = $addressFactory ?: new PostAddressFactory();
         $this->referentTagManager = $referentTagManager;
     }

--- a/src/Exception/AdherentTokenMismatchException.php
+++ b/src/Exception/AdherentTokenMismatchException.php
@@ -9,8 +9,11 @@ final class AdherentTokenMismatchException extends AdherentTokenException
 {
     private $unexpectedAdherentUuid;
 
-    public function __construct(AdherentExpirableTokenInterface $token, UuidInterface $unexpectedAdherentUuid, \Exception $previous = null)
-    {
+    public function __construct(
+        AdherentExpirableTokenInterface $token,
+        UuidInterface $unexpectedAdherentUuid,
+        \Exception $previous = null
+    ) {
         $message = sprintf(
             'The %s token %s cannot be used by the adherent %s but only by adherent %s.',
             $token->getType(),

--- a/src/Exception/CitizenProjectCommitteeSupportAlreadySupportException.php
+++ b/src/Exception/CitizenProjectCommitteeSupportAlreadySupportException.php
@@ -11,8 +11,13 @@ class CitizenProjectCommitteeSupportAlreadySupportException extends CitizenProje
     private $committee;
     private $citizenProject;
 
-    public function __construct(Committee $committee, CitizenProject $citizenProject, $message = '', $code = 0, Throwable $previous = null)
-    {
+    public function __construct(
+        Committee $committee,
+        CitizenProject $citizenProject,
+        $message = '',
+        $code = 0,
+        Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
         $this->committee = $committee;
         $this->citizenProject = $citizenProject;

--- a/src/Exception/CitizenProjectMembershipException.php
+++ b/src/Exception/CitizenProjectMembershipException.php
@@ -15,8 +15,10 @@ class CitizenProjectMembershipException extends \RuntimeException
         $this->membershipUuid = $membershipUuid;
     }
 
-    public static function createNotPromotableAdministratorPrivilegeException(UuidInterface $membershipUuid, \Exception $previous = null): self
-    {
+    public static function createNotPromotableAdministratorPrivilegeException(
+        UuidInterface $membershipUuid,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Citizen project membership "%s" cannot be promoted to the administrator privilege.', $membershipUuid),
@@ -24,8 +26,10 @@ class CitizenProjectMembershipException extends \RuntimeException
         );
     }
 
-    public static function createNotDemotableFollowerPrivilegeException(UuidInterface $membershipUuid, \Exception $previous = null): self
-    {
+    public static function createNotDemotableFollowerPrivilegeException(
+        UuidInterface $membershipUuid,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('CitizenProject membership "%s" cannot be demoted to the simple follower.', $membershipUuid),

--- a/src/Exception/CommitteeMembershipException.php
+++ b/src/Exception/CommitteeMembershipException.php
@@ -15,8 +15,10 @@ class CommitteeMembershipException extends \RuntimeException
         $this->membershipUuid = $membershipUuid;
     }
 
-    public static function createNotPromotableHostPrivilegeException(UuidInterface $membershipUuid, \Exception $previous = null): self
-    {
+    public static function createNotPromotableHostPrivilegeException(
+        UuidInterface $membershipUuid,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Committee membership "%s" cannot be promoted to the host privilege.', $membershipUuid),
@@ -24,8 +26,10 @@ class CommitteeMembershipException extends \RuntimeException
         );
     }
 
-    public static function createNotDemotableFollowerPrivilegeException(UuidInterface $membershipUuid, \Exception $previous = null): self
-    {
+    public static function createNotDemotableFollowerPrivilegeException(
+        UuidInterface $membershipUuid,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Committee membership "%s" cannot be demoted to the simple follower.', $membershipUuid),
@@ -33,8 +37,10 @@ class CommitteeMembershipException extends \RuntimeException
         );
     }
 
-    public static function createNotPromotableSupervisorPrivilegeException(UuidInterface $membershipUuid, \Exception $previous = null): self
-    {
+    public static function createNotPromotableSupervisorPrivilegeException(
+        UuidInterface $membershipUuid,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Committee membership "%s" cannot be promoted to the supervisor privilege. Only one supervisor per committee allowed.', $membershipUuid),
@@ -42,8 +48,11 @@ class CommitteeMembershipException extends \RuntimeException
         );
     }
 
-    public static function createNotPromotableSupervisorPrivilegeForSupervisorException(UuidInterface $membershipUuid, string $emailAddress, \Exception $previous = null): self
-    {
+    public static function createNotPromotableSupervisorPrivilegeForSupervisorException(
+        UuidInterface $membershipUuid,
+        string $emailAddress,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Committee membership "%s" cannot be promoted to the supervisor privilege. Adherent with email "%s" is supervisor of another committee.', $membershipUuid, $emailAddress),
@@ -51,8 +60,11 @@ class CommitteeMembershipException extends \RuntimeException
         );
     }
 
-    public static function createNotPromotableSupervisorPrivilegeForNotApprovedCommitteeException(UuidInterface $membershipUuid, string $committeeName, \Exception $previous = null): self
-    {
+    public static function createNotPromotableSupervisorPrivilegeForNotApprovedCommitteeException(
+        UuidInterface $membershipUuid,
+        string $committeeName,
+        \Exception $previous = null
+    ): self {
         return new self(
             $membershipUuid,
             sprintf('Committee membership "%s" cannot be promoted to the supervisor privilege. Please approve the committee "%s" before add a supervisor.', $membershipUuid, $committeeName),

--- a/src/Filter/ContributorsCountFilter.php
+++ b/src/Filter/ContributorsCountFilter.php
@@ -10,7 +10,8 @@ use Doctrine\ORM\QueryBuilder;
 final class ContributorsCountFilter extends AbstractFilter
 {
     protected function filterProperty(
-        string $property, $value,
+        string $property,
+        $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/src/Filter/IdeaStatusFilter.php
+++ b/src/Filter/IdeaStatusFilter.php
@@ -17,7 +17,8 @@ final class IdeaStatusFilter extends AbstractFilter
     private $ideaRepository;
 
     protected function filterProperty(
-        string $property, $value,
+        string $property,
+        $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/src/History/CommitteeMembershipHistoryHandler.php
+++ b/src/History/CommitteeMembershipHistoryHandler.php
@@ -16,8 +16,11 @@ class CommitteeMembershipHistoryHandler
         $this->historyRepository = $historyRepository;
     }
 
-    public function queryCountByMonth(Adherent $referent, int $months = 6, StatisticsParametersFilter $filter = null): array
-    {
+    public function queryCountByMonth(
+        Adherent $referent,
+        int $months = 6,
+        StatisticsParametersFilter $filter = null
+    ): array {
         foreach (range(0, $months - 1) as $monthInterval) {
             $until = $monthInterval
                         ? (new Chronos("last day of -$monthInterval month"))->setTime(23, 59, 59, 999)

--- a/src/Interactive/PurchasingPowerMessageBodyBuilder.php
+++ b/src/Interactive/PurchasingPowerMessageBodyBuilder.php
@@ -9,10 +9,8 @@ class PurchasingPowerMessageBodyBuilder
     private $twig;
     private $repository;
 
-    public function __construct(
-        \Twig_Environment $twig,
-        PurchasingPowerChoiceRepository $repository
-    ) {
+    public function __construct(\Twig_Environment $twig, PurchasingPowerChoiceRepository $repository)
+    {
         $this->twig = $twig;
         $this->repository = $repository;
     }

--- a/src/Interactive/PurchasingPowerProcessor.php
+++ b/src/Interactive/PurchasingPowerProcessor.php
@@ -167,9 +167,11 @@ final class PurchasingPowerProcessor
         if ($this->friendPosition) {
             $collection->add($this->friendPosition);
         }
+
         foreach ($this->friendCases as $interest) {
             $collection->add($interest);
         }
+
         foreach ($this->friendAppreciations as $reason) {
             $collection->add($reason);
         }

--- a/src/Legislative/LegislativeCampaignContactMessageHandler.php
+++ b/src/Legislative/LegislativeCampaignContactMessageHandler.php
@@ -11,8 +11,11 @@ class LegislativeCampaignContactMessageHandler
     private $financialHotlineEmailAddress;
     private $standardHotlineEmailAddress;
 
-    public function __construct(MailerService $mailer, string $financialHotlineEmailAddress, string $standardHotlineEmailAddress)
-    {
+    public function __construct(
+        MailerService $mailer,
+        string $financialHotlineEmailAddress,
+        string $standardHotlineEmailAddress
+    ) {
         $this->mailer = $mailer;
         $this->financialHotlineEmailAddress = $financialHotlineEmailAddress;
         $this->standardHotlineEmailAddress = $standardHotlineEmailAddress;

--- a/src/Mailer/EmailTemplate.php
+++ b/src/Mailer/EmailTemplate.php
@@ -40,8 +40,11 @@ abstract class EmailTemplate implements \JsonSerializable
         $this->recipients = [];
     }
 
-    public static function createWithMessage(Message $message, string $defaultSenderEmail, string $defaultSenderName = null): self
-    {
+    public static function createWithMessage(
+        Message $message,
+        string $defaultSenderEmail,
+        string $defaultSenderName = null
+    ): self {
         $senderEmail = $message->getSenderEmail() ?: $defaultSenderEmail;
         $senderName = $message->getSenderName() ?: $defaultSenderName;
 

--- a/src/Mailer/Event/MailerEvent.php
+++ b/src/Mailer/Event/MailerEvent.php
@@ -13,11 +13,8 @@ class MailerEvent extends Event
     private $email;
     private $exception;
 
-    public function __construct(
-        Message $message,
-        EmailTemplate $email,
-        MailerException $exception = null
-    ) {
+    public function __construct(Message $message, EmailTemplate $email, MailerException $exception = null)
+    {
         $this->message = $message;
         $this->email = $email;
         $this->exception = $exception;

--- a/src/Mailer/Message/AdherentAccountConfirmationMessage.php
+++ b/src/Mailer/Message/AdherentAccountConfirmationMessage.php
@@ -7,8 +7,11 @@ use Ramsey\Uuid\Uuid;
 
 final class AdherentAccountConfirmationMessage extends Message
 {
-    public static function createFromAdherent(Adherent $adherent, int $adherentsCount = 0, int $committeesCount = 0): self
-    {
+    public static function createFromAdherent(
+        Adherent $adherent,
+        int $adherentsCount = 0,
+        int $committeesCount = 0
+    ): self {
         return new self(
             Uuid::uuid4(),
             '54673',

--- a/src/Mailer/Message/CitizenActionRegistrationConfirmationMessage.php
+++ b/src/Mailer/Message/CitizenActionRegistrationConfirmationMessage.php
@@ -27,11 +27,8 @@ final class CitizenActionRegistrationConfirmationMessage extends Message
         );
     }
 
-    private static function getTemplateVars(
-        string $eventName,
-        string $organizerName,
-        string $calendarEventUrl
-    ): array {
+    private static function getTemplateVars(string $eventName, string $organizerName, string $calendarEventUrl): array
+    {
         return [
             'citizen_action_name' => self::escape($eventName),
             'citizen_action_organiser' => self::escape($organizerName),

--- a/src/Mailer/Message/CitizenProjectCreationConfirmationMessage.php
+++ b/src/Mailer/Message/CitizenProjectCreationConfirmationMessage.php
@@ -8,8 +8,11 @@ use Ramsey\Uuid\Uuid;
 
 class CitizenProjectCreationConfirmationMessage extends Message
 {
-    public static function create(Adherent $adherent, CitizenProject $citizenProject, string $linkCreateCitizenAction): self
-    {
+    public static function create(
+        Adherent $adherent,
+        CitizenProject $citizenProject,
+        string $linkCreateCitizenAction
+    ): self {
         $message = new self(
             Uuid::uuid4(),
             '244426',

--- a/src/Mailer/Message/CitizenProjectRequestCommitteeSupportMessage.php
+++ b/src/Mailer/Message/CitizenProjectRequestCommitteeSupportMessage.php
@@ -8,8 +8,11 @@ use Ramsey\Uuid\Uuid;
 
 class CitizenProjectRequestCommitteeSupportMessage extends Message
 {
-    public static function create(CitizenProject $citizenProject, Adherent $committeeSupervisor, string $validationUrl): self
-    {
+    public static function create(
+        CitizenProject $citizenProject,
+        Adherent $committeeSupervisor,
+        string $validationUrl
+    ): self {
         $message = new self(
             Uuid::uuid4(),
             '263222',

--- a/src/Mailer/Message/EventRegistrationConfirmationMessage.php
+++ b/src/Mailer/Message/EventRegistrationConfirmationMessage.php
@@ -27,11 +27,8 @@ final class EventRegistrationConfirmationMessage extends Message
         );
     }
 
-    private static function getTemplateVars(
-        string $eventName,
-        string $organizerName,
-        string $eventLink
-    ): array {
+    private static function getTemplateVars(string $eventName, string $organizerName, string $eventLink): array
+    {
         return [
             'event_name' => self::escape($eventName),
             'event_organiser' => self::escape($organizerName),

--- a/src/Mailer/Message/IdeaFinalizeMessage.php
+++ b/src/Mailer/Message/IdeaFinalizeMessage.php
@@ -17,8 +17,12 @@ final class IdeaFinalizeMessage extends Message
         return static::createMessage($adherent, $ideaLink, '648151', 'Plus que 3 jours pour finaliser votre proposition !');
     }
 
-    private static function createMessage(Adherent $adherent, string $ideaLink, string $templateId, string $subject): self
-    {
+    private static function createMessage(
+        Adherent $adherent,
+        string $ideaLink,
+        string $templateId,
+        string $subject
+    ): self {
         $message = new self(
             Uuid::uuid4(),
             $templateId,

--- a/src/Mailer/Message/InvitationMessage.php
+++ b/src/Mailer/Message/InvitationMessage.php
@@ -18,8 +18,11 @@ final class InvitationMessage extends Message
         );
     }
 
-    private static function getTemplateVars(string $senderFirstName, string $senderLastName, string $targetMessage): array
-    {
+    private static function getTemplateVars(
+        string $senderFirstName,
+        string $senderLastName,
+        string $targetMessage
+    ): array {
         return [
             'sender_firstname' => self::escape($senderFirstName),
             'sender_lastname' => self::escape($senderLastName),

--- a/src/Mailer/Message/ProcurationProxyFoundMessage.php
+++ b/src/Mailer/Message/ProcurationProxyFoundMessage.php
@@ -8,10 +8,8 @@ use Ramsey\Uuid\Uuid;
 
 final class ProcurationProxyFoundMessage extends Message
 {
-    public static function create(
-        ProcurationRequest $request,
-        string $infosUrl
-    ): self {
+    public static function create(ProcurationRequest $request, string $infosUrl): self
+    {
         $proxy = $request->getFoundProxy();
         $message = new self(
             Uuid::uuid4(),

--- a/src/Membership/AdherentFactory.php
+++ b/src/Membership/AdherentFactory.php
@@ -13,10 +13,8 @@ class AdherentFactory
     private $encoders;
     private $addressFactory;
 
-    public function __construct(
-        EncoderFactoryInterface $encoders,
-        PostAddressFactory $addressFactory = null
-    ) {
+    public function __construct(EncoderFactoryInterface $encoders, PostAddressFactory $addressFactory = null)
+    {
         $this->encoders = $encoders;
         $this->addressFactory = $addressFactory ?: new PostAddressFactory();
     }

--- a/src/Membership/AdherentManager.php
+++ b/src/Membership/AdherentManager.php
@@ -13,10 +13,8 @@ class AdherentManager
     private $manager;
     private $repository;
 
-    public function __construct(
-        AdherentRepository $repository,
-        ObjectManager $manager
-    ) {
+    public function __construct(AdherentRepository $repository, ObjectManager $manager)
+    {
         $this->repository = $repository;
         $this->manager = $manager;
     }

--- a/src/Membership/AdherentRegistry.php
+++ b/src/Membership/AdherentRegistry.php
@@ -28,8 +28,10 @@ class AdherentRegistry
     private $em;
     private $emailSubscriptionHistoryHandler;
 
-    public function __construct(EntityManagerInterface $em, EmailSubscriptionHistoryHandler $emailSubscriptionHistoryHandler)
-    {
+    public function __construct(
+        EntityManagerInterface $em,
+        EmailSubscriptionHistoryHandler $emailSubscriptionHistoryHandler
+    ) {
         $this->em = $em;
         $this->emailSubscriptionHistoryHandler = $emailSubscriptionHistoryHandler;
     }

--- a/src/Membership/MemberActivityTracker.php
+++ b/src/Membership/MemberActivityTracker.php
@@ -11,8 +11,10 @@ class MemberActivityTracker
     private $eventRegistrationRepository;
     private $eventRepository;
 
-    public function __construct(EventRegistrationRepository $eventRegistrationRepository, EventRepository $eventRepository)
-    {
+    public function __construct(
+        EventRegistrationRepository $eventRegistrationRepository,
+        EventRepository $eventRepository
+    ) {
         $this->eventRegistrationRepository = $eventRegistrationRepository;
         $this->eventRepository = $eventRepository;
     }

--- a/src/Membership/UnregistrationFactory.php
+++ b/src/Membership/UnregistrationFactory.php
@@ -7,8 +7,10 @@ use AppBundle\Entity\Unregistration;
 
 class UnregistrationFactory
 {
-    public function createFromUnregistrationCommandAndAdherent(UnregistrationCommand $command, Adherent $adherent): Unregistration
-    {
+    public function createFromUnregistrationCommandAndAdherent(
+        UnregistrationCommand $command,
+        Adherent $adherent
+    ): Unregistration {
         $unregistration = new Unregistration(
             $adherent->getUuid(),
             $command->getReasons(),

--- a/src/OAuth/AuthorizationValidators/JsonWebTokenValidator.php
+++ b/src/OAuth/AuthorizationValidators/JsonWebTokenValidator.php
@@ -23,8 +23,10 @@ class JsonWebTokenValidator implements AuthorizationValidatorInterface
     private $accessTokenRepository;
     private $enableQueryStringTransport;
 
-    public function __construct(AccessTokenRepositoryInterface $accessTokenRepository, bool $enableQueryStringTransport = false)
-    {
+    public function __construct(
+        AccessTokenRepositoryInterface $accessTokenRepository,
+        bool $enableQueryStringTransport = false
+    ) {
         $this->accessTokenRepository = $accessTokenRepository;
         $this->enableQueryStringTransport = $enableQueryStringTransport;
     }

--- a/src/OAuth/CallbackManager.php
+++ b/src/OAuth/CallbackManager.php
@@ -37,8 +37,11 @@ class CallbackManager
      *
      * @throws \Symfony\Component\Routing\Exception\InvalidParameterException
      */
-    public function generateUrl(string $name, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
-    {
+    public function generateUrl(
+        string $name,
+        array $parameters = [],
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
+    ): string {
         $callbackParameters = $this->validateRedirectUriAndClient();
 
         return $this->urlGenerator->generate($name, $parameters + $callbackParameters, $referenceType);

--- a/src/OAuth/ClientManager.php
+++ b/src/OAuth/ClientManager.php
@@ -10,10 +10,8 @@ class ClientManager
     private $em;
     private $tokenRevocationAuthority;
 
-    public function __construct(
-        EntityManagerInterface $em,
-        TokenRevocationAuthority $tokenRevocationAuthority
-    ) {
+    public function __construct(EntityManagerInterface $em, TokenRevocationAuthority $tokenRevocationAuthority)
+    {
         $this->em = $em;
         $this->tokenRevocationAuthority = $tokenRevocationAuthority;
     }

--- a/src/OAuth/Store/ScopeStore.php
+++ b/src/OAuth/Store/ScopeStore.php
@@ -19,8 +19,12 @@ class ScopeStore implements ScopeRepositoryInterface
         return new Scope($identifier);
     }
 
-    public function finalizeScopes(array $scopes, $grantType, ClientEntityInterface $clientEntity, $userIdentifier = null)
-    {
+    public function finalizeScopes(
+        array $scopes,
+        $grantType,
+        ClientEntityInterface $clientEntity,
+        $userIdentifier = null
+    ) {
         if (!$clientEntity instanceof Client) {
             throw new \LogicException(sprintf('Only %s instances are supported', Client::class));
         }

--- a/src/Procuration/ProcurationManager.php
+++ b/src/Procuration/ProcurationManager.php
@@ -33,8 +33,13 @@ class ProcurationManager
         $this->dispatcher = $dispatcher;
     }
 
-    public function processProcurationRequest(ProcurationRequest $request, ProcurationProxy $proxy = null, Adherent $referent = null, bool $notify = false, bool $flush = true): void
-    {
+    public function processProcurationRequest(
+        ProcurationRequest $request,
+        ProcurationProxy $proxy = null,
+        Adherent $referent = null,
+        bool $notify = false,
+        bool $flush = true
+    ): void {
         $request->process($proxy, $referent);
 
         if ($flush) {
@@ -44,8 +49,12 @@ class ProcurationManager
         $this->dispatcher->dispatch(ProcurationEvents::REQUEST_PROCESSED, new ProcurationRequestEvent($request, $notify));
     }
 
-    public function unprocessProcurationRequest(ProcurationRequest $request, Adherent $referent = null, bool $notify = false, bool $flush = true): void
-    {
+    public function unprocessProcurationRequest(
+        ProcurationRequest $request,
+        Adherent $referent = null,
+        bool $notify = false,
+        bool $flush = true
+    ): void {
         $request->unprocess();
 
         if ($flush) {

--- a/src/Procuration/ProcurationProxyMessageFactory.php
+++ b/src/Procuration/ProcurationProxyMessageFactory.php
@@ -21,8 +21,10 @@ class ProcurationProxyMessageFactory
         $this->replyToEmailAddress = $replyToEmailAddress;
     }
 
-    public function createProxyCancelledMessage(ProcurationRequest $request, ?Adherent $referent): ProcurationProxyCancelledMessage
-    {
+    public function createProxyCancelledMessage(
+        ProcurationRequest $request,
+        ?Adherent $referent
+    ): ProcurationProxyCancelledMessage {
         $message = ProcurationProxyCancelledMessage::create($request, $referent);
         $message->setReplyTo($this->replyToEmailAddress);
 

--- a/src/Query/Mysql/JsonContains.php
+++ b/src/Query/Mysql/JsonContains.php
@@ -39,6 +39,7 @@ class JsonContains extends FunctionNode
         if ($this->jsonPathExpr) {
             $jsonPath = ', '.$sqlWalker->walkStringPrimary($this->jsonPathExpr);
         }
+
         if ($sqlWalker->getConnection()->getDatabasePlatform() instanceof MySqlPlatform) {
             return sprintf('%s(%s, %s)', static::FUNCTION_NAME, $jsonDoc, $jsonVal.$jsonPath);
         }

--- a/src/React/PageMetaData.php
+++ b/src/React/PageMetaData.php
@@ -10,8 +10,13 @@ class PageMetaData implements PageMetaDataInterface
     private $imageHeight;
     private $imageUrl;
 
-    public function __construct(string $title, string $description = null, int $imageWidth = null, int $imageHeight = null, string $imageUrl = null)
-    {
+    public function __construct(
+        string $title,
+        string $description = null,
+        int $imageWidth = null,
+        int $imageHeight = null,
+        string $imageUrl = null
+    ) {
         $this->title = $title;
         $this->description = $description;
         $this->imageWidth = $imageWidth;

--- a/src/Redirection/Dynamic/RedirectToRemoveUuidHandler.php
+++ b/src/Redirection/Dynamic/RedirectToRemoveUuidHandler.php
@@ -15,8 +15,12 @@ class RedirectToRemoveUuidHandler extends AbstractRedirectTo implements Redirect
     private $router;
     private $patternUuid;
 
-    public function __construct(RedirectionsProvider $provider, RouterInterface $router, EventRepository $eventRepository, string $patternUuid)
-    {
+    public function __construct(
+        RedirectionsProvider $provider,
+        RouterInterface $router,
+        EventRepository $eventRepository,
+        string $patternUuid
+    ) {
         $this->provider = $provider;
         $this->router = $router;
         $this->eventRepository = $eventRepository;

--- a/src/Redirection/Dynamic/RedirectToRouteHandler.php
+++ b/src/Redirection/Dynamic/RedirectToRouteHandler.php
@@ -20,10 +20,13 @@ class RedirectToRouteHandler extends AbstractRedirectTo implements RedirectToInt
     private $orderArticleRepository;
 
     public function __construct(
-        RedirectionsProvider $provider, RouterInterface $router, EventRepository $eventRepository,
-        ArticleRepository $articleRepository, ProposalRepository $proposalRepository,
-        OrderArticleRepository $orderArticleRepository)
-    {
+        RedirectionsProvider $provider,
+        RouterInterface $router,
+        EventRepository $eventRepository,
+        ArticleRepository $articleRepository,
+        ProposalRepository $proposalRepository,
+        OrderArticleRepository $orderArticleRepository
+    ) {
         $this->provider = $provider;
         $this->router = $router;
         $this->eventRepository = $eventRepository;

--- a/src/Redirection/Dynamic/RedirectionManager.php
+++ b/src/Redirection/Dynamic/RedirectionManager.php
@@ -15,8 +15,11 @@ class RedirectionManager
 
     private $serializer;
 
-    public function __construct(CacheItemPoolInterface $cache, EntityManagerInterface $entityManager, Serializer $serializer)
-    {
+    public function __construct(
+        CacheItemPoolInterface $cache,
+        EntityManagerInterface $entityManager,
+        Serializer $serializer
+    ) {
         $this->cache = $cache;
         $this->entityManager = $entityManager;
         $this->serializer = $serializer;

--- a/src/Referent/ReferentMessageNotifier.php
+++ b/src/Referent/ReferentMessageNotifier.php
@@ -11,10 +11,8 @@ class ReferentMessageNotifier
     private $manager;
     private $producer;
 
-    public function __construct(
-        ObjectManager $manager,
-        ReferentMessageDispatcherProducerInterface $producer
-    ) {
+    public function __construct(ObjectManager $manager, ReferentMessageDispatcherProducerInterface $producer)
+    {
         $this->manager = $manager;
         $this->producer = $producer;
     }

--- a/src/Repository/AdherentRepository.php
+++ b/src/Repository/AdherentRepository.php
@@ -301,8 +301,12 @@ class AdherentRepository extends ServiceEntityRepository implements UserLoaderIn
         ;
     }
 
-    public function findByNearCitizenProjectOrAcceptAllNotification(CitizenProject $citizenProject, int $offset = 0, bool $excludeSupervisor = true, int $radius = CitizenProjectMessageNotifier::RADIUS_NOTIFICATION_NEAR_PROJECT_CITIZEN): Paginator
-    {
+    public function findByNearCitizenProjectOrAcceptAllNotification(
+        CitizenProject $citizenProject,
+        int $offset = 0,
+        bool $excludeSupervisor = true,
+        int $radius = CitizenProjectMessageNotifier::RADIUS_NOTIFICATION_NEAR_PROJECT_CITIZEN
+    ): Paginator {
         $qb = $this->createNearbyQueryBuilder(
                 new Coordinates(
                     $citizenProject->getLatitude(),
@@ -386,8 +390,10 @@ class AdherentRepository extends ServiceEntityRepository implements UserLoaderIn
         ;
     }
 
-    private function createBoardMemberFilterQueryBuilder(BoardMemberFilter $filter, Adherent $excludedMember): QueryBuilder
-    {
+    private function createBoardMemberFilterQueryBuilder(
+        BoardMemberFilter $filter,
+        Adherent $excludedMember
+    ): QueryBuilder {
         $qb = $this->createBoardMemberQueryBuilder();
 
         $qb->andWhere('a != :member');
@@ -605,8 +611,11 @@ class AdherentRepository extends ServiceEntityRepository implements UserLoaderIn
         return $this->formatCount($result);
     }
 
-    public function countCommitteeMembersInReferentManagedArea(Adherent $referent, StatisticsParametersFilter $filter = null, int $months = 5): array
-    {
+    public function countCommitteeMembersInReferentManagedArea(
+        Adherent $referent,
+        StatisticsParametersFilter $filter = null,
+        int $months = 5
+    ): array {
         $this->checkReferent($referent);
 
         $query = $this->createQueryBuilder('adherent', 'adherent.gender')

--- a/src/Repository/CitizenProjectMembershipRepository.php
+++ b/src/Repository/CitizenProjectMembershipRepository.php
@@ -47,8 +47,10 @@ class CitizenProjectMembershipRepository extends ServiceEntityRepository
         return new CitizenProjectMembershipCollection($query->getResult());
     }
 
-    public function findCitizenProjectMembership(Adherent $adherent, CitizenProject $citizenProject): ?CitizenProjectMembership
-    {
+    public function findCitizenProjectMembership(
+        Adherent $adherent,
+        CitizenProject $citizenProject
+    ): ?CitizenProjectMembership {
         return $this
             ->createMembershipQueryBuilder($adherent, $citizenProject)
             ->getQuery()
@@ -130,8 +132,10 @@ class CitizenProjectMembershipRepository extends ServiceEntityRepository
         return $this->createAdherentCollection($query);
     }
 
-    public function findFollowers(CitizenProject $citizenProject, bool $includeAdministrators = true): AdherentCollection
-    {
+    public function findFollowers(
+        CitizenProject $citizenProject,
+        bool $includeAdministrators = true
+    ): AdherentCollection {
         $privileges = [CitizenProjectMembership::CITIZEN_PROJECT_FOLLOWER];
 
         if ($includeAdministrators) {
@@ -147,8 +151,10 @@ class CitizenProjectMembershipRepository extends ServiceEntityRepository
      * @param CitizenProject $citizenProject The citizen project
      * @param array          $privileges     An array of privilege constants (see {@link : CitizenProjectMembership}
      */
-    public function findPrivilegedMemberships(CitizenProject $citizenProject, array $privileges): CitizenProjectMembershipCollection
-    {
+    public function findPrivilegedMemberships(
+        CitizenProject $citizenProject,
+        array $privileges
+    ): CitizenProjectMembershipCollection {
         $qb = $this->createQueryBuilder('cpm');
 
         $query = $qb
@@ -251,8 +257,10 @@ class CitizenProjectMembershipRepository extends ServiceEntityRepository
      * @param CitizenProject $citizenProject The citizen project for which the memberships to fetch belong
      * @param string         $alias          The custom root alias for the query
      */
-    private function createCitizenProjectMembershipsQueryBuilder(CitizenProject $citizenProject, string $alias = 'cpm'): QueryBuilder
-    {
+    private function createCitizenProjectMembershipsQueryBuilder(
+        CitizenProject $citizenProject,
+        string $alias = 'cpm'
+    ): QueryBuilder {
         return $this->createQueryBuilder($alias)
             ->leftJoin($alias.'.adherent', 'a')
             ->where($alias.'.citizenProject = :citizenProject')

--- a/src/Repository/CitizenProjectRepository.php
+++ b/src/Repository/CitizenProjectRepository.php
@@ -67,8 +67,10 @@ class CitizenProjectRepository extends AbstractGroupRepository
     /**
      * @return CitizenProject[]
      */
-    public function findAllRegisteredCitizenProjectsForAdherent(Adherent $adherent, bool $onlyAdministrated = false): array
-    {
+    public function findAllRegisteredCitizenProjectsForAdherent(
+        Adherent $adherent,
+        bool $onlyAdministrated = false
+    ): array {
         $memberships = $adherent->getCitizenProjectMemberships(true);
 
         if ($onlyAdministrated) {

--- a/src/Repository/CommitteeFeedItemRepository.php
+++ b/src/Repository/CommitteeFeedItemRepository.php
@@ -18,8 +18,11 @@ class CommitteeFeedItemRepository extends ServiceEntityRepository
         parent::__construct($registry, CommitteeFeedItem::class);
     }
 
-    public function findPaginatedMostRecentFeedItems(string $committeeUuid, int $limit, int $firstResultIndex = 0): Paginator
-    {
+    public function findPaginatedMostRecentFeedItems(
+        string $committeeUuid,
+        int $limit,
+        int $firstResultIndex = 0
+    ): Paginator {
         $qb = $this
             ->createCommitteeTimelineQueryBuilder($committeeUuid)
             ->setFirstResult($firstResultIndex)
@@ -39,8 +42,11 @@ class CommitteeFeedItemRepository extends ServiceEntityRepository
         return $this->findMostRecentFeedItem(CommitteeFeedItem::EVENT, $committeeUuid, $published);
     }
 
-    private function findMostRecentFeedItem(string $type, string $committeeUuid = null, ?bool $published = null): ?CommitteeFeedItem
-    {
+    private function findMostRecentFeedItem(
+        string $type,
+        string $committeeUuid = null,
+        ?bool $published = null
+    ): ?CommitteeFeedItem {
         $qb = $this
             ->createQueryBuilder('i')
             ->select('i, a')

--- a/src/Repository/CommitteeMembershipHistoryRepository.php
+++ b/src/Repository/CommitteeMembershipHistoryRepository.php
@@ -21,8 +21,11 @@ class CommitteeMembershipHistoryRepository extends ServiceEntityRepository
         parent::__construct($registry, CommitteeMembershipHistory::class);
     }
 
-    public function countAdherentMemberOfAtLeastOneCommitteeManagedBy(Adherent $referent, \DateTimeInterface $until, StatisticsParametersFilter $filter = null): int
-    {
+    public function countAdherentMemberOfAtLeastOneCommitteeManagedBy(
+        Adherent $referent,
+        \DateTimeInterface $until,
+        StatisticsParametersFilter $filter = null
+    ): int {
         $this->checkReferent($referent);
 
         $query = $this->createQueryBuilder('history')

--- a/src/Repository/CommitteeMembershipRepository.php
+++ b/src/Repository/CommitteeMembershipRepository.php
@@ -184,8 +184,10 @@ class CommitteeMembershipRepository extends ServiceEntityRepository
      * @param Committee $committee    The committee
      * @param bool      $includeHosts Whether or not to include committee hosts as followers
      */
-    public function findFollowerMemberships(Committee $committee, bool $includeHosts = true): CommitteeMembershipCollection
-    {
+    public function findFollowerMemberships(
+        Committee $committee,
+        bool $includeHosts = true
+    ): CommitteeMembershipCollection {
         $privileges = [CommitteeMembership::COMMITTEE_FOLLOWER];
         if ($includeHosts) {
             $privileges = array_merge($privileges, CommitteeMembership::getHostPrivileges());

--- a/src/Repository/CommitteeRepository.php
+++ b/src/Repository/CommitteeRepository.php
@@ -441,8 +441,11 @@ class CommitteeRepository extends ServiceEntityRepository
         ;
     }
 
-    private function retrieveTopCommitteesInReferentManagedArea(Adherent $referent, int $limit = 5, bool $mostActive = true): array
-    {
+    private function retrieveTopCommitteesInReferentManagedArea(
+        Adherent $referent,
+        int $limit = 5,
+        bool $mostActive = true
+    ): array {
         $this->checkReferent($referent);
 
         $result = $this->createQueryBuilder('committee')

--- a/src/Repository/EmailSubscriptionHistoryRepository.php
+++ b/src/Repository/EmailSubscriptionHistoryRepository.php
@@ -21,8 +21,11 @@ class EmailSubscriptionHistoryRepository extends ServiceEntityRepository
     /**
      * Count active adherents (not users) history for each specified subscription types in the referent managed area before the specified date.
      */
-    public function countAllByTypeForReferentManagedArea(Adherent $referent, array $subscriptionTypeCodes, \DateTimeInterface $until): array
-    {
+    public function countAllByTypeForReferentManagedArea(
+        Adherent $referent,
+        array $subscriptionTypeCodes,
+        \DateTimeInterface $until
+    ): array {
         $this->checkReferent($referent);
 
         $qb = $this->createQueryBuilder('history')

--- a/src/Repository/EventRegistrationRepository.php
+++ b/src/Repository/EventRegistrationRepository.php
@@ -162,8 +162,11 @@ class EventRegistrationRepository extends ServiceEntityRepository
         ;
     }
 
-    public function countEventParticipantsInReferentManagedArea(Adherent $referent, StatisticsParametersFilter $filter = null, int $months = 5): array
-    {
+    public function countEventParticipantsInReferentManagedArea(
+        Adherent $referent,
+        StatisticsParametersFilter $filter = null,
+        int $months = 5
+    ): array {
         $this->checkReferent($referent);
 
         $query = $this->createQueryBuilderForEventParticipantsInReferentManagedArea($referent, $months);
@@ -175,8 +178,11 @@ class EventRegistrationRepository extends ServiceEntityRepository
         return RepositoryUtils::aggregateCountByMonth($query->getQuery()->getArrayResult());
     }
 
-    public function countEventParticipantsAsAdherentInReferentManagedArea(Adherent $referent, StatisticsParametersFilter $filter = null, int $months = 5): array
-    {
+    public function countEventParticipantsAsAdherentInReferentManagedArea(
+        Adherent $referent,
+        StatisticsParametersFilter $filter = null,
+        int $months = 5
+    ): array {
         $this->checkReferent($referent);
 
         $query = $this->createQueryBuilderForEventParticipantsInReferentManagedArea($referent, $months)
@@ -190,8 +196,10 @@ class EventRegistrationRepository extends ServiceEntityRepository
         return RepositoryUtils::aggregateCountByMonth($query->getQuery()->getArrayResult());
     }
 
-    private function createQueryBuilderForEventParticipantsInReferentManagedArea(Adherent $referent, int $months): QueryBuilder
-    {
+    private function createQueryBuilderForEventParticipantsInReferentManagedArea(
+        Adherent $referent,
+        int $months
+    ): QueryBuilder {
         return $this->createQueryBuilder('eventRegistrations')
             ->select('DISTINCT eventRegistrations.emailAddress, COUNT(DISTINCT eventRegistrations) AS count, YEAR_MONTH(event.beginAt) as yearmonth')
             ->join(Event::class, 'event', Join::WITH, 'eventRegistrations.event = event.id')

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -628,8 +628,10 @@ SQL;
         return $results->fetchColumn();
     }
 
-    public function countCommitteeEventsInReferentManagedArea(Adherent $referent, StatisticsParametersFilter $filter = null): array
-    {
+    public function countCommitteeEventsInReferentManagedArea(
+        Adherent $referent,
+        StatisticsParametersFilter $filter = null
+    ): array {
         $this->checkReferent($referent);
 
         $query = $this->queryCountByMonth($referent);

--- a/src/Repository/ReferentOrganizationalChart/ReferentPersonLinkRepository.php
+++ b/src/Repository/ReferentOrganizationalChart/ReferentPersonLinkRepository.php
@@ -16,8 +16,10 @@ class ReferentPersonLinkRepository extends ServiceEntityRepository
         parent::__construct($registry, ReferentPersonLink::class);
     }
 
-    public function findOrCreateByOrgaItemAndReferent(PersonOrganizationalChartItem $organizationalChartItem, Referent $referent): ?ReferentPersonLink
-    {
+    public function findOrCreateByOrgaItemAndReferent(
+        PersonOrganizationalChartItem $organizationalChartItem,
+        Referent $referent
+    ): ?ReferentPersonLink {
         return $this->createQueryBuilder('referent_person_link')
             ->where('referent_person_link.referent = :referent')
             ->andWhere('referent_person_link.personOrganizationalChartItem = :personOrganizationalChartItem')

--- a/src/RepublicanSilence/CheckRepublicanSilenceListener.php
+++ b/src/RepublicanSilence/CheckRepublicanSilenceListener.php
@@ -38,8 +38,11 @@ class CheckRepublicanSilenceListener implements EventSubscriberInterface
     private $republicanSilenceManager;
     private $templateEngine;
 
-    public function __construct(TokenStorageInterface $tokenStorage, RepublicanSilenceManager $manager, EngineInterface $engine)
-    {
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        RepublicanSilenceManager $manager,
+        EngineInterface $engine
+    ) {
         $this->tokenStorage = $tokenStorage;
         $this->republicanSilenceManager = $manager;
         $this->templateEngine = $engine;

--- a/src/Search/CitizenProjectSearchResultsProvider.php
+++ b/src/Search/CitizenProjectSearchResultsProvider.php
@@ -10,8 +10,10 @@ class CitizenProjectSearchResultsProvider implements SearchResultsProviderInterf
     private $citizenProjectRepository;
     private $citizenProjectManager;
 
-    public function __construct(CitizenProjectRepository $citizenProjectRepository, CitizenProjectManager $citizenProjectManager)
-    {
+    public function __construct(
+        CitizenProjectRepository $citizenProjectRepository,
+        CitizenProjectManager $citizenProjectManager
+    ) {
         $this->citizenProjectRepository = $citizenProjectRepository;
         $this->citizenProjectManager = $citizenProjectManager;
     }

--- a/src/Statistics/Acquisition/Calculator/RatioCommitteeMemberAdherentCalculator.php
+++ b/src/Statistics/Acquisition/Calculator/RatioCommitteeMemberAdherentCalculator.php
@@ -12,8 +12,10 @@ class RatioCommitteeMemberAdherentCalculator extends AbstractCalculator
     private $adherentCalculator;
     private $committeeMemberCalculator;
 
-    public function __construct(AdherentCalculator $adherentCalculator, CommitteeMemberCalculator $committeeMemberCalculator)
-    {
+    public function __construct(
+        AdherentCalculator $adherentCalculator,
+        CommitteeMemberCalculator $committeeMemberCalculator
+    ) {
         $this->adherentCalculator = $adherentCalculator;
         $this->committeeMemberCalculator = $committeeMemberCalculator;
     }

--- a/src/Statistics/StatisticsParametersFilter.php
+++ b/src/Statistics/StatisticsParametersFilter.php
@@ -19,8 +19,10 @@ class StatisticsParametersFilter
     private $cityName = null;
     private $countryCode = null;
 
-    public static function createFromRequest(Request $request, CommitteeRepository $committeeRepository): StatisticsParametersFilter
-    {
+    public static function createFromRequest(
+        Request $request,
+        CommitteeRepository $committeeRepository
+    ): StatisticsParametersFilter {
         $filter = new self();
 
         if ($uuid = $request->query->get(self::PARAMETER_COMMITTEE_UUID)) {

--- a/src/Storage/FilesystemAdapterFactory.php
+++ b/src/Storage/FilesystemAdapterFactory.php
@@ -10,8 +10,13 @@ use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 
 class FilesystemAdapterFactory
 {
-    public static function createAdapter(string $environment, string $localPath, $gcloudId, $gcloudKeyFilePath, $gcloudBucket)
-    {
+    public static function createAdapter(
+        string $environment,
+        string $localPath,
+        $gcloudId,
+        $gcloudKeyFilePath,
+        $gcloudBucket
+    ) {
         if ('prod' !== $environment) {
             return new Local($localPath);
         }

--- a/src/Summary/SummaryItemDisplayOrderer.php
+++ b/src/Summary/SummaryItemDisplayOrderer.php
@@ -7,8 +7,12 @@ class SummaryItemDisplayOrderer
     /**
      * @param SummaryItemPositionableInterface[]|iterable $collection
      */
-    public static function updateItem(iterable $collection, SummaryItemPositionableInterface $updatedItem, int $currentItemPosition, int $newItemPosition): void
-    {
+    public static function updateItem(
+        iterable $collection,
+        SummaryItemPositionableInterface $updatedItem,
+        int $currentItemPosition,
+        int $newItemPosition
+    ): void {
         if (1 < \count($collection) && $currentItemPosition !== $newItemPosition) {
             foreach ($collection as $item) {
                 if (!$item instanceof SummaryItemPositionableInterface) {

--- a/src/Summary/SummaryItemDisplayOrderer.php
+++ b/src/Summary/SummaryItemDisplayOrderer.php
@@ -18,6 +18,7 @@ class SummaryItemDisplayOrderer
                 if (!$item instanceof SummaryItemPositionableInterface) {
                     throw new \InvalidArgumentException(sprintf('Expected instance of "%s", got "%s".', SummaryItemPositionableInterface::class, \is_object($item) ? \get_class($item) : \gettype($item)));
                 }
+
                 if ($updatedItem === $item) {
                     continue;
                 }
@@ -48,6 +49,7 @@ class SummaryItemDisplayOrderer
             if (!$item instanceof SummaryItemPositionableInterface) {
                 throw new \InvalidArgumentException(sprintf('Expected instance of "%s", got "%s".', SummaryItemPositionableInterface::class, \is_object($item) ? \get_class($item) : \gettype($item)));
             }
+
             if ($newPosition <= ($order = $item->getDisplayOrder())) {
                 $item->setDisplayOrder(++$order);
             }
@@ -64,9 +66,11 @@ class SummaryItemDisplayOrderer
             if (!$item instanceof SummaryItemPositionableInterface) {
                 throw new \InvalidArgumentException(sprintf('Expected instance of "%s", got "%s".', SummaryItemPositionableInterface::class, \is_object($item) ? \get_class($item) : \gettype($item)));
             }
+
             if ($removedItem === $item) {
                 continue;
             }
+
             if ($position < ($order = $item->getDisplayOrder())) {
                 $item->setDisplayOrder(--$order);
             }

--- a/src/Swagger/SwaggerDecorator.php
+++ b/src/Swagger/SwaggerDecorator.php
@@ -56,8 +56,11 @@ final class SwaggerDecorator implements NormalizerInterface
         return $this->decorated->supportsNormalization($data, $format);
     }
 
-    private function overridePaginatedResponseFormat(array $docs, ResourceMetadata $resourceMetadata, ?string $group): array
-    {
+    private function overridePaginatedResponseFormat(
+        array $docs,
+        ResourceMetadata $resourceMetadata,
+        ?string $group
+    ): array {
         $path = sprintf('%s%s', $this->apiPathPrefix, $this->getPath($resourceMetadata->getShortName(), ['get'], 'collection'));
 
         if ($group) {

--- a/src/TonMacron/InvitationProcessor.php
+++ b/src/TonMacron/InvitationProcessor.php
@@ -181,12 +181,15 @@ final class InvitationProcessor
         if ($this->friendPosition) {
             $collection->add($this->friendPosition);
         }
+
         if ($this->friendProject) {
             $collection->add($this->friendProject);
         }
+
         foreach ($this->friendInterests as $interest) {
             $collection->add($interest);
         }
+
         foreach ($this->selfReasons as $reason) {
             $collection->add($reason);
         }
@@ -197,6 +200,7 @@ final class InvitationProcessor
         if ($this->friendPosition) {
             $this->friendPosition = $manager->merge($this->friendPosition);
         }
+
         if ($this->friendProject) {
             $this->friendProject = $manager->merge($this->friendProject);
         }

--- a/src/TonMacron/TonMacronMessageBodyBuilder.php
+++ b/src/TonMacron/TonMacronMessageBodyBuilder.php
@@ -9,10 +9,8 @@ class TonMacronMessageBodyBuilder
     private $twig;
     private $repository;
 
-    public function __construct(
-        \Twig_Environment $twig,
-        TonMacronChoiceRepository $repository
-    ) {
+    public function __construct(\Twig_Environment $twig, TonMacronChoiceRepository $repository)
+    {
         $this->twig = $twig;
         $this->repository = $repository;
     }

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -16,8 +16,13 @@ class AssetRuntime
     private $env;
     private $hash;
 
-    public function __construct(Router $router, BaseAssetExtension $symfonyAssetExtension, string $secret, string $env, ?string $hash)
-    {
+    public function __construct(
+        Router $router,
+        BaseAssetExtension $symfonyAssetExtension,
+        string $secret,
+        string $env,
+        ?string $hash
+    ) {
         $this->router = $router;
         $this->symfonyAssetExtension = $symfonyAssetExtension;
         $this->secret = $secret;
@@ -29,15 +34,21 @@ class AssetRuntime
         }
     }
 
-    public function transformedStaticAsset(string $path, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
-    {
+    public function transformedStaticAsset(
+        string $path,
+        array $parameters = [],
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
+    ): string {
         $parameters['cache'] = $this->hash;
 
         return $this->generateAssetUrl('static/'.$path, $parameters, $referenceType);
     }
 
-    public function transformedMediaAsset(Media $media, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
-    {
+    public function transformedMediaAsset(
+        Media $media,
+        array $parameters = [],
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
+    ): string {
         $parameters['cache'] = substr(md5($media->getUpdatedAt()->format('U')), 0, 20);
 
         if ($media->isVideo()) {

--- a/src/Twig/ReadMoreExtension.php
+++ b/src/Twig/ReadMoreExtension.php
@@ -14,8 +14,13 @@ class ReadMoreExtension extends AbstractExtension
         ];
     }
 
-    public static function addReadMoreLink($text, $length = 256, $salt = null, $readMoreLabelText = 'Show more', $readLessLabelText = 'Show less')
-    {
+    public static function addReadMoreLink(
+        $text,
+        $length = 256,
+        $salt = null,
+        $readMoreLabelText = 'Show more',
+        $readLessLabelText = 'Show less'
+    ) {
         if (mb_strlen($text) <= $length) {
             return $text;
         }

--- a/src/Twig/ReferentPersonLinkExtension.php
+++ b/src/Twig/ReferentPersonLinkExtension.php
@@ -16,8 +16,10 @@ class ReferentPersonLinkExtension extends AbstractExtension
         ];
     }
 
-    public function getRefPersonLink(PersonOrganizationalChartItem $personOrganizationalChartItem, ?Referent $referent): ?ReferentPersonLink
-    {
+    public function getRefPersonLink(
+        PersonOrganizationalChartItem $personOrganizationalChartItem,
+        ?Referent $referent
+    ): ?ReferentPersonLink {
         if (!$referent) {
             return null;
         }

--- a/src/Validator/CommitteeMemberValidator.php
+++ b/src/Validator/CommitteeMemberValidator.php
@@ -18,10 +18,8 @@ class CommitteeMemberValidator extends ConstraintValidator
     private $committeeMembershipRepository;
     private $security;
 
-    public function __construct(
-        CommitteeMembershipRepository $committeeMembershipRepository,
-        Security $security
-    ) {
+    public function __construct(CommitteeMembershipRepository $committeeMembershipRepository, Security $security)
+    {
         $this->committeeMembershipRepository = $committeeMembershipRepository;
         $this->security = $security;
     }

--- a/tests/Api/CommitteeProviderTest.php
+++ b/tests/Api/CommitteeProviderTest.php
@@ -76,8 +76,13 @@ class CommitteeProviderTest extends TestCase
         );
     }
 
-    private function createCommitteeMock(string $uuid, string $slug, string $name, float $latitude = null, float $longitude = null)
-    {
+    private function createCommitteeMock(
+        string $uuid,
+        string $slug,
+        string $name,
+        float $latitude = null,
+        float $longitude = null
+    ) {
         $committee = $this->createMock(Committee::class);
         $committee->expects($this->any())->method('isGeocoded')->willReturn($latitude && $longitude);
         $committee->expects($this->any())->method('getUuid')->willReturn(Uuid::fromString($uuid));

--- a/tests/Api/EventProviderTest.php
+++ b/tests/Api/EventProviderTest.php
@@ -83,8 +83,14 @@ class EventProviderTest extends TestCase
         );
     }
 
-    private function createCommitteeEventMock(string $uuid, string $slug, string $name, float $latitude = null, float $longitude = null, $withOrganizer = false)
-    {
+    private function createCommitteeEventMock(
+        string $uuid,
+        string $slug,
+        string $name,
+        float $latitude = null,
+        float $longitude = null,
+        $withOrganizer = false
+    ) {
         $event = $this->createMock(Event::class);
         $event->expects($this->any())->method('isGeocoded')->willReturn($latitude && $longitude);
         $event->expects($this->any())->method('getUuid')->willReturn(Uuid::fromString($uuid));

--- a/tests/CitizenProject/CitizenProjectMessageNotifierTest.php
+++ b/tests/CitizenProject/CitizenProjectMessageNotifierTest.php
@@ -186,6 +186,7 @@ class CitizenProjectMessageNotifierTest extends TestCase
         if ($administrator) {
             $manager->expects($this->any())->method('getCitizenProjectCreator')->willReturn($administrator);
         }
+
         if ($member) {
             $membres = new AdherentCollection();
             $membres->add($member);

--- a/tests/Controller/Api/FormControllerTest.php
+++ b/tests/Controller/Api/FormControllerTest.php
@@ -170,6 +170,7 @@ class FormControllerTest extends WebTestCase
             if (\is_array($item)) {
                 static::assertArrayValues($item, $actual[$key]);
             }
+
             if (\is_string($item)) {
                 static::assertSame($item, $actual[$key]);
             }

--- a/tests/Controller/Api/OAuthServerControllerTest.php
+++ b/tests/Controller/Api/OAuthServerControllerTest.php
@@ -328,8 +328,11 @@ class OAuthServerControllerTest extends WebTestCase
         ;
     }
 
-    private function createAuthorizeUrl($scopes = [], string $clientId = 'f80ce2df-af6d-4ce4-8239-04cfcefd5a19', ?string $redirectUri = 'http://client-oauth.docker:8000/client/receive_authcode'): string
-    {
+    private function createAuthorizeUrl(
+        $scopes = [],
+        string $clientId = 'f80ce2df-af6d-4ce4-8239-04cfcefd5a19',
+        ?string $redirectUri = 'http://client-oauth.docker:8000/client/receive_authcode'
+    ): string {
         $params = ['client_id' => $clientId];
 
         if ($redirectUri) {

--- a/tests/Controller/ControllerTestTrait.php
+++ b/tests/Controller/ControllerTestTrait.php
@@ -41,8 +41,12 @@ trait ControllerTestTrait
         $this->assertSame($statusCode, $response->getStatusCode(), $message);
     }
 
-    public function assertClientIsRedirectedTo(string $path, Client $client, bool $withSchemes = false, bool $permanent = false)
-    {
+    public function assertClientIsRedirectedTo(
+        string $path,
+        Client $client,
+        bool $withSchemes = false,
+        bool $permanent = false
+    ) {
         $response = $client->getResponse();
 
         $this->assertResponseStatusCode($permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND, $response);
@@ -113,8 +117,11 @@ trait ControllerTestTrait
         return 1 === \count($flash);
     }
 
-    protected function appendCollectionFormPrototype(\DOMElement $collection, string $newIndex = '0', string $prototypeName = '__name__'): void
-    {
+    protected function appendCollectionFormPrototype(
+        \DOMElement $collection,
+        string $newIndex = '0',
+        string $prototypeName = '__name__'
+    ): void {
         $prototypeHTML = $collection->getAttribute('data-prototype');
         $prototypeHTML = str_replace($prototypeName, $newIndex, $prototypeHTML);
         $prototypeFragment = new \DOMDocument();
@@ -124,8 +131,13 @@ trait ControllerTestTrait
         }
     }
 
-    protected function assertSeeCommitteeTimelineMessage(Crawler $crawler, int $position, string $author, string $role, string $text)
-    {
+    protected function assertSeeCommitteeTimelineMessage(
+        Crawler $crawler,
+        int $position,
+        string $author,
+        string $role,
+        string $text
+    ) {
         $message = $crawler->filter('.committee__timeline__message')->eq($position);
 
         $this->assertContains($author, $message->filter('h3')->text());

--- a/tests/Controller/EnMarche/AdherentControllerTest.php
+++ b/tests/Controller/EnMarche/AdherentControllerTest.php
@@ -608,8 +608,11 @@ class AdherentControllerTest extends WebTestCase
     /**
      * @return EmailSubscriptionHistory[]
      */
-    public function findEmailSubscriptionHistoryByAdherent(Adherent $adherent, string $action = null, string $referentTagCode = null): array
-    {
+    public function findEmailSubscriptionHistoryByAdherent(
+        Adherent $adherent,
+        string $action = null,
+        string $referentTagCode = null
+    ): array {
         $qb = $this
             ->getEmailSubscriptionHistoryRepository()
             ->createQueryBuilder('history')
@@ -639,8 +642,10 @@ class AdherentControllerTest extends WebTestCase
     /**
      * @return EmailSubscriptionHistory[]
      */
-    public function findAllEmailSubscriptionHistoryByAdherentAndType(Adherent $adherent, string $subscriptionType): array
-    {
+    public function findAllEmailSubscriptionHistoryByAdherentAndType(
+        Adherent $adherent,
+        string $subscriptionType
+    ): array {
         return $this
             ->getEmailSubscriptionHistoryRepository()
             ->createQueryBuilder('history')
@@ -1084,8 +1089,13 @@ class AdherentControllerTest extends WebTestCase
     /**
      * @dataProvider provideAdherentCredentials
      */
-    public function testAdherentTerminatesMembership(string $userEmail, string $uuid, int $nbComments, string $committee, int $nbFollowers): void
-    {
+    public function testAdherentTerminatesMembership(
+        string $userEmail,
+        string $uuid,
+        int $nbComments,
+        string $committee,
+        int $nbFollowers
+    ): void {
         /** @var Adherent $adherent */
         $adherentBeforeUnregistration = $this->getAdherentRepository()->findOneByEmail($userEmail);
         $referentTagsBeforeUnregistration = $adherentBeforeUnregistration->getReferentTags()->toArray(); // It triggers the real SQL query instead of lazy-load

--- a/tests/Controller/EnMarche/LegislativesControllerTest.php
+++ b/tests/Controller/EnMarche/LegislativesControllerTest.php
@@ -48,8 +48,10 @@ class LegislativesControllerTest extends WebTestCase
     /**
      * @dataProvider provideLegislativeCandidatesContacts
      */
-    public function testLegislativeCandidateIsAllowedToSendContactMessage(string $expectedRecipient, string $selectedRecipient)
-    {
+    public function testLegislativeCandidateIsAllowedToSendContactMessage(
+        string $expectedRecipient,
+        string $selectedRecipient
+    ) {
         $this->authenticateAsAdherent($this->client, 'kiroule.p@blabla.tld');
 
         $crawler = $this->client->request(Request::METHOD_GET, '/espace-candidat-legislatives/contact');

--- a/tests/Geocoder/Subscriber/EntityAddressGeocodingSubscriberTest.php
+++ b/tests/Geocoder/Subscriber/EntityAddressGeocodingSubscriberTest.php
@@ -180,10 +180,8 @@ class EntityAddressGeocodingSubscriberTest extends TestCase
         return $committee;
     }
 
-    private function createCitizenProject(
-        string $address = null,
-        Committee $committee = null
-    ): CitizenProject {
+    private function createCitizenProject(string $address = null, Committee $committee = null): CitizenProject
+    {
         if (null === $committee) {
             $committee = $this->createCommittee('63 rue Saint Anne');
         }

--- a/tests/OAuth/CallbackManagerTest.php
+++ b/tests/OAuth/CallbackManagerTest.php
@@ -87,8 +87,10 @@ class CallbackManagerTest extends TestCase
     /**
      * @dataProvider providesInvalidClientOrRedirectUri
      */
-    public function testItGeneratesUrlWithCallbackInformationWhenRedirectUriOrClientIdIsNotValid(string $redirectUri, string $clientId): void
-    {
+    public function testItGeneratesUrlWithCallbackInformationWhenRedirectUriOrClientIdIsNotValid(
+        string $redirectUri,
+        string $clientId
+    ): void {
         $this->request->query->set('redirect_uri', $redirectUri);
         $this->request->query->set('client_id', $clientId);
 

--- a/tests/Procuration/ProcurationProxyMessageFactoryTest.php
+++ b/tests/Procuration/ProcurationProxyMessageFactoryTest.php
@@ -132,8 +132,12 @@ class ProcurationProxyMessageFactoryTest extends TestCase
         );
     }
 
-    private function createProcurationRequestMock(string $firstNames, string $lastName, string $email, string $phone = '')
-    {
+    private function createProcurationRequestMock(
+        string $firstNames,
+        string $lastName,
+        string $email,
+        string $phone = ''
+    ) {
         $request = $this->createMock(ProcurationRequest::class);
         $request->expects($this->any())->method('getFirstNames')->willReturn($firstNames);
         $request->expects($this->any())->method('getLastName')->willReturn($lastName);

--- a/tests/Redirection/Dynamic/RedirectionManagerTest.php
+++ b/tests/Redirection/Dynamic/RedirectionManagerTest.php
@@ -58,8 +58,12 @@ class RedirectionManagerTest extends WebTestCase
         self::assertRedirectionValues($redirection, '/test4', '/test1');
     }
 
-    private static function assertRedirectionValues(Redirection $redirection, string $source, string $target, int $type = 301): void
-    {
+    private static function assertRedirectionValues(
+        Redirection $redirection,
+        string $source,
+        string $target,
+        int $type = 301
+    ): void {
         self::assertSame($source, $redirection->getFrom());
         self::assertSame($target, $redirection->getTo());
         self::assertSame($type, $redirection->getType());

--- a/tests/Referent/ManagedAreaUtilsTest.php
+++ b/tests/Referent/ManagedAreaUtilsTest.php
@@ -11,11 +11,8 @@ class ManagedAreaUtilsTest extends TestCase
     /**
      * @dataProvider provideLocationsAndTags
      */
-    public function testGetLocalCodes(
-        string $country,
-        ?string $postalCode,
-        array $expectedCodes
-    ): void {
+    public function testGetLocalCodes(string $country, ?string $postalCode, array $expectedCodes): void
+    {
         $adherent = $this->createMock(Adherent::class);
         $adherent->expects(self::any())->method('getCountry')->willReturn($country);
         $adherent->expects(self::any())->method('getPostalCode')->willReturn($postalCode);

--- a/tests/Security/Voter/AbstractAdherentVoterTest.php
+++ b/tests/Security/Voter/AbstractAdherentVoterTest.php
@@ -33,8 +33,12 @@ abstract class AbstractAdherentVoterTest extends TestCase
     /**
      * @dataProvider provideAnonymousCases
      */
-    public function testAnonymousIsGranted(bool $granted, bool $adherentInstanceChecked, string $attribute, $subject = null): void
-    {
+    public function testAnonymousIsGranted(
+        bool $granted,
+        bool $adherentInstanceChecked,
+        string $attribute,
+        $subject = null
+    ): void {
         if ($granted) {
             $this->assertSame(
                 VoterInterface::ACCESS_GRANTED,

--- a/tests/Security/Voter/CitizenProject/AdministrateCitizenProjectVoterTest.php
+++ b/tests/Security/Voter/CitizenProject/AdministrateCitizenProjectVoterTest.php
@@ -56,8 +56,11 @@ class AdministrateCitizenProjectVoterTest extends AbstractAdherentVoterTest
     /**
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(bool $getUuidIsCalled, CitizenProject $project = null, bool $isAdministrator = null): Adherent
-    {
+    private function getAdherentMock(
+        bool $getUuidIsCalled,
+        CitizenProject $project = null,
+        bool $isAdministrator = null
+    ): Adherent {
         $adherent = $this->createAdherentMock();
 
         if ($getUuidIsCalled) {

--- a/tests/Security/Voter/CitizenProject/CommentsCitizenProjectVoterTest.php
+++ b/tests/Security/Voter/CitizenProject/CommentsCitizenProjectVoterTest.php
@@ -31,8 +31,11 @@ class CommentsCitizenProjectVoterTest extends AbstractAdherentVoterTest
     /**
      * @dataProvider provideCommentsCases
      */
-    public function testCitizenProjectMemberCanCommentIfProjectApproved(string $attribute, bool $approved, bool $isMember)
-    {
+    public function testCitizenProjectMemberCanCommentIfProjectApproved(
+        string $attribute,
+        bool $approved,
+        bool $isMember
+    ) {
         $project = $this->getCitizenProjectMock($approved);
         $adherent = $this->getAdherentMock($approved, $project, $isMember);
 

--- a/tests/Security/Voter/CitizenProject/CommentsCitizenProjectVoterTest.php
+++ b/tests/Security/Voter/CitizenProject/CommentsCitizenProjectVoterTest.php
@@ -18,6 +18,7 @@ class CommentsCitizenProjectVoterTest extends AbstractAdherentVoterTest
         foreach (CitizenProjectPermissions::COMMENTS as $permission) {
             yield [false, true, $permission, $this->getCitizenProjectMock(true)];
         }
+
         foreach (CitizenProjectPermissions::COMMENTS as $permission) {
             yield [false, false, $permission, $this->getCitizenProjectMock(false)];
         }

--- a/tests/Security/Voter/CitizenProject/FollowerCitizenProjectVoterTest.php
+++ b/tests/Security/Voter/CitizenProject/FollowerCitizenProjectVoterTest.php
@@ -68,8 +68,11 @@ class FollowerCitizenProjectVoterTest extends AbstractAdherentVoterTest
      *
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(CitizenProject $project, bool $isFollower = null, bool $isAdministrator = null): Adherent
-    {
+    private function getAdherentMock(
+        CitizenProject $project,
+        bool $isFollower = null,
+        bool $isAdministrator = null
+    ): Adherent {
         $adherent = $this->createAdherentMock();
 
         $adherent->expects($this->once())

--- a/tests/Security/Voter/Committee/CreateCommitteeVoterTest.php
+++ b/tests/Security/Voter/Committee/CreateCommitteeVoterTest.php
@@ -101,8 +101,11 @@ class CreateCommitteeVoterTest extends AbstractAdherentVoterTest
         return $adherent;
     }
 
-    private function assertRepositoryBehavior(bool $isCalled, Adherent $adherent = null, bool $allowedToCreate = false): void
-    {
+    private function assertRepositoryBehavior(
+        bool $isCalled,
+        Adherent $adherent = null,
+        bool $allowedToCreate = false
+    ): void {
         if ($isCalled) {
             $this->committeeRepository->expects($this->once())
                 ->method('hasCommitteeInStatus')

--- a/tests/Security/Voter/Committee/FollowCommitteeVoterTest.php
+++ b/tests/Security/Voter/Committee/FollowCommitteeVoterTest.php
@@ -128,8 +128,12 @@ class FollowCommitteeVoterTest extends AbstractAdherentVoterTest
     /**
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(Committee $committee = null, bool $isFollower = null, bool $isSupervisor = null, bool $isHost = false): Adherent
-    {
+    private function getAdherentMock(
+        Committee $committee = null,
+        bool $isFollower = null,
+        bool $isSupervisor = null,
+        bool $isHost = false
+    ): Adherent {
         $adherent = $this->createAdherentMock();
 
         if ($committee) {
@@ -150,8 +154,11 @@ class FollowCommitteeVoterTest extends AbstractAdherentVoterTest
     /**
      * @return CommitteeMembership|\PHPUnit_Framework_MockObject_MockObject|null
      */
-    private function getMembershipMock(?bool $isFollower, ?bool $isSupervisor, bool $isHost = false): ?CommitteeMembership
-    {
+    private function getMembershipMock(
+        ?bool $isFollower,
+        ?bool $isSupervisor,
+        bool $isHost = false
+    ): ?CommitteeMembership {
         if (!$isFollower) {
             return null;
         }

--- a/tests/Security/Voter/Committee/HostCommitteeVoterTest.php
+++ b/tests/Security/Voter/Committee/HostCommitteeVoterTest.php
@@ -74,8 +74,12 @@ class HostCommitteeVoterTest extends AbstractAdherentVoterTest
      *
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(bool $isSupervisor = null, Committee $committee = null, bool $isCreator = false, bool $isHost = null): Adherent
-    {
+    private function getAdherentMock(
+        bool $isSupervisor = null,
+        Committee $committee = null,
+        bool $isCreator = false,
+        bool $isHost = null
+    ): Adherent {
         $adherent = $this->createAdherentMock();
 
         if (null !== $isSupervisor) {

--- a/tests/Security/Voter/HostEventVoterTest.php
+++ b/tests/Security/Voter/HostEventVoterTest.php
@@ -59,8 +59,11 @@ class HostEventVoterTest extends AbstractAdherentVoterTest
     /**
      * @return Adherent|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAdherentMock(bool $isOrganizer = false, bool $isHost = null, Committee $committee = null): Adherent
-    {
+    private function getAdherentMock(
+        bool $isOrganizer = false,
+        bool $isHost = null,
+        Committee $committee = null
+    ): Adherent {
         $adherent = $this->createAdherentMock();
 
         if ($isOrganizer) {

--- a/tests/Security/Voter/ManageCitizenActionVoterTest.php
+++ b/tests/Security/Voter/ManageCitizenActionVoterTest.php
@@ -197,8 +197,11 @@ class ManageCitizenActionVoterTest extends AbstractAdherentVoterTest
         return $project;
     }
 
-    private function assertMembershipRepositoryMock(bool $hasAdministrator = null, Adherent $host = null, CitizenProject $project = null): void
-    {
+    private function assertMembershipRepositoryMock(
+        bool $hasAdministrator = null,
+        Adherent $host = null,
+        CitizenProject $project = null
+    ): void {
         if (null !== $hasAdministrator) {
             $this->membershipRepository->expects($this->once())
                 ->method('administrateCitizenProject')

--- a/tests/Security/Voter/ShowGroupVoterTest.php
+++ b/tests/Security/Voter/ShowGroupVoterTest.php
@@ -50,8 +50,11 @@ class ShowGroupVoterTest extends AbstractAdherentVoterTest
     /**
      * @dataProvider provideGroupCases
      */
-    public function testAdherentIsGrantedWhenGroupIsNotApprovedIfCreator(string $groupClass, bool $approved, string $attribute)
-    {
+    public function testAdherentIsGrantedWhenGroupIsNotApprovedIfCreator(
+        string $groupClass,
+        bool $approved,
+        string $attribute
+    ) {
         $adherent = $this->getAdherentMock(!$approved);
         $group = $this->getGroupMock($groupClass, $approved, true);
 

--- a/tests/Sitemap/SitemapFactoryTest.php
+++ b/tests/Sitemap/SitemapFactoryTest.php
@@ -198,8 +198,12 @@ class SitemapFactoryTest extends TestCase
         parent::tearDown();
     }
 
-    private function invokeReflectionMethod(string $methodName, Sitemap $sitemap = null, int $page = null, int $perpage = null)
-    {
+    private function invokeReflectionMethod(
+        string $methodName,
+        Sitemap $sitemap = null,
+        int $page = null,
+        int $perpage = null
+    ) {
         $reflection = new \ReflectionMethod(SitemapFactory::class, $methodName);
         $reflection->setAccessible(true);
 

--- a/tests/Summary/SummaryItemDisplayOrdererTest.php
+++ b/tests/Summary/SummaryItemDisplayOrdererTest.php
@@ -71,8 +71,12 @@ class SummaryItemDisplayOrdererTest extends TestCase
         SummaryItemDisplayOrderer::removeItem([$item1, $item2, $item3], $item3);
     }
 
-    private function createDummyItem(int $position, bool $willBeChecked = false, bool $willBeOrdered = false, int $newPosition = null): SummaryItemPositionableInterface
-    {
+    private function createDummyItem(
+        int $position,
+        bool $willBeChecked = false,
+        bool $willBeOrdered = false,
+        int $newPosition = null
+    ): SummaryItemPositionableInterface {
         $mock = $this->createMock(SummaryItemPositionableInterface::class);
 
         if ($willBeChecked) {


### PR DESCRIPTION
2.11.0 version because it's the latest compatible with our php cs version. 

- 1st commit apply the `line_break_between_method_arguments` rule (164 files)
- 2nd commit apply the `line_break_between_statements` rule (18 files)
- 3nd commit apply the `useless_comment` rule (2 files changed)

From https://github.com/PedroTroller/PhpCSFixer-Custom-Fixers/tree/v2.11.0
