### PR TITLE
Add new column for proxy count

### DIFF
--- a/app/migrations/Version20190227153320.php
+++ b/app/migrations/Version20190227153320.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20190227153320 extends AbstractMigration
+{
+    private $procurationMatches = [];
+
+    public function preUp(Schema $schema)
+    {
+        foreach ($this->connection->fetchAll('SELECT id AS procuration_proxy_id, procuration_request_id, vote_country FROM procuration_proxies WHERE procuration_request_id IS NOT NULL') as $procurationProxy) {
+            $this->procurationMatches[] = [
+                'procuration_proxy_id' => $procurationProxy['procuration_proxy_id'],
+                'procuration_request_id' => $procurationProxy['procuration_request_id'],
+                'vote_country' => $procurationProxy['vote_country'],
+            ];
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE procuration_proxies SET procuration_request_id = NULL WHERE procuration_request_id IS NOT NULL');
+        $this->addSql('ALTER TABLE procuration_proxies DROP FOREIGN KEY FK_9B5E777A128D9C53');
+        $this->addSql('DROP INDEX UNIQ_9B5E777A128D9C53 ON procuration_proxies');
+        $this->addSql('ALTER TABLE procuration_proxies DROP procuration_request_id');
+        $this->addSql('ALTER TABLE procuration_requests ADD found_proxy_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE 
+          procuration_requests 
+        ADD 
+          CONSTRAINT FK_9769FD842F1B6663 FOREIGN KEY (found_proxy_id) REFERENCES procuration_proxies (id)');
+        $this->addSql('CREATE INDEX IDX_9769FD842F1B6663 ON procuration_requests (found_proxy_id)');
+        $this->addSql('ALTER TABLE 
+          procuration_proxies 
+        ADD 
+          french_request_available TINYINT(1) DEFAULT \'1\' NOT NULL, 
+        ADD 
+          foreign_request_available TINYINT(1) DEFAULT \'1\' NOT NULL');
+        $this->addSql('ALTER TABLE procuration_requests ADD request_from_france TINYINT(1) DEFAULT \'1\' NOT NULL');
+    }
+
+    public function postUp(Schema $schema)
+    {
+        foreach ($this->procurationMatches as $procurationMatch) {
+            $this->connection->executeUpdate(
+                sprintf('UPDATE procuration_requests SET found_proxy_id = %d WHERE id = %d',
+                    $procurationMatch['procuration_proxy_id'],
+                    $procurationMatch['procuration_request_id']
+                )
+            );
+
+            $columnToUpdate = 'FR' === $procurationMatch['vote_country']
+                ? 'french_request_available'
+                : 'foreign_request_available'
+            ;
+
+            $this->connection->executeUpdate(
+                sprintf("UPDATE procuration_proxies SET $columnToUpdate = 0 WHERE id = %d",
+                    $procurationMatch['procuration_proxy_id']
+                )
+            );
+        }
+    }
+
+    public function preDown(Schema $schema)
+    {
+        foreach ($this->connection->fetchAll('SELECT id AS procuration_request_id, found_proxy_id AS procuration_proxy_id FROM procuration_requests WHERE found_proxy_id IS NOT NULL') as $procurationRequest) {
+            $this->procurationMatches[] = [
+                'procuration_proxy_id' => $procurationRequest['procuration_proxy_id'],
+                'procuration_request_id' => $procurationRequest['procuration_request_id'],
+            ];
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE procuration_proxies ADD procuration_request_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE 
+          procuration_proxies 
+        ADD 
+          CONSTRAINT FK_9B5E777A128D9C53 FOREIGN KEY (procuration_request_id) REFERENCES procuration_requests (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9B5E777A128D9C53 ON procuration_proxies (procuration_request_id)');
+        $this->addSql('ALTER TABLE procuration_requests DROP FOREIGN KEY FK_9769FD842F1B6663');
+        $this->addSql('DROP INDEX IDX_9769FD842F1B6663 ON procuration_requests');
+        $this->addSql('ALTER TABLE procuration_requests DROP found_proxy_id');
+        $this->addSql('ALTER TABLE procuration_proxies DROP french_request_available, DROP foreign_request_available');
+        $this->addSql('ALTER TABLE procuration_requests DROP request_from_france');
+    }
+
+    public function postDown(Schema $schema)
+    {
+        foreach ($this->procurationMatches as $procurationMatch) {
+            $this->connection->executeUpdate(
+                sprintf('UPDATE procuration_proxies SET procuration_request_id = %d WHERE id = %d',
+                    $procurationMatch['procuration_request_id'],
+                    $procurationMatch['procuration_proxy_id']
+                )
+            );
+        }
+    }
+}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -83,4 +83,16 @@ class FeatureContext extends RawMinkContext
             $this->assertPageAddressAfterAllRedirection($url, $ttl, ++$try);
         }
     }
+
+    /**
+     * @When I click the :cssElementSelector selector
+     */
+    public function clickElementSelector($cssElementSelector)
+    {
+        $field = $this->getSession()->getPage()->find('css', $cssElementSelector);
+
+        Assert::notNull($field, "Cannot find '$cssElementSelector'");
+
+        $field->click();
+    }
 }

--- a/features/procuration.feature
+++ b/features/procuration.feature
@@ -1,0 +1,25 @@
+@javascript
+Feature:
+  As a non logged user
+  I can fill a form and became a representative
+
+  Background:
+    Given the following fixtures are loaded:
+      | LoadProcurationData |
+
+  Scenario: As a non logged user, I can fill a form
+    Given I am on "/procuration/choisir/proposition"
+    When I click the ".form__label" selector
+    And I press "Continuer"
+    Then I should be on "procuration/je-propose"
+    And I should see 3 "#app_procuration_proposal_proxiesCount div" element
+
+    When I fill in the following:
+      | app_procuration_proposal[voteCountry] | FR |
+    Then I should see 1 "#app_procuration_proposal_proxiesCount div.hidden" element
+    And I should see "Attention, vous ne pouvez être mandataire que pour deux procurations dont une seule maximum établie en France."
+
+    When I fill in the following:
+      | app_procuration_proposal[voteCountry] | ES |
+    Then I should see 0 "#app_procuration_proposal_proxiesCount div.hidden" element
+    And I should see "Attention, vous ne pouvez être mandataire que pour trois procurations dont une seule maximum établie en France."

--- a/src/DataFixtures/ORM/LoadProcurationData.php
+++ b/src/DataFixtures/ORM/LoadProcurationData.php
@@ -106,14 +106,14 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
             'René',
             'thomas.rene@example.gb',
             '95, Faubourg Saint Honoré',
-            '75020',
-            '75020-75120',
+            '75008',
+            '75008-75108',
             null,
             '33 0099887766',
             '1962-10-11',
             'FR',
             '75020',
-            '75020-75120',
+            '75008-75108',
             null,
             'Lycée Faubourg',
             $partialLegislativeElections->getRounds(),
@@ -178,6 +178,107 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
             'École de la république',
             $partialLegislativeElections->getRounds(),
             ProcurationRequest::REASON_TRAINING
+        ));
+
+        $manager->persist($request3 = $this->createRequest(
+            'male',
+            'Jean',
+            'Dell',
+            'jean.dell@example.gb',
+            '100 Roy Square, Main Street',
+            'E14 8BY',
+            'London',
+            'London',
+            '44 9999888111',
+            '1972-11-23',
+            'FR',
+            '75008',
+            '75008-75108',
+            null,
+            'Gymnase de Iéna',
+            $partialLegislativeElections->getRounds(),
+            ProcurationRequest::REASON_RESIDENCY,
+            false
+        ));
+
+        $manager->persist($this->createRequest(
+            'female',
+            'Aurélie',
+            'Baumé',
+            'aurelie.baume@example.gb',
+            '24, Carrer de Pelai',
+            '08001',
+            'Barcelona',
+            'Barcelona',
+            '34 9999888222',
+            '1985-01-20',
+            'ES',
+            '08001',
+            'Barcelona',
+            'Barcelona',
+            'Institut Català de la Salut',
+            $partialLegislativeElections->getRounds()
+        ));
+
+        $manager->persist($this->createRequest(
+            'male',
+            'René',
+            'Rage',
+            'rene.rage@example.gb',
+            '100 Roy Square, Main Street',
+            'E14 8BY',
+            null,
+            'London',
+            '44 9999888111',
+            '1972-11-23',
+            'GB',
+            'E14 8BY',
+            null,
+            'London',
+            'Lycée international Winston Churchill',
+            $partialLegislativeElections->getRounds()
+        ));
+
+        $manager->persist($this->createRequest(
+            'male',
+            'Jean-Michel',
+            'Amoitié',
+            'jeanmichel.amoitié@example.es',
+            '4Q Covent Garden',
+            'GV6H',
+            'London',
+            null,
+            '44 234567891',
+            '1989-12-20',
+            'GB',
+            'GV6H',
+            'London',
+            null,
+            'Camden',
+            $partialLegislativeElections->getRounds(),
+            ProcurationRequest::REASON_HEALTH,
+            0
+        ));
+
+        $manager->persist($this->createRequest(
+            'male',
+            'Jean-Michel',
+            'Gastro',
+            'jeanmichel.gastro@example.es',
+            '4Q Covent Garden',
+            'GV6H',
+            'London',
+            null,
+            '44 234567891',
+            '1989-12-20',
+            'GB',
+            'GV6H',
+            'London',
+            null,
+            'Camden',
+            $partialLegislativeElections->getRounds(),
+            ProcurationRequest::REASON_HEALTH,
+            0
         ));
 
         $referent = $manager->getRepository(Adherent::class)->findByUuid(LoadAdherentData::REFERENT_1_UUID);
