### PR TITLE
Add autocomplete on new proxy and request proposal

### DIFF
--- a/front/app.js
+++ b/front/app.js
@@ -222,6 +222,18 @@ class App {
             module.default(this.get('api'), messageId, synchronized, recipientCount);
         });
     }
+
+    runProcurationProxy() {
+        System.import('pages/procuration_proxy').catch((error) => { throw error; }).then((module) => {
+            module.default();
+        });
+    }
+
+    runProcurationRequest() {
+        System.import('pages/procuration_request').catch((error) => { throw error; }).then((module) => {
+            module.default();
+        });
+    }
 }
 
 window.App = new App();

--- a/front/pages/procuration_proxy.js
+++ b/front/pages/procuration_proxy.js
@@ -1,0 +1,16 @@
+import AutocompletedAddressForm from '../services/address/AutocompletedAddressForm';
+import AddressObject from '../services/address/AddressObject';
+
+export default () => {
+    (new AutocompletedAddressForm(
+        dom('.address-autocomplete'),
+        dom('.address-block'),
+        new AddressObject(
+            dom('#app_procuration_proposal_address'),
+            dom('#app_procuration_proposal_postalCode'),
+            dom('#app_procuration_proposal_cityName'),
+            null,
+            dom('#app_procuration_proposal_country')
+        )
+    )).buildWidget();
+};

--- a/front/pages/procuration_request.js
+++ b/front/pages/procuration_request.js
@@ -1,0 +1,16 @@
+import AutocompletedAddressForm from '../services/address/AutocompletedAddressForm';
+import AddressObject from '../services/address/AddressObject';
+
+export default () => {
+    (new AutocompletedAddressForm(
+        dom('.address-autocomplete'),
+        dom('.address-block'),
+        new AddressObject(
+            dom('#app_procuration_request_address'),
+            dom('#app_procuration_request_postalCode'),
+            dom('#app_procuration_request_cityName'),
+            null,
+            dom('#app_procuration_request_country')
+        )
+    )).buildWidget();
+};

--- a/templates/procuration/profile.html.twig
+++ b/templates/procuration/profile.html.twig
@@ -3,14 +3,12 @@
 {% block page_title 'Mes coordonnées - Procuration' %}
 
 {% block javascripts %}
+    {% if google_maps_api_key %}
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&amp;libraries=places" async defer></script>
+    {% endif %}
     <script type="text/javascript">
         Kernel.onLoad(function() {
-            App.createAddressSelector(
-                '{{ procuration_form.country.vars.id }}',
-                '{{ procuration_form.postalCode.vars.id }}',
-                '{{ procuration_form.city.vars.id }}',
-                '{{ procuration_form.cityName.vars.id }}'
-            );
+            App.runProcurationRequest();
         });
     </script>
 {% endblock %}
@@ -48,25 +46,34 @@
                 </div>
 
                 <div id="membership-address">
-                    <div class="l__row l__row--h-stretch register__form--full">
-                        {{ form_widget(procuration_form.address, { attr: { placeholder: 'Adresse postale' } }) }}
-                        {{ form_errors(procuration_form.address) }}
+                    <div>
+                        <div class="address-autocomplete"></div>
+                        <p class="text--smallest text--muted text--left visually-hidden" id="address-autocomplete-help-message">
+                            Nous n'avons pas reconnu votre adresse, veuillez cliquer <a href="#">ici</a> pour pouvoir la renseigner librement.
+                        </p>
                     </div>
 
-                    <div class="l__row l__row--top l__row--h-stretch l__mobile--col">
-                        <div class="register__form__country register__form--third">
-                            {{ form_widget(procuration_form.country) }}
-                            {{ form_errors(procuration_form.country) }}
+                    <div class="address-block">
+                        <div class="l__row l__row--h-stretch register__form--full">
+                            {{ form_widget(procuration_form.address, { attr: { placeholder: 'Adresse postale' } }) }}
+                            {{ form_errors(procuration_form.address) }}
                         </div>
 
-                        <div class="register__form__zip_code register__form--third">
-                            {{ form_widget(procuration_form.postalCode, { attr: { placeholder: 'Code postal' } }) }}
-                        </div>
+                        <div class="l__row l__row--top l__row--h-stretch l__mobile--col">
+                            <div class="register__form__country register__form--third">
+                                {{ form_widget(procuration_form.country) }}
+                                {{ form_errors(procuration_form.country) }}
+                            </div>
 