@@ -267,7 +368,8 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
                 $partialLegislativeElections->getRounds()->toArray()
             ),
             5,
-            'Responsable procuration'
+            'Responsable procuration',
+            2
         ));
 
         $manager->persist($this->createProxyProposal(
@@ -314,15 +416,66 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
             'Responsable procuration'
         ));
 
+        $manager->persist($this->createProxyProposal(
+            $referent,
+            'female',
+            'Annie',
+            'Versaire',
+            'annie.versaire@exemple.org',
+            '100 Roy Square, Main Street',
+            'E14 8BY',
+            null,
+            'London',
+            '44 9999888111',
+            '1972-11-23',
+            'GB',
+            'E14 8BY',
+            null,
+            'London',
+            'Lycée international Winston Churchill',
+            $partialLegislativeElections->getRounds(),
+            5,
+            'Désactivé',
+            1,
+            1
+        ));
+
+        $manager->persist($this->createProxyProposal(
+            $referent,
+            'male',
+            'Jean-Michel',
+            'Gastro',
+            'jeanmichel.gastro@example.es',
+            '4Q Covent Garden',
+            'GV6H',
+            'London',
+            null,
+            '44 234567891',
+            '1989-12-21',
+            'GB',
+            'GV6H',
+            'London',
+            null,
+            'Camden',
+            $partialLegislativeElections->getRounds(),
+            5,
+            'Responsable procuration',
+            3
+        ));
+
         $manager->flush();
 
         $manager->refresh($request1);
         $manager->refresh($request2);
+        $manager->refresh($request3);
         $manager->refresh($proxy1);
         $manager->refresh($proxy2);
+
         $finder = $manager->getRepository(Adherent::class)->findByUuid(LoadAdherentData::ADHERENT_4_UUID);
+
         $request1->process($proxy1, $finder);
         $request2->process($proxy2, $finder);
+        $request3->process($proxy2, $finder);
 
         $reflectionClass = new \ReflectionClass(ProcurationRequest::class);
         $reflectionProperty = $reflectionClass->getProperty('processedAt');
@@ -358,7 +511,8 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
         ?string $voteCityName,
         string $voteOffice,
         iterable $electionRounds,
-        string $reason = ProcurationRequest::REASON_HOLIDAYS
+        string $reason = ProcurationRequest::REASON_HOLIDAYS,
+        bool $requestFromFrance = true
     ): ProcurationRequest {
         if ($phone) {
             $phone = $this->createPhone($phone);
@@ -382,6 +536,7 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
         $request->setVoteOffice($voteOffice);
         $request->setElectionRounds($electionRounds);
         $request->setReason($reason);
+        $request->setRequestFromFrance($requestFromFrance);
 
         return $request;
     }
@@ -405,7 +560,9 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
         string $voteOffice,
         iterable $electionRounds,
         int $reliability = 0,
-        string $reliabilityDescription = ''
+        string $reliabilityDescription = '',
+        int $proxiesCount = 1,
+        bool $disabled = false
     ): ProcurationProxy {
         if ($phone) {
             $phone = $this->createPhone($phone);
@@ -430,6 +587,8 @@ class LoadProcurationData implements FixtureInterface, DependentFixtureInterface
         $proxy->setElectionRounds($electionRounds);
         $proxy->setReliability($reliability);
         $proxy->setReliabilityDescription($reliabilityDescription);
+        $proxy->setDisabled($disabled);
+        $proxy->setProxiesCount($proxiesCount);
 
         return $proxy;
     }

--- a/src/Entity/ProcurationRequest.php
+++ b/src/Entity/ProcurationRequest.php
@@ -72,7 +72,7 @@ class ProcurationRequest
      *
      * @var ProcurationProxy
      *
-     * @ORM\OneToOne(targetEntity="AppBundle\Entity\ProcurationProxy", mappedBy="foundRequest")
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\ProcurationProxy", inversedBy="foundRequests")
      */
     private $foundProxy;
 
@@ -310,6 +310,13 @@ class ProcurationRequest
      */
     public $recaptcha = '';
 
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", options={"default": true})
+     */
+    private $requestFromFrance = true;
+
     public function __construct()
     {
         $this->phone = static::createPhoneNumber();
@@ -338,23 +345,21 @@ class ProcurationRequest
 
     public function process(ProcurationProxy $procurationProxy = null, Adherent $procurationFoundBy = null): void
     {
-        $this->foundProxy = $procurationProxy;
         $this->foundBy = $procurationFoundBy;
         $this->processed = true;
         $this->processedAt = new \DateTimeImmutable();
 
         if ($procurationProxy) {
-            $procurationProxy->setFoundRequest($this);
+            $procurationProxy->process($this);
         }
     }
 
     public function unprocess(): void
     {
         if ($this->foundProxy instanceof ProcurationProxy) {
-            $this->foundProxy->setFoundRequest(null);
+            $this->foundProxy->unprocess($this);
         }
 
-        $this->foundProxy = null;
         $this->processed = false;
         $this->processedAt = null;
     }
@@ -674,5 +679,15 @@ class ProcurationRequest
         }
 
         return $phone;
+    }
+
+    public function isRequestFromFrance(): bool
+    {
+        return $this->requestFromFrance;
+    }
+
+    public function setRequestFromFrance(bool $requestFromFrance): void
+    {
+        $this->requestFromFrance = $requestFromFrance;
     }
 }

--- a/src/Form/Procuration/ProcurationRequestType.php
+++ b/src/Form/Procuration/ProcurationRequestType.php
@@ -68,6 +68,14 @@ class ProcurationRequestType extends AbstractProcurationType
 
             case ProcurationRequest::STEP_URI_ELECTION_ROUNDS:
                 $builder
+                    ->add('requestFromFrance', ChoiceType::class, [
+                        'label' => 'Type',
+                        'choices' => [
+                            'France' => true,
+                            'Étranger' => false,
+                        ],
+                        'expanded' => true,
+                    ])
                     ->add('electionRounds', ElectionRoundsChoiceType::class, [
                         'election_context' => $options['election_context'],
                     ])

--- a/src/Procuration/Filter/ProcurationProxyProposalFilters.php
+++ b/src/Procuration/Filter/ProcurationProxyProposalFilters.php
@@ -36,14 +36,28 @@ class ProcurationProxyProposalFilters extends ProcurationFilters
         parent::apply($qb, $alias);
 
         $status = $this->getStatus();
+
+        $qb->andWhere("$alias.disabled = :disabled");
+
         if (self::UNASSOCIATED === $status) {
-            $qb->andWhere("$alias.foundRequest IS NULL");
+            $qb
+                ->andWhere(
+                    $qb->expr()->orX(
+                        "$alias.frenchRequestAvailable != 0",
+                        "$alias.foreignRequestAvailable != 0"
+                    )
+                )
+                ->setParameter('disabled', false)
+             ;
         } elseif (self::ASSOCIATED === $status) {
-            $qb->andWhere("$alias.foundRequest IS NOT NULL");
+            $qb
+                ->andWhere("$alias.frenchRequestAvailable = 0")
+                ->andWhere("$alias.foreignRequestAvailable = 0")
+                ->setParameter('disabled', false)
+            ;
         } elseif (self::DISABLED === $status) {
             $qb
-                ->andWhere("$alias.disabled = :disabled")
-                ->setParameter('disabled', 1)
+                ->setParameter('disabled', true)
             ;
         }
 

--- a/templates/admin/procuration/proxy_list_actions.html.twig
+++ b/templates/admin/procuration/proxy_list_actions.html.twig
@@ -14,7 +14,7 @@
     </div>
 
     <div style="width: 160px; margin-top: 5px;">
-        {% if not object.foundRequest %}
+        {% if object.foundRequests.isEmpty %}
             <a href="{{ path('admin_app_procurationproxy_delete', { id: object.id }) }}" class="btn btn-xs btn-default" title="Supprimer">
                 <i class="fa fa-times" aria-hidden="true"></i>
                 Supprimer

--- a/templates/procuration/election_rounds.html.twig
+++ b/templates/procuration/election_rounds.html.twig
@@ -41,6 +41,12 @@
             <form method="post" name="app_procuration_elections">
                 {{ form_errors(procuration_form) }}
 
+                {{ form_label(procuration_form.requestFromFrance, 'Où ai-je fait ma procuration ?') }}
+                <div class="form__row form__radio-button">
+                    {{ form_errors(procuration_form.requestFromFrance) }}
+                    {{ form_widget(procuration_form.requestFromFrance, { attr: { class: 'form--full b__nudge--top-5' } }) }}
+                </div>
+
                 <h5 class="procuration__title-elections">
                     Je donne procuration pour...
                     <span class="text--small text--gray">(cocher les cases correspondantes)</span>

--- a/templates/procuration/proposal.html.twig
+++ b/templates/procuration/proposal.html.twig
@@ -43,11 +43,11 @@
 
                 if ('FR' === $('#{{ procuration_form.voteCountry.vars.id }}').val()) {
                     $(proxiesCountSelected+'_'+1).prop('checked', true);
-                    radioButtons.last().hide();
+                    radioButtons.last().addClass("hidden");
                     radioButtonsHelper.text('{{ 'procuration.vote_country.conditions.fr'|trans({}, 'validators')|e('js') }}')
                 } else {
                     $(proxiesCountSelected+'_'+2).prop('checked', true);
-                    radioButtons.last().show();
+                    radioButtons.last().removeClass("hidden");
                     radioButtonsHelper.text('{{ 'procuration.vote_country.conditions.other'|trans({}, 'validators')|e('js') }}');
                 }
             }

--- a/templates/procuration_manager/_matching_election_rounds.html.twig
+++ b/templates/procuration_manager/_matching_election_rounds.html.twig
@@ -1,8 +1,0 @@
-{% for round in proxy_rounds %}
-    {% if request is not null and request.hasElectionRound(round) %}
-        <strong>{{ round.label }}</strong>
-    {% else %}
-        {{ round.label }}
-    {% endif %}
-    <br />
-{% endfor %}

--- a/templates/procuration_manager/_proposals_list.html.twig
+++ b/templates/procuration_manager/_proposals_list.html.twig
@@ -27,18 +27,22 @@
             </span>
         </td>
         <td class="datagrid__table__col--left">
-            {{ include('procuration_manager/_matching_election_rounds.html.twig', {
-                proxy_rounds: proxy.availableRounds,
-                request: proxy.foundRequest,
-            }, with_context=false) }}
+            {{ proxy.getAvailableRoundsAsString|nl2br }}
         </td>
         <td class="datagrid__table__col--hide-mobile">
             {{ proxy.createdAt|date('d/m/Y H:i') }}
         </td>
         <td>
-            {% if proxy.foundRequest %}
-                Associé à la<br />
-                demande n°<a href="{{ path('app_procuration_manager_request', { id: proxy.foundRequest.id }) }}">{{ proxy.foundRequest.id }}</a>
+            Pour une demande faite :<br>
+            en France : {{ proxy.frenchRequestAvailable ? 'global.yes'|trans : 'global.no'|trans }} <br>
+            à l'étranger : {{ proxy.foreignRequestAvailable ? 'global.yes'|trans : 'global.no'|trans }}
+        </td>
+        <td>
+            {% if not proxy.foundRequests.isEmpty %}
+                {% for foundRequest in proxy.foundRequests %}
+                    Associé à la<br />
+                    demande n°<a href="{{ path('app_procuration_manager_request', { id: foundRequest.id }) }}">{{ foundRequest.id }}</a>
+                {% endfor %}
             {% elseif proxy.disabled %}
                 Désactivé<br />
                 (n'est plus associable)

--- a/templates/procuration_manager/_requests_list.html.twig
+++ b/templates/procuration_manager/_requests_list.html.twig
@@ -6,8 +6,13 @@
         <td class="datagrid__table__col--left">
             {{ request.data.firstNames }} {{ request.data.lastName }}<br />
             <span class="datagrid__table__col--hide-mobile">
-                <em>Lieu de vote :</em>
+                <em>Lieu de vote :</em><br>
                 {{ request.data.votePostalCode }} {{ request.data.voteCityName }} {{ request.data.voteCountry }}
+            </span>
+            <br>
+            <span class="datagrid__table__col--hide-mobile">
+                <em>Lieu de résidence :</em><br>
+                {{ request.data.postalCode }} {{ request.data.cityName }} {{ request.data.country }}
             </span>
         </td>
         <td>

--- a/templates/procuration_manager/associate.html.twig
+++ b/templates/procuration_manager/associate.html.twig
@@ -148,10 +148,7 @@
             </div>
             <div class="profile-value">
                 <span id="proxy-election">
-                    {{ include('procuration_manager/_matching_election_rounds.html.twig', {
-                        proxy_rounds: proxy.electionRounds,
-                        request: request
-                    }, with_context=false) }}
+                    {{ proxy.getAvailableRoundsAsString|nl2br }}}
                 </span>
             </div>
         </div>