-                        <div class="register__form__city register__form--third">
-                            {{ form_widget(procuration_form.city, { attr: { class: 'register__form__city' } }) }}
-                            {{ form_widget(procuration_form.cityName, { attr: { class: 'register__form__city_name', placeholder: 'Ville' } }) }}
-                            {{ form_errors(procuration_form.city) }}
+                            <div class="register__form__zip_code register__form--third">
+                                {{ form_widget(procuration_form.postalCode, { attr: { placeholder: 'Code postal' } }) }}
+                            </div>
+
+                            <div class="register__form__city register__form--third">
+                                {{ form_widget(procuration_form.city, { attr: { class: 'register__form__city' } }) }}
+                                {{ form_widget(procuration_form.cityName, { attr: { class: 'register__form__city_name', placeholder: 'Ville' } }) }}
+                                {{ form_errors(procuration_form.city) }}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/templates/procuration/proposal.html.twig
+++ b/templates/procuration/proposal.html.twig
@@ -13,16 +13,14 @@
 {% block footer '' %}
 
 {% block javascripts %}
+    {% if google_maps_api_key %}
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&amp;libraries=places" async defer></script>
+    {% endif %}
     <script src={{ asset('bundles/sonataadmin/vendor/jquery/dist/jquery.min.js') }}></script>
     <script src="https://www.google.com/recaptcha/api.js"></script>
     <script type="text/javascript">
         Kernel.onLoad(function() {
-            App.createAddressSelector(
-                '{{ procuration_form.country.vars.id }}',
-                '{{ procuration_form.postalCode.vars.id }}',
-                '{{ procuration_form.city.vars.id }}',
-                '{{ procuration_form.cityName.vars.id }}'
-            );
+            App.runProcurationProxy();
 
             App.createVoteLocationSelector(
                 '{{ procuration_form.voteCountry.vars.id }}',
@@ -101,25 +99,34 @@
                             </div>
                         </div>
 
-                        <div class="l__row l__row--h-stretch register__form--full">
-                            {{ form_widget(procuration_form.address, { attr: { placeholder: 'Mon adresse de résidence' } }) }}
-                            {{ form_errors(procuration_form.address) }}
+                        <div class="form__row">
+                            <div class="address-autocomplete"></div>
+                            <p class="text--smallest text--muted text--left visually-hidden" id="address-autocomplete-help-message">
+                                Nous n'avons pas reconnu votre adresse, veuillez cliquer <a href="#">ici</a> pour pouvoir la renseigner librement.
+                            </p>
                         </div>
 
-                        <div class="l__row l__row--top l__row--h-stretch l__mobile--col">
-                            <div class="register__form__country register__form--third">
-                                {{ form_widget(procuration_form.country) }}
-                                {{ form_errors(procuration_form.country) }}
+                        <div class="address-block">
+                            <div class="l__row l__row--h-stretch register__form--full">
+                                {{ form_widget(procuration_form.address, { attr: { placeholder: 'Mon adresse de résidence' } }) }}
+                                {{ form_errors(procuration_form.address) }}
                             </div>
 
-                            <div id="vote-row-postal-code" class="register__form__zip_code register__form--third">
-                                {{ form_widget(procuration_form.postalCode, { attr: { placeholder: 'Code postal' } }) }}
-                            </div>
+                            <div class="l__row l__row--top l__row--h-stretch l__mobile--col">
+                                <div class="register__form__country register__form--third">
+                                    {{ form_widget(procuration_form.country) }}
+                                    {{ form_errors(procuration_form.country) }}
+                                </div>
 
-                            <div class="register__form__city register__form--third">
-                                {{ form_widget(procuration_form.city, { attr: { class: 'register__form__city'} }) }}
-                                {{ form_widget(procuration_form.cityName, { attr: { class: 'register__form__city_name', placeholder: 'Ville' } }) }}
-                                {{ form_errors(procuration_form.city) }}
+                                <div id="vote-row-postal-code" class="register__form__zip_code register__form--third">
+                                    {{ form_widget(procuration_form.postalCode, { attr: { placeholder: 'Code postal' } }) }}
+                                </div>
+
+                                <div class="register__form__city register__form--third">
+                                    {{ form_widget(procuration_form.city, { attr: { class: 'register__form__city'} }) }}
+                                    {{ form_widget(procuration_form.cityName, { attr: { class: 'register__form__city_name', placeholder: 'Ville' } }) }}
+                                    {{ form_errors(procuration_form.city) }}
+                                </div>
                             </div>
                         </div>
 


### PR DESCRIPTION
This feature add the google autocomplete places on both procuration form (new proxy and new request).
It will hide `address-block` composed with `address`, `city`, `postalCode` and `country`, display an input with `change` event on it, then, if found, fill & show all previous hidden fields. 

I add to removed the form validation process that send a `POST` to `/api/form/validation/{formType}` because both forms are different than the one from donation and registration (new adherent)  