--- a/templates/procuration_manager/deassociate.html.twig
+++ b/templates/procuration_manager/deassociate.html.twig
@@ -151,10 +151,7 @@
                 Disponibilités
             </div>
             <div class="profile-value">
-                {{ include('procuration_manager/_matching_election_rounds.html.twig', {
-                    proxy_rounds: proxy.availableRounds,
-                    request: proxy.foundRequest,
-                }, with_context=false) }}
+                {{ proxy.getAvailableRoundsAsString|nl2br }}
             </div>
         </div>
     </div>

--- a/templates/procuration_manager/proposals.html.twig
+++ b/templates/procuration_manager/proposals.html.twig
@@ -46,10 +46,11 @@
         <table class="datagrid__table datagrid__table--bordered-rows">
             <thead>
             <tr>
-                <th class="datagrid__table__col--hide-mobile" style="width: 100px;">Numéro</th>
+                <th class="datagrid__table__col--hide-mobile" style="width: 70px;">Numéro</th>
                 <th class="datagrid__table__col--left">Coordonnées du mandataire</th>
                 <th class="datagrid__table__col--left">Disponibilités restantes</th>
                 <th class="datagrid__table__col--hide-mobile">Date de la proposition</th>
+                <th class="datagrid__table__col--hide-mobile" style="width: 170px;">Procurations disponibles</th>
                 <th>Statut</th>
                 <th>Actions</th>
             </tr>

--- a/templates/procuration_manager/request.html.twig
+++ b/templates/procuration_manager/request.html.twig
@@ -172,10 +172,7 @@
                         Disponibilités
                     </div>
                     <div class="profile-value">
-                        {{ include('procuration_manager/_matching_election_rounds.html.twig', {
-                            proxy_rounds: request.foundProxy.electionRounds,
-                            request: request,
-                        }, with_context=false) }}
+                        {{ request.foundProxy.getAvailableRoundsAsString|nl2br }}
                     </div>
                 {% endif %}
             {% else %}
@@ -236,10 +233,7 @@
                                     {% endif %}
                                     <br />
                                     <em>Disponibilités :</em><br />
-                                    {{ include('procuration_manager/_matching_election_rounds.html.twig', {
-                                        proxy_rounds: proxy.availableRounds,
-                                        request: request,
-                                    }, with_context=false) }}
+                                    {{ proxy.getAvailableRoundsAsString|nl2br }}
                                 </td>
                                 <td class="datagrid__table__col--left">
                                     <em>Lieu de vote :</em><br />

--- a/tests/Controller/EnMarche/ProcurationControllerTest.php
+++ b/tests/Controller/EnMarche/ProcurationControllerTest.php
@@ -69,7 +69,9 @@ class ProcurationControllerTest extends WebTestCase
             'Vous avez des questions concernant les modalités du vote par procuration ? Cliquez ici !',
             trim($crawler->filter('.procuration > div > p#procuration_faq')->text())
         );
+
         $this->assertCount(1, $crawler->filter('.procuration__content a:contains("Je me porte mandataire")'));
+        $this->assertCount(1, $crawler->filter('.procuration__content div:last-child a:contains("Je donne procuration")'));
     }
 
     public function testChooseElectionOnRequest()
@@ -94,7 +96,8 @@ class ProcurationControllerTest extends WebTestCase
             'Un de nos volontaires peut porter votre voix',
             trim($crawler->filter('.procuration__content h2')->text())
         );
-        $this->assertCount(1, $crawler->filter('#election_context_elections input[type="checkbox"]'));
+
+        $this->assertCount(1, $crawler->filter('#election_context_elections > div.form__checkbox > input[type="checkbox"]'));
         $this->assertSame(
             'Élection législative partielle pour la 1ère circonscription du Val-d\'Oise',
             $crawler->filter('#election_context_elections label')->text()
@@ -186,7 +189,7 @@ class ProcurationControllerTest extends WebTestCase
     {
         $this->setElectionContext();
 
-        $initialProcurationRequestCount = 8;
+        $initialProcurationRequestCount = 13;
         $procurationRequest = new ProcurationRequest();
 
         $this->assertCurrentProcurationRequestSameAs($procurationRequest);
@@ -406,7 +409,7 @@ class ProcurationControllerTest extends WebTestCase
     {
         $this->setElectionContext(ElectionContext::ACTION_PROPOSAL);
 
-        $initialProcurationProxyCount = 6;
+        $initialProcurationProxyCount = 8;
 
         $this->assertCount($initialProcurationProxyCount, $this->procurationProxyRepostitory->findAll(), 'There should not be any proposal at the moment');
 
@@ -444,9 +447,9 @@ class ProcurationControllerTest extends WebTestCase
                 'electionRounds' => [],
                 'conditions' => true,
                 'authorization' => true,
+                'proxiesCount' => 2,
             ],
         ]));
-
         $this->isSuccessful($this->client->getResponse());
         $this->assertCount(0, $crawler->filter('.form--warning'));
         $this->assertCount(2, $errors = $crawler->filter('.form__error'));
@@ -481,6 +484,8 @@ class ProcurationControllerTest extends WebTestCase
                 'voteOffice' => 'TestOfficeName',
                 'electionRounds' => ['9'],
                 'conditions' => true,
+                'authorization' => true,
+                'proxiesCount' => 2,
             ],
         ]));
 
@@ -490,10 +495,10 @@ class ProcurationControllerTest extends WebTestCase
         $this->client->followRedirect();
 
         $this->isSuccessful($this->client->getResponse());
+
         /* @var ProcurationProxy $proposal */
         $this->assertCount($initialProcurationProxyCount + 1, $proposals = $this->procurationProxyRepostitory->findAll(), 'Procuration request should have been saved');
         $this->assertInstanceOf(ProcurationProxy::class, $proposal = end($proposals));
-
         $this->assertSame('FR', $proposal->getVoteCountry());
         $this->assertSame('92110', $proposal->getVotePostalCode());
         $this->assertSame('Clichy', $proposal->getVoteCityName());
@@ -511,7 +516,7 @@ class ProcurationControllerTest extends WebTestCase
 
     public function testProcurationRequestNotUniqueEmailBirthDate()
     {
-        $initialProcurationRequestCount = 8;
+        $initialProcurationRequestCount = 13;
 
         $this->assertCount($initialProcurationRequestCount, $this->procurationRequestRepostitory->findAll());
 
@@ -589,7 +594,7 @@ class ProcurationControllerTest extends WebTestCase
 
     public function testProcurationProposalNotUniqueEmailBirthdate()
     {
-        $initialProcurationProxyCount = 6;
+        $initialProcurationProxyCount = 8;
 
         $this->assertCount($initialProcurationProxyCount, $this->procurationProxyRepostitory->findAll(), 'There should not be any proposal at the moment');
 
@@ -629,6 +634,7 @@ class ProcurationControllerTest extends WebTestCase
                 'electionRounds' => ['9'],
                 'conditions' => true,
                 'authorization' => true,
+                'proxiesCount' => 2,
             ],
         ]));
 

--- a/tests/Controller/EnMarche/ProcurationManagerControllerTest.php
+++ b/tests/Controller/EnMarche/ProcurationManagerControllerTest.php
@@ -74,8 +74,8 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $this->isSuccessful($this->client->getResponse());
 
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
-        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 2, 'à traiter');
+        $this->assertCount(5, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 5, 'à traiter');
 
         // Request page
         $linkNode = $crawler->filter('#request-link-6');
@@ -99,31 +99,30 @@ class ProcurationManagerControllerTest extends WebTestCase
         $this->assertSame('75010 Paris 10e FR', trim($crawler->filter('#request-city')->text()));
         $this->assertSame('Pour raison de santé', trim($crawler->filter('#request-reason')->text()));
 
-        $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration/demande/3');
+        $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration/demande/12');
 
         $this->isSuccessful($this->client->getResponse());
 
         // I see request data
-        $this->assertSame('Demande de procuration n°3', trim($crawler->filter('#request-title')->text()));
+        $this->assertSame('Demande de procuration n°12', trim($crawler->filter('#request-title')->text()));
         $this->assertSame('Demande en attente', trim($crawler->filter('.procuration-manager__request__col-left h4')->text()));
-        $this->assertSame('Madame Fleur Paré', trim($crawler->filter('#request-author')->text()));
-        $this->assertSame('FleurPare@armyspy.com', trim($crawler->filter('#request-email')->text()));
-        $this->assertSame('+33 1 69 64 10 61', trim($crawler->filter('#request-phone')->text()));
-        $this->assertSame('29/01/1945', trim($crawler->filter('#request-birthdate')->text()));
-        $this->assertSame('75018 Paris 18e FR', trim($crawler->filter('#request-vote-city')->text()));
-        $this->assertSame('Aquarius', trim($crawler->filter('#request-vote-office')->text()));
-        $this->assertSame('13, rue Reine Elisabeth', trim($crawler->filter('#request-address')->text()));
-        $this->assertSame('77000 Melun FR', trim($crawler->filter('#request-city')->text()));
+        $this->assertSame('Monsieur Jean-Michel Amoitié', trim($crawler->filter('#request-author')->text()));
+        $this->assertSame('jeanmichel.amoitié@example.es', trim($crawler->filter('#request-email')->text()));
+        $this->assertSame('+44 234567891', trim($crawler->filter('#request-phone')->text()));
+        $this->assertSame('20/12/1989', trim($crawler->filter('#request-birthdate')->text()));
+        $this->assertSame('GV6H  GB', trim($crawler->filter('#request-vote-city')->text()));
+        $this->assertSame('Camden', trim($crawler->filter('#request-vote-office')->text()));
+        $this->assertSame('4Q Covent Garden', trim($crawler->filter('#request-address')->text()));
+        $this->assertSame('GV6H  FR', trim($crawler->filter('#request-city')->text()));
         $this->assertSame('Pour raison de santé', trim($crawler->filter('#request-reason')->text()));
 
         // I see request potential proxies
         $proxies = $crawler->filter('.datagrid__table tbody tr td.proxy_name strong');
 
-        $this->assertSame('Jean-Michel Carbonneau', trim($proxies->first()->text()));
-        $this->assertSame('Maxime Michaux', trim($proxies->last()->text()));
+        $this->assertSame('Jean-Michel Gastro', trim($proxies->first()->text()));
 
         // Associate the request with the proxy
-        $linkNode = $crawler->filter('#associate-link-2');
+        $linkNode = $crawler->filter('#associate-link-8');
 
         $this->assertCount(1, $linkNode);
 
@@ -132,24 +131,24 @@ class ProcurationManagerControllerTest extends WebTestCase
         $this->isSuccessful($this->client->getResponse());
 
         // I see proxy data
-        $this->assertSame('Monsieur Jean-Michel Carbonneau', trim($crawler->filter('#proxy-author')->text()));
-        $this->assertSame('jm.carbonneau@example.fr', trim($crawler->filter('#proxy-email')->text()));
-        $this->assertSame('+33 9 88 77 66 55', trim($crawler->filter('#proxy-phone')->text()));
-        $this->assertSame('17/01/1974', trim($crawler->filter('#proxy-birthdate')->text()));
-        $this->assertSame('75018 Paris 18e FR', trim($crawler->filter('#proxy-vote-city')->text()));
-        $this->assertSame('Lycée général Zola', trim($crawler->filter('#proxy-vote-office')->text()));
-        $this->assertSame('14 rue Jules Ferry', trim($crawler->filter('#proxy-address')->text()));
-        $this->assertSame('75018 Paris 20e FR', trim($crawler->filter('#proxy-city')->text()));
+        $this->assertSame('Monsieur Jean-Michel Gastro', trim($crawler->filter('#proxy-author')->text()));
+        $this->assertSame('jeanmichel.gastro@example.es', trim($crawler->filter('#proxy-email')->text()));
+        $this->assertSame('+44 234567891', trim($crawler->filter('#proxy-phone')->text()));
+        $this->assertSame('21/12/1989', trim($crawler->filter('#proxy-birthdate')->text()));
+        $this->assertSame('GV6H  GB', trim($crawler->filter('#proxy-vote-city')->text()));
+        $this->assertSame('Camden', trim($crawler->filter('#proxy-vote-office')->text()));
+        $this->assertSame('4Q Covent Garden', trim($crawler->filter('#proxy-address')->text()));
+        $this->assertSame('GV6H  FR', trim($crawler->filter('#proxy-city')->text()));
 
         $this->client->submit($crawler->filter('form[name=app_associate]')->form());
 
-        $this->assertClientIsRedirectedTo('/espace-responsable-procuration/demande/3', $this->client);
+        $this->assertClientIsRedirectedTo('/espace-responsable-procuration/demande/12', $this->client);
 
         $crawler = $this->client->followRedirect();
 
         $this->isSuccessful($this->client->getResponse());
 
-        $this->assertSame('Demande associée à Jean-Michel Carbonneau', trim($crawler->filter('.procuration-manager__request__col-right h4')->text()));
+        $this->assertSame('Demande associée à Jean-Michel Gastro', trim($crawler->filter('.procuration-manager__request__col-right h4')->text()));
 
         // Deassociate
         $linkNode = $crawler->filter('#request-deassociate');
@@ -162,7 +161,7 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $this->client->submit($crawler->filter('form[name=app_deassociate]')->form());
 
-        $this->assertClientIsRedirectedTo('/espace-responsable-procuration/demande/3', $this->client);
+        $this->assertClientIsRedirectedTo('/espace-responsable-procuration/demande/12', $this->client);
 
         $crawler = $this->client->followRedirect();
 
@@ -172,8 +171,7 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $proxies = $crawler->filter('.datagrid__table tbody tr td.proxy_name strong');
 
-        $this->assertSame('Jean-Michel Carbonneau', trim($proxies->first()->text()));
-        $this->assertSame('Maxime Michaux', trim($proxies->last()->text()));
+        $this->assertSame('Jean-Michel Gastro', trim($proxies->first()->text()));
     }
 
     public function testProcurationManagerProxiesList()
@@ -183,10 +181,11 @@ class ProcurationManagerControllerTest extends WebTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration/mandataires');
 
         $this->isSuccessful($this->client->getResponse());
-        $this->assertProcurationTotalCount($crawler, self::SUBJECT_PROPOSAL, 2, 'disponible');
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_PROPOSAL, 3, 'disponible');
+        $this->assertCount(3, $crawler->filter('.datagrid__table tbody tr'));
         $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Léa Bouquet")'));
         $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Emmanuel Harquin")'));
+        $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Jean-Michel Gastro")'));
     }
 
     public function testProcurationManagerProxiesListAssociated()
@@ -208,8 +207,8 @@ class ProcurationManagerControllerTest extends WebTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration');
 
         $this->isSuccessful($this->client->getResponse());
-        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 2, 'à traiter');
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 5, 'à traiter');
+        $this->assertCount(5, $crawler->filter('.datagrid__table tbody tr'));
 
         $formValues = [
             ProcurationRequestFilters::PARAMETER_COUNTRY => null,
@@ -220,7 +219,7 @@ class ProcurationManagerControllerTest extends WebTestCase
         $form = $crawler->selectButton('Filtrer')->form();
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationRequestFilters::PARAMETER_COUNTRY => 'GB']));
 
-        $this->assertCount(0, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(3, $crawler->filter('.datagrid__table tbody tr'));
 
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationRequestFilters::PARAMETER_COUNTRY => 'FR']));
 
@@ -244,11 +243,11 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationRequestFilters::PARAMETER_ELECTION_ROUND => 9]));
 
-        $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(4, $crawler->filter('.datagrid__table tbody tr'));
 
         $crawler = $this->client->click($crawler->selectLink('Annuler')->link());
 
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(5, $crawler->filter('.datagrid__table tbody tr'));
     }
 
     public function testProcurationManagerRequestsListProcessed()
@@ -258,9 +257,10 @@ class ProcurationManagerControllerTest extends WebTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration?status=processed');
 
         $this->isSuccessful($this->client->getResponse());
-        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 1, 'traitée');
-        $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_REQUEST, 2, 'traitée');
+        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
         $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Alice Delavega")'));
+        $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Jean Dell")'));
     }
 
     public function testFilterProcurationProxyProposalsList()
@@ -270,8 +270,8 @@ class ProcurationManagerControllerTest extends WebTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration/mandataires');
 
         $this->isSuccessful($this->client->getResponse());
-        $this->assertProcurationTotalCount($crawler, self::SUBJECT_PROPOSAL, 2, 'disponible');
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_PROPOSAL, 3, 'disponible');
+        $this->assertCount(3, $crawler->filter('.datagrid__table tbody tr'));
 
         $formValues = [
             ProcurationProxyProposalFilters::PARAMETER_COUNTRY => null,
@@ -282,7 +282,7 @@ class ProcurationManagerControllerTest extends WebTestCase
         $form = $crawler->selectButton('Filtrer')->form();
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationProxyProposalFilters::PARAMETER_COUNTRY => 'GB']));
 
-        $this->assertCount(0, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
 
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationProxyProposalFilters::PARAMETER_COUNTRY => 'FR']));
 
@@ -306,11 +306,23 @@ class ProcurationManagerControllerTest extends WebTestCase
 
         $crawler = $this->client->submit($form, array_merge($formValues, [ProcurationProxyProposalFilters::PARAMETER_ELECTION_ROUND => 10]));
 
-        $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
 
         $crawler = $this->client->click($crawler->selectLink('Annuler')->link());
 
-        $this->assertCount(2, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(3, $crawler->filter('.datagrid__table tbody tr'));
+    }
+
+    public function testProcurationManagerProxiesListDisabled()
+    {
+        $this->authenticateAsAdherent($this->client, 'luciole1989@spambox.fr');
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/espace-responsable-procuration/mandataires?status=disabled');
+
+        $this->isSuccessful($this->client->getResponse());
+        $this->assertProcurationTotalCount($crawler, self::SUBJECT_PROPOSAL, 1, 'désactivée');
+        $this->assertCount(1, $crawler->filter('.datagrid__table tbody tr'));
+        $this->assertCount(1, $crawler->filter('.datagrid__table td:contains("Annie Versaire")'));
     }
 
     protected function setUp()

--- a/tests/Entity/ProcurationProxyTest.php
+++ b/tests/Entity/ProcurationProxyTest.php
@@ -10,22 +10,104 @@ use PHPUnit\Framework\TestCase;
 
 class ProcurationProxyTest extends TestCase
 {
-    public function testGetAvailableRounds()
-    {
-        $round1 = $this->createMock(ElectionRound::class);
-        $round2 = $this->createMock(ElectionRound::class);
-        $round3 = $this->createMock(ElectionRound::class);
-
-        $request = $this->createMock(ProcurationRequest::class);
-        $request
-            ->expects($this->exactly(3))
-            ->method('hasElectionRound')
-            ->withConsecutive($round1, $round2, $round3)
-            ->willReturnOnConsecutiveCalls(true, false, true)
+    /**
+     * @dataProvider provideTestCases
+     */
+    public function testGetAvailableRoundsCount(
+        int $proxiesCount,
+        int $requestElectionRoundsCount,
+        int $proxyElectionRoundsCount,
+        int $expectedAvailableElectionRoundsCount
+    ) {
+        $maxElectionRound = $requestElectionRoundsCount > $proxyElectionRoundsCount
+            ? $requestElectionRoundsCount
+            : $proxyElectionRoundsCount
         ;
 
+        $electionRounds = [];
+        for ($i = 0; $i < $maxElectionRound; ++$i) {
+            array_push($electionRounds, new ElectionRound());
+        }
+
+        $request = new ProcurationRequest();
+        $request->setElectionRounds(\array_slice($electionRounds, 0, $requestElectionRoundsCount));
+
         $proxy = new ProcurationProxy(null);
-        $proxy->setFoundRequest($request);
+        $proxy->setProxiesCount($proxiesCount);
+        $proxy->process($request);
+        $proxy->setElectionRounds(\array_slice($electionRounds, 0, $proxyElectionRoundsCount));
+
+        $this->assertCount($expectedAvailableElectionRoundsCount, $available = $proxy->getAvailableRounds());
+    }
+
+    public function provideTestCases(): \Generator
+    {
+        // For one request max by procuration proxy
+        yield 'One election for the request and one for the proxy should not give available election' => [
+            1, 1, 1, 0,
+        ];
+        yield 'One election for the request and two for the proxy should give one available election' => [
+            1, 1, 2, 1,
+        ];
+        yield 'One election for the request and three for the proxy should give two available elections' => [
+            1, 1, 3, 2,
+        ];
+        yield 'Two elections for the request and two for the proxy should not give available election' => [
+            1, 2, 2, 0,
+        ];
+        yield 'Two elections for the request and three for the proxy should give one available election' => [
+            1, 2, 3, 1,
+        ];
+        yield 'Three elections for the request and three for the proxy should not give available election' => [
+            1, 3, 3, 0,
+        ];
+
+        // For two requests max by procuration proxy
+        yield 'One election for the request and two for the proxy should give three available elections' => [
+            2, 1, 2, 3,
+        ];
+        yield 'One election for the request and three for the proxy should give five available elections' => [
+            2, 1, 3, 5,
+        ];
+        yield 'Two elections for the request and two for the proxy should give two available elections' => [
+            2, 2, 2, 2,
+        ];
+        yield 'Two elections for the request and three for the proxy should give four available elections' => [
+            2, 2, 3, 4,
+        ];
+        yield 'Three elections for the request and three for the proxy should give three available elections' => [
+            2, 3, 3, 3,
+        ];
+
+        // For three requests max by procuration proxy
+        yield 'One election for the request and two for the proxy should give five available elections' => [
+            3, 1, 2, 5,
+        ];
+        yield 'One election for the request and three for the proxy should give height available elections' => [
+            3, 1, 3, 8,
+        ];
+        yield 'Two elections for the request and two for the proxy should give four available elections' => [
+            3, 2, 2, 4,
+        ];
+        yield 'Two elections for the request and three for the proxy should give seven available elections' => [
+            3, 2, 3, 7,
+        ];
+        yield 'Three elections for the request and three for the proxy should give six available elections' => [
+            3, 3, 3, 6,
+        ];
+    }
+
+    public function testGetAvailableRounds()
+    {
+        $round1 = new ElectionRound();
+        $round2 = new ElectionRound();
+        $round3 = new ElectionRound();
+
+        $request = new ProcurationRequest();
+        $request->setElectionRounds([$round1, $round3]);
+
+        $proxy = new ProcurationProxy(null);
+        $proxy->process($request);
         $proxy->setElectionRounds([$round1, $round2, $round3]);
 
         $this->assertCount(1, $available = $proxy->getAvailableRounds());

--- a/tests/Entity/ProcurationRequestTest.php
+++ b/tests/Entity/ProcurationRequestTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\AppBundle\Entity;
+
+use AppBundle\Entity\ProcurationProxy;
+use AppBundle\Entity\ProcurationRequest;
+use PHPUnit\Framework\TestCase;
+
+class ProcurationRequestTest extends TestCase
+{
+    /**
+     * @dataProvider provideTestCases
+     */
+    public function testFrenchRequestProcess(
+        int $proxiesCount,
+        string $proxyVoteCountry,
+        bool $requestFromFrance,
+        string $requestVoteCountry,
+        bool $isFrenchRequestAvailable,
+        bool $isForeignRequestAvailable
+    ) {
+        $proxy = new ProcurationProxy(null);
+        $proxy->setVoteCountry($proxyVoteCountry);
+        $proxy->setProxiesCount($proxiesCount);
+
+        $request = new ProcurationRequest();
+        $request->setVoteCountry($requestVoteCountry);
+        $request->setRequestFromFrance($requestFromFrance);
+
+        $request->process($proxy);
+
+        $this->assertEquals($isFrenchRequestAvailable, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals($isForeignRequestAvailable, $proxy->isForeignRequestAvailable());
+    }
+
+    public function provideTestCases(): \Generator
+    {
+        // For one request max by procuration proxy
+        yield 'An associated french proxy with a french request made in France should result with no more availability' => [
+            1, 'FR', 1, 'FR', false, false,
+        ];
+        yield 'An associated french proxy with a french request not made in France should result with no more availability' => [
+            1, 'FR', 0, 'FR', false, false,
+        ];
+        yield 'An associated french proxy with a foreign request made in France should result with no more availability' => [
+            1, 'FR', 1, 'GB', false, false,
+        ];
+        yield 'An associated french proxy with a foreign request not made in France should result with no more availability' => [
+            1, 'FR', 0, 'GB', false, false,
+        ];
+        yield 'An associated foreign proxy with a foreign request made in France should result with no more availability' => [
+            1, 'GB', 1, 'GB', false, false,
+        ];
+        yield 'An associated foreign proxy with a foreign request not made in France should result with no more availability' => [
+            1, 'GB', 0, 'GB', false, false,
+        ];
+        yield 'An associated foreign proxy with a french request made in France should result with no more availability' => [
+            1, 'GB', 1, 'FR', false, false,
+        ];
+        yield 'An associated foreign proxy with a french request not made in France should result with no more availability' => [
+            1, 'GB', 0, 'FR', false, false,
+        ];
+
+        // For two requests max by procuration proxy
+        yield 'An associated french proxy with a french request made in France should result with one foreign availability' => [
+            2, 'FR', 1, 'FR', false, true,
+        ];
+        yield 'An associated french proxy with a french request not made in France should result with one foreign availability' => [
+            2, 'FR', 0, 'FR', false, true,
+        ];
+        yield 'An associated french proxy with a foreign request made in France should result with one foreign availability' => [
+            2, 'FR', 1, 'GB', false, true,
+        ];
+        yield 'An associated french proxy with a foreign request not made in France should result with one foreign availability' => [
+            2, 'FR', 0, 'GB', false, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request made in France should result with one french and one foreign availability' => [
+            2, 'GB', 1, 'GB', true, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request not made in France should result with one french and one foreign availability' => [
+            2, 'GB', 0, 'GB', true, true,
+        ];
+        yield 'An associated french proxy with a french request not made in France should result with one foreign availability' => [
+            2, 'FR', 0, 'FR', false, true,
+        ];
+        yield 'An associated french proxy with a french request made in France should result with one foreign availability' => [
+            2, 'FR', 1, 'FR', false, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request not made in France should result with both french and foreign availability' => [
+            2, 'GB', 0, 'GB', true, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request made in France should result with both french and foreign availability' => [
+            2, 'GB', 1, 'GB', true, true,
+        ];
+
+        // For three requests max by procuration proxy
+        yield 'An associated french proxy with a french request made in France should result with one foreign availability' => [
+            3, 'FR', 1, 'FR', false, true,
+        ];
+        yield 'An associated french proxy with a french request not made in France should result with one foreign availability' => [
+            3, 'FR', 0, 'FR', false, true,
+        ];
+        yield 'An associated french proxy with a foreign request made in France should result with one foreign availability' => [
+            3, 'FR', 1, 'GB', false, true,
+        ];
+        yield 'An associated french proxy with a foreign request not made in France should result with one foreign availability' => [
+            3, 'FR', 0, 'GB', false, true,
+        ];
+        yield 'An associated foreign proxy with a french request made in France should result with both french and foreign availability' => [
+            3, 'GB', 1, 'FR', true, true,
+        ];
+        yield 'An associated foreign proxy with a french request not made in France should result with both french and foreign availability' => [
+            3, 'GB', 0, 'FR', true, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request made in France should result with both french and foreign availability' => [
+            3, 'GB', 1, 'GB', true, true,
+        ];
+        yield 'An associated foreign proxy with a foreign request not made in France should result with both french and foreign availability' => [
+            3, 'GB', 0, 'GB', true, true,
+        ];
+    }
+
+    public function testProcessAndUnProcessWithOneProxyCount()
+    {
+        $proxy = new ProcurationProxy(null);
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(0);
+
+        $request->process($proxy);
+
+        $this->assertEquals(1, $proxy->getFoundRequests()->count());
+        $this->assertEquals(false, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(false, $proxy->isForeignRequestAvailable());
+
+        $request->unprocess();
+
+        $this->assertEquals(0, $proxy->getFoundRequests()->count());
+        $this->assertEquals(true, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(true, $proxy->isForeignRequestAvailable());
+    }
+
+    public function testProcessAndUnProcessWithForeignMultiProxyCount()
+    {
+        $proxy = new ProcurationProxy(null);
+        $proxy->setProxiesCount(3);
+        $proxy->setVoteCountry('GB');
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(0);
+        $request->setVoteCountry('GB');
+
+        $request->process($proxy);
+
+        $this->assertEquals(1, $proxy->getFoundRequests()->count());
+        $this->assertEquals(true, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(true, $proxy->isForeignRequestAvailable());
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(0);
+        $request->setVoteCountry('GB');
+
+        $request->process($proxy);
+
+        $this->assertEquals(2, $proxy->getFoundRequests()->count());
+        $this->assertEquals(true, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(true, $proxy->isForeignRequestAvailable());
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(0);
+        $request->setVoteCountry('GB');
+
+        $request->process($proxy);
+
+        $this->assertEquals(3, $proxy->getFoundRequests()->count());
+        $this->assertEquals(false, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(false, $proxy->isForeignRequestAvailable());
+
+        $request->unprocess();
+
+        $this->assertEquals(2, $proxy->getFoundRequests()->count());
+        $this->assertEquals(true, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(true, $proxy->isForeignRequestAvailable());
+    }
+
+    public function testProcessAndUnProcessWithFrenchMultiProxyCount()
+    {
+        $proxy = new ProcurationProxy(null);
+        $proxy->setVoteCountry('GB');
+        $proxy->setProxiesCount(2);
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(1);
+        $proxy->setVoteCountry('GB');
+
+        $request->process($proxy);
+
+        $this->assertEquals(1, $proxy->getFoundRequests()->count());
+        $this->assertEquals(true, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(true, $proxy->isForeignRequestAvailable());
+
+        $request = new ProcurationRequest();
+        $request->setRequestFromFrance(0);
+        $request->setVoteCountry('GB');
+
+        $request->process($proxy);
+
+        $this->assertEquals(2, $proxy->getFoundRequests()->count());
+        $this->assertEquals(false, $proxy->isFrenchRequestAvailable());
+        $this->assertEquals(false, $proxy->isForeignRequestAvailable());
+    }
+}

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -207,8 +207,8 @@ procuration.proposal_conditions.required: Vous devez vous engager à voter selon
 
 procuration.authorization.required: Vous devez nous autoriser à utiliser ces informations dans le cadre du processus de procuration.
 
-procuration.vote_country.conditions.fr: Attention, vous ne pouvez être mandataire que pour une seule procuration établie en France et une établie à l'étranger.
-procuration.vote_country.conditions.other: Attention, vous ne pouvez être mandataire que pour une seule procuration établie en France et deux établies à l'étranger.
+procuration.vote_country.conditions.fr: Attention, vous ne pouvez être mandataire que pour deux procurations dont une seule maximum établie en France.
+procuration.vote_country.conditions.other: Attention, vous ne pouvez être mandataire que pour trois procurations dont une seule maximum établie en France.
 procuration.vote_country.conditions.conditions: Merci de bien vouloir remplir la condition ci-dessous.
 
 #


### PR DESCRIPTION
A procuration proxy can now have more than one request associated (OneToOne => OneToMany) based on those two rules :
- A French proxy (voting in France) can receive max one request from France or two requests made in another country or one of each.
- A foreign proxy (voting in another country) can receive one request from France, or one in France and one (or two) from another country, than France or 3 from another chountry than France. 

_You will have all details here (in french) =>_ https://www.service-public.fr/particuliers/vosdroits/F1604

Severals changes on the front

**First, on the new proxy form (`procuration/je-propose`)**

![fr](https://user-images.githubusercontent.com/5656168/54376825-2d3b5000-4684-11e9-9bb5-cb0369e9f973.png)

![non fr](https://user-images.githubusercontent.com/5656168/54376837-30ced700-4684-11e9-86aa-a2314621099e.png)

_from #3415 the only thing that changed is the rule saying that a foreign proxy can take 3 requests from another country._

**Second, the request form (`procuration/je-demande/ma-procuration`)**

![where](https://user-images.githubusercontent.com/5656168/54376985-899e6f80-4684-11e9-87b8-f6dc667c5c9a.png)

_Here the user have to say where he made his request (in France or in another country)_

Some other change have been made on the back side

**First, relation one to one / one to many**

```php
/**
     * The associated found request(s).
     *
     * @var ArrayCollection
     *
     * @ORM\OneToMany(targetEntity="AppBundle\Entity\ProcurationRequest", mappedBy="foundProxy")
     */
    private $foundRequests;
```

A proxy can now have multiple requests
A request can only have one proxy

```php
/**
     * The associated found proxy.
     *
     * @var ProcurationProxy
     *
     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\ProcurationProxy", inversedBy="foundRequests")
     */
    private $foundProxy;
```

**Then, on the `ProcurationProxy` entity, booleans have been added to apply the new rule**

```php
/**
     * @var bool
     *
     * @ORM\Column(type="boolean", options={"default": true})
     */
    public $frenchRequestAvailable = true;

    /**
     * @var bool
     *
     * @ORM\Column(type="boolean", options={"default": true})
     */
    public $foreignRequestAvailable = true;
```

those two booleans will be drive by the `process` and `unprocess` functions called when the procuration manager will associate or disassociate a proxy and a request.
I choose boolean because I can centralize the new rules in one place and use them in the repository to ease proxy responsable space navigation.

**Moreover we have the rules that apply this feature in the function**

```php
public function process(ProcurationProxy $procurationProxy = null, Adherent $procurationFoundBy = null): void
    {
        $this->foundProxy = $procurationProxy;
        $this->foundBy = $procurationFoundBy;
        $this->processed = true;
        $this->processedAt = new \DateTimeImmutable();

        if ($procurationProxy) {
            $proxiesUsedCount = $procurationProxy->getFoundRequests()->count();
            $remainingProxiesCount = $procurationProxy->proxiesCount - $proxiesUsedCount;

            if (1 === $remainingProxiesCount) {
                $procurationProxy->setFrenchRequestAvailable(false);
                $procurationProxy->setForeignRequestAvailable(false);
            } else {
                if ('FR' === $procurationProxy->getVoteCountry()) {
                    $procurationProxy->setFrenchRequestAvailable(false);
                } else {
                    if (2 === $remainingProxiesCount && !$procurationProxy->isFrenchRequestAvailable()) {
                        $procurationProxy->setForeignRequestAvailable(false);
                    }
                }
            }

            $procurationProxy->addFoundRequest($this);
        }
    }

public function unprocess(): void
    {
        if ($this->foundProxy instanceof ProcurationProxy) {
            $proxiesUsedCount = $this->foundProxy->getFoundRequests()->count();
            $remainingProxiesCount = $this->foundProxy->proxiesCount - $proxiesUsedCount;

            if (1 === $this->foundProxy->getFoundRequests()->count()) {
                $this->foundProxy->setFrenchRequestAvailable(true);
                $this->foundProxy->setForeignRequestAvailable(true);
            } else {
                if ('FR' === $this->foundProxy->getVoteCountry()) {
                    $this->foundProxy->setFrenchRequestAvailable(true);
                } else {
                    $this->foundProxy->setForeignRequestAvailable(true);

                    if (0 === $remainingProxiesCount) {
                        $this->foundProxy->setFrenchRequestAvailable(true);
                    }
                }
            }

            $this->foundProxy->removeFoundRequest($this);
        }

        $this->foundProxy = null;
        $this->processed = false;
        $this->processedAt = null;
    }
```
