### PR TITLE
[PHP CS Fixer] Remove method annotations

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -27,6 +27,7 @@ return PhpCsFixer\Config::create()
         'PedroTroller/useless_comment' => true,
         'App/doctrine_migration_clean' => true,
         'App/sensio_to_symfony_route' => true,
+        'App/method_to_route_annotation' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)
@@ -37,5 +38,6 @@ return PhpCsFixer\Config::create()
         new PedroTroller\CS\Fixer\Comment\UselessCommentFixer,
         new AppBundle\Fixer\DoctrineMigrationCleanFixer,
         new AppBundle\Fixer\SensioToSymfonyRouteFixer,
+        new AppBundle\Fixer\MethodToRouteAnnotationFixer,
     ])
 ;

--- a/src/Controller/Admin/AdminAdherentController.php
+++ b/src/Controller/Admin/AdminAdherentController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller\Admin;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -12,8 +11,7 @@ class AdminAdherentController extends Controller
     /**
      * Exit impersonation.
      *
-     * @Route("/impersonation/exit", name="app_admin_impersonation_exit")
-     * @Method("GET")
+     * @Route("/impersonation/exit", name="app_admin_impersonation_exit", methods={"GET"})
      */
     public function exitImpersonationAction(): Response
     {

--- a/src/Controller/Admin/AdminCitizenProjectController.php
+++ b/src/Controller/Admin/AdminCitizenProjectController.php
@@ -8,7 +8,6 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Entity\CitizenProject;
 use AppBundle\Exception\BaseGroupException;
 use AppBundle\Exception\CitizenProjectMembershipException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,8 +24,7 @@ class AdminCitizenProjectController extends Controller
     /**
      * Approves the citizen project.
      *
-     * @Route("/{id}/approve", name="app_admin_citizenproject_approve")
-     * @Method("GET")
+     * @Route("/{id}/approve", name="app_admin_citizenproject_approve", methods={"GET"})
      */
     public function approveAction(CitizenProject $citizenProject): Response
     {
@@ -43,8 +41,7 @@ class AdminCitizenProjectController extends Controller
     /**
      * Refuses the citizen project.
      *
-     * @Route("/{id}/refuse", name="app_admin_citizenproject_refuse")
-     * @Method("GET")
+     * @Route("/{id}/refuse", name="app_admin_citizenproject_refuse", methods={"GET"})
      */
     public function refuseAction(CitizenProject $citizenProject): Response
     {
@@ -59,8 +56,7 @@ class AdminCitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{id}/members", name="app_admin_citizenproject_members")
-     * @Method("GET")
+     * @Route("/{id}/members", name="app_admin_citizenproject_members", methods={"GET"})
      */
     public function membersAction(CitizenProject $citizenProject, CitizenProjectManager $manager): Response
     {
@@ -71,8 +67,7 @@ class AdminCitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{citizenProject}/members/{adherent}/set-privilege/{privilege}", name="app_admin_citizenproject_change_privilege")
-     * @Method("GET")
+     * @Route("/{citizenProject}/members/{adherent}/set-privilege/{privilege}", name="app_admin_citizenproject_change_privilege", methods={"GET"})
      */
     public function changePrivilegeAction(
         Request $request,

--- a/src/Controller/Admin/AdminCommitteeController.php
+++ b/src/Controller/Admin/AdminCommitteeController.php
@@ -10,7 +10,6 @@ use AppBundle\Entity\Committee;
 use AppBundle\Exception\BaseGroupException;
 use AppBundle\Exception\CommitteeMembershipException;
 use AppBundle\Form\Admin\CommitteeMergeType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,8 +25,7 @@ class AdminCommitteeController extends Controller
     /**
      * Approves the committee.
      *
-     * @Route("/{id}/approve", name="app_admin_committee_approve")
-     * @Method("GET")
+     * @Route("/{id}/approve", name="app_admin_committee_approve", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
     public function approveAction(Committee $committee): Response
@@ -58,8 +56,7 @@ class AdminCommitteeController extends Controller
     /**
      * Refuses the committee.
      *
-     * @Route("/{id}/refuse", name="app_admin_committee_refuse")
-     * @Method("GET")
+     * @Route("/{id}/refuse", name="app_admin_committee_refuse", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
     public function refuseAction(Committee $committee): Response
@@ -75,8 +72,7 @@ class AdminCommitteeController extends Controller
     }
 
     /**
-     * @Route("/{id}/members", name="app_admin_committee_members")
-     * @Method("GET")
+     * @Route("/{id}/members", name="app_admin_committee_members", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
     public function membersAction(Committee $committee): Response
@@ -91,8 +87,7 @@ class AdminCommitteeController extends Controller
     }
 
     /**
-     * @Route("/{committee}/members/{adherent}/set-privilege/{privilege}", name="app_admin_committee_change_privilege")
-     * @Method("GET")
+     * @Route("/{committee}/members/{adherent}/set-privilege/{privilege}", name="app_admin_committee_change_privilege", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_COMMITTEES')")
      */
     public function changePrivilegeAction(
@@ -121,8 +116,7 @@ class AdminCommitteeController extends Controller
     }
 
     /**
-     * @Route("/merge", name="app_admin_committee_merge")
-     * @Method({"GET", "POST"})
+     * @Route("/merge", name="app_admin_committee_merge", methods={"GET", "POST"})
      *
      * @Security("has_role('ROLE_ADMIN_COMMITTEES_MERGE')")
      */

--- a/src/Controller/Admin/AdminMyEuropeController.php
+++ b/src/Controller/Admin/AdminMyEuropeController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Admin;
 use AppBundle\Entity\MyEuropeChoice;
 use AppBundle\Entity\MyEuropeInvitation;
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,8 +21,7 @@ class AdminMyEuropeController extends Controller
     const PER_PAGE = 1000;
 
     /**
-     * @Route("/export/choices", name="app_admin_myeurope_export_choices")
-     * @Method("GET")
+     * @Route("/export/choices", name="app_admin_myeurope_export_choices", methods={"GET"})
      */
     public function exportChoicesAction(): Response
     {
@@ -34,8 +32,7 @@ class AdminMyEuropeController extends Controller
     }
 
     /**
-     * @Route("/export/invitations", name="app_admin_myeurope_export_invitations")
-     * @Method("GET")
+     * @Route("/export/invitations", name="app_admin_myeurope_export_invitations", methods={"GET"})
      */
     public function exportInvitationsAction(): Response
     {
@@ -58,8 +55,7 @@ class AdminMyEuropeController extends Controller
     }
 
     /**
-     * @Route("/export/invitations/partial", name="app_admin_myeurope_export_invitations_partial")
-     * @Method("GET")
+     * @Route("/export/invitations/partial", name="app_admin_myeurope_export_invitations_partial", methods={"GET"})
      */
     public function exportInvitationsPartialAction(Request $request): Response
     {

--- a/src/Controller/Admin/AdminProcurationController.php
+++ b/src/Controller/Admin/AdminProcurationController.php
@@ -7,7 +7,6 @@ use AppBundle\Procuration\ProcurationManager;
 use AppBundle\Procuration\ProcurationRequestSerializer;
 use AppBundle\Repository\AdherentRepository;
 use AppBundle\Repository\ProcurationRequestRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -25,8 +24,7 @@ class AdminProcurationController extends Controller
     /**
      * List the procuration referents invitations URLs.
      *
-     * @Route("/referents-invitation-urls", name="app_admin_procuration_referents_invitations_urls")
-     * @Method("GET")
+     * @Route("/referents-invitation-urls", name="app_admin_procuration_referents_invitations_urls", methods={"GET"})
      */
     public function referentsInvitationUrlsAction(AdherentRepository $repository): Response
     {
@@ -36,8 +34,7 @@ class AdminProcurationController extends Controller
     }
 
     /**
-     * @Route("/export")
-     * @Method("GET")
+     * @Route("/export", methods={"GET"})
      */
     public function exportMailsAction(
         ProcurationRequestRepository $repository,
@@ -52,8 +49,7 @@ class AdminProcurationController extends Controller
     /**
      * List the procuration referents invitations URLs.
      *
-     * @Route("/request/{id}/deassociate", name="app_admin_procuration_request_deassociate")
-     * @Method("GET|POST")
+     * @Route("/request/{id}/deassociate", name="app_admin_procuration_request_deassociate", methods={"GET", "POST"})
      */
     public function deassociateAction(Request $sfRequest, ProcurationRequest $request): Response
     {

--- a/src/Controller/Admin/AdminReferentExportsController.php
+++ b/src/Controller/Admin/AdminReferentExportsController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Admin;
 use AppBundle\Entity\Referent;
 use AppBundle\Exporter\ReferentPersonLinkExport;
 use AppBundle\Repository\ReferentOrganizationalChart\ReferentPersonLinkRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AdminReferentExportsController extends Controller
 {
     /**
-     * @Route("/{id}/equipe-departementale", name="app_admin_referent_exports_departemental_team")
-     * @Method("GET")
+     * @Route("/{id}/equipe-departementale", name="app_admin_referent_exports_departemental_team", methods={"GET"})
      */
     public function exportDepartementaleTeam(
         ReferentPersonLinkExport $referentPersonLinkExport,

--- a/src/Controller/Admin/AdminReportController.php
+++ b/src/Controller/Admin/AdminReportController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Admin;
 
 use AppBundle\Entity\Report\Report;
 use AppBundle\Report\ReportManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,8 +17,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AdminReportController extends Controller
 {
     /**
-     * @Route("/{id}/resolve", name="app_admin_report_resolve")
-     * @Method("GET")
+     * @Route("/{id}/resolve", name="app_admin_report_resolve", methods={"GET"})
      * @Security("has_role('ROLE_APP_ADMIN_REPORT_APPROVE')")
      */
     public function resolveAction(Request $request, Report $report, ReportManager $reportManager): Response

--- a/src/Controller/Admin/AdminTonMacronController.php
+++ b/src/Controller/Admin/AdminTonMacronController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Admin;
 use AppBundle\Entity\TonMacronChoice;
 use AppBundle\Entity\TonMacronFriendInvitation;
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,8 +20,7 @@ class AdminTonMacronController extends Controller
     const PER_PAGE = 1000;
 
     /**
-     * @Route("/export/choices", name="app_admin_tonmacron_export_choices")
-     * @Method("GET")
+     * @Route("/export/choices", name="app_admin_tonmacron_export_choices", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_TON_MACRON')")
      */
     public function exportChoicesAction(): Response
@@ -34,8 +32,7 @@ class AdminTonMacronController extends Controller
     }
 
     /**
-     * @Route("/export/invitations", name="app_admin_tonmacron_export_invitations")
-     * @Method("GET")
+     * @Route("/export/invitations", name="app_admin_tonmacron_export_invitations", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_TON_MACRON')")
      */
     public function exportInvitationsAction(): Response
@@ -59,8 +56,7 @@ class AdminTonMacronController extends Controller
     }
 
     /**
-     * @Route("/export/invitations/partial", name="app_admin_tonmacron_export_invitations_partial")
-     * @Method("GET")
+     * @Route("/export/invitations/partial", name="app_admin_tonmacron_export_invitations_partial", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_TON_MACRON')")
      */
     public function exportInvitationsPartialAction(Request $request): Response

--- a/src/Controller/Admin/AdminTurnkeyProjectController.php
+++ b/src/Controller/Admin/AdminTurnkeyProjectController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Admin;
 
 use AppBundle\Entity\TurnkeyProject;
 use AppBundle\TurnkeyProject\TurnkeyProjectManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,8 +17,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AdminTurnkeyProjectController extends Controller
 {
     /**
-     * @Route("/{id}/remove-image", name="app_admin_turnkey_project_remove_image")
-     * @Method("GET")
+     * @Route("/{id}/remove-image", name="app_admin_turnkey_project_remove_image", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_TURNKEY_PROJECTS')")
      */
     public function removeImageAction(

--- a/src/Controller/Admin/AdminUnregistrationController.php
+++ b/src/Controller/Admin/AdminUnregistrationController.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Controller\Admin;
 
 use AppBundle\Repository\UnregistrationRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,8 +18,7 @@ class AdminUnregistrationController extends Controller
     const PER_PAGE = 1000;
 
     /**
-     * @Route("/export", name="app_admin_unregistration_export")
-     * @Method("GET")
+     * @Route("/export", name="app_admin_unregistration_export", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_UNREGISTRATIONS')")
      */
     public function exportUnregistrationsAction(UnregistrationRepository $repository): Response
@@ -39,8 +37,7 @@ class AdminUnregistrationController extends Controller
     }
 
     /**
-     * @Route("/export/partial", name="app_admin_unregistration_export_partial")
-     * @Method("GET")
+     * @Route("/export/partial", name="app_admin_unregistration_export_partial", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_UNREGISTRATIONS')")
      */
     public function exportUnregistrationsPartialAction(Request $request, UnregistrationRepository $repository): Response

--- a/src/Controller/Amp/AmpController.php
+++ b/src/Controller/Amp/AmpController.php
@@ -8,7 +8,6 @@ use AppBundle\Entity\OrderArticle;
 use AppBundle\Entity\Proposal;
 use AppBundle\Sitemap\SitemapFactory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -18,8 +17,7 @@ class AmpController extends Controller
     use CanaryControllerTrait;
 
     /**
-     * @Route("/articles/{categorySlug}/{articleSlug}", name="amp_article_view")
-     * @Method("GET")
+     * @Route("/articles/{categorySlug}/{articleSlug}", name="amp_article_view", methods={"GET"})
      * @Entity("article", expr="repository.findOnePublishedBySlugAndCategorySlug(articleSlug, categorySlug)")
      */
     public function articleAction(Article $article): Response
@@ -28,8 +26,7 @@ class AmpController extends Controller
     }
 
     /**
-     * @Route("/proposition/{slug}", name="amp_proposal_view")
-     * @Method("GET")
+     * @Route("/proposition/{slug}", name="amp_proposal_view", methods={"GET"})
      * @Entity("proposal", expr="repository.findPublishedProposal(slug)")
      */
     public function proposalAction(Proposal $proposal): Response
@@ -40,8 +37,7 @@ class AmpController extends Controller
     }
 
     /**
-     * @Route("/transformer-la-france/{slug}", name="amp_explainer_article_show")
-     * @Method("GET")
+     * @Route("/transformer-la-france/{slug}", name="amp_explainer_article_show", methods={"GET"})
      * @Entity("article", expr="repository.findPublishedArticle(slug)")
      */
     public function orderArticleAction(OrderArticle $article): Response
@@ -50,8 +46,7 @@ class AmpController extends Controller
     }
 
     /**
-     * @Route("/sitemap.xml", name="amp_sitemap")
-     * @Method("GET")
+     * @Route("/sitemap.xml", name="amp_sitemap", methods={"GET"})
      */
     public function sitemapIndexAction(): Response
     {

--- a/src/Controller/Api/AcquisitionStatisticsController.php
+++ b/src/Controller/Api/AcquisitionStatisticsController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Api;
 
 use AppBundle\Statistics\Acquisition\Aggregator;
 use AppBundle\Statistics\Acquisition\StatisticsRequest;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,8 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AcquisitionStatisticsController extends Controller
 {
     /**
-     * @Route("/statistics/acquisition", name="api_acquisition_statistics")
-     * @Method("GET")
+     * @Route("/statistics/acquisition", name="api_acquisition_statistics", methods={"GET"})
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")
      */

--- a/src/Controller/Api/AdherentController.php
+++ b/src/Controller/Api/AdherentController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Api;
 
 use AppBundle\Entity\Adherent;
 use Doctrine\Common\Persistence\ObjectManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,9 +18,9 @@ class AdherentController extends AbstractController
     /**
      * @Route(
      *     "/adherents/me/anonymize",
-     *     name="api_adherent_anonymize_me"
+     *     name="api_adherent_anonymize_me",
+     *     methods={"PUT"}
      * )
-     * @Method("PUT")
      * @Security("is_granted('ROLE_ADHERENT')")
      */
     public function anonymizeAction(

--- a/src/Controller/Api/AdherentsController.php
+++ b/src/Controller/Api/AdherentsController.php
@@ -8,7 +8,6 @@ use AppBundle\History\EmailSubscriptionHistoryHandler;
 use AppBundle\Membership\AdherentManager;
 use AppBundle\Repository\AdherentRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -23,8 +22,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AdherentsController extends Controller
 {
     /**
-     * @Route("/count", name="app_adherents_count")
-     * @Method("GET")
+     * @Route("/count", name="app_adherents_count", methods={"GET"})
      */
     public function adherentsCountAction(AdherentRepository $adherentRepository): Response
     {
@@ -34,8 +32,7 @@ class AdherentsController extends Controller
     }
 
     /**
-     * @Route("/count-by-referent-area", name="app_adherents_count_for_referent_managed_area")
-     * @Method("GET")
+     * @Route("/count-by-referent-area", name="app_adherents_count_for_referent_managed_area", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      */
     public function adherentsCountForReferentManagedAreaAction(

--- a/src/Controller/Api/CommitteesController.php
+++ b/src/Controller/Api/CommitteesController.php
@@ -11,7 +11,6 @@ use AppBundle\Repository\CommitteeMembershipRepository;
 use AppBundle\Repository\CommitteeRepository;
 use AppBundle\Statistics\StatisticsParametersFilter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -23,8 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class CommitteesController extends Controller
 {
     /**
-     * @Route("/committees", name="api_committees")
-     * @Method("GET")
+     * @Route("/committees", name="api_committees", methods={"GET"})
      */
     public function getApprovedCommitteesAction(): Response
     {
@@ -32,8 +30,7 @@ class CommitteesController extends Controller
     }
 
     /**
-     * @Route("/statistics/committees/count-for-referent-area", name="app_committees_count_for_referent_area")
-     * @Method("GET")
+     * @Route("/statistics/committees/count-for-referent-area", name="app_committees_count_for_referent_area", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")
@@ -51,8 +48,7 @@ class CommitteesController extends Controller
     }
 
     /**
-     * @Route("/statistics/committees/members/count-by-month", name="app_committee_members_count_by_month_for_referent_area")
-     * @Method("GET")
+     * @Route("/statistics/committees/members/count-by-month", name="app_committee_members_count_by_month_for_referent_area", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")
@@ -68,8 +64,7 @@ class CommitteesController extends Controller
     }
 
     /**
-     * @Route("/statistics/committees/top-5-in-referent-area", name="app_most_active_committees")
-     * @Method("GET")
+     * @Route("/statistics/committees/top-5-in-referent-area", name="app_most_active_committees", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")

--- a/src/Controller/Api/DomController.php
+++ b/src/Controller/Api/DomController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller\Api;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -10,8 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class DomController extends Controller
 {
     /**
-     * @Route("/dom", name="app_api_dom")
-     * @Method("GET")
+     * @Route("/dom", name="app_api_dom", methods={"GET"})
      */
     public function dom(): JsonResponse
     {

--- a/src/Controller/Api/EventsController.php
+++ b/src/Controller/Api/EventsController.php
@@ -8,7 +8,6 @@ use AppBundle\Repository\EventRegistrationRepository;
 use AppBundle\Repository\EventRepository;
 use AppBundle\Statistics\StatisticsParametersFilter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,8 +19,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class EventsController extends Controller
 {
     /**
-     * @Route("/events", name="api_committees_events")
-     * @Method("GET")
+     * @Route("/events", name="api_committees_events", methods={"GET"})
      */
     public function getUpcomingCommitteesEventsAction(Request $request): Response
     {
@@ -29,8 +27,7 @@ class EventsController extends Controller
     }
 
     /**
-     * @Route("/statistics/events/count-by-month", name="app_committee_events_count_by_month")
-     * @Method("GET")
+     * @Route("/statistics/events/count-by-month", name="app_committee_events_count_by_month", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")
@@ -55,8 +52,7 @@ class EventsController extends Controller
     }
 
     /**
-     * @Route("/statistics/events/count", name="app_events_count")
-     * @Method("GET")
+     * @Route("/statistics/events/count", name="app_events_count", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")
@@ -73,8 +69,7 @@ class EventsController extends Controller
     }
 
     /**
-     * @Route("/statistics/events/count-participants", name="app_committee_events_count_participants")
-     * @Method("GET")
+     * @Route("/statistics/events/count-participants", name="app_committee_events_count_participants", methods={"GET"})
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      *
      * @Security("is_granted('ROLE_OAUTH_SCOPE_READ:STATS')")

--- a/src/Controller/Api/FormController.php
+++ b/src/Controller/Api/FormController.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Controller\Api;
 
 use JMS\Serializer\SerializerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
@@ -18,8 +17,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class FormController extends Controller
 {
     /**
-     * @Route("/validate/{formType}", name="api_form_validate", condition="request.isXmlHttpRequest()")
-     * @Method("POST")
+     * @Route("/validate/{formType}", name="api_form_validate", condition="request.isXmlHttpRequest()", methods={"POST"})
      */
     public function validate(Request $request, SerializerInterface $serializer, string $formType): Response
     {

--- a/src/Controller/Api/IntlController.php
+++ b/src/Controller/Api/IntlController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Api;
 
 use AppBundle\Intl\FranceCitiesBundle;
 use AppBundle\Intl\VoteOfficeBundle;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -12,8 +11,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class IntlController extends Controller
 {
     /**
-     * @Route("/postal-code/{postalCode}", name="api_postal_code")
-     * @Method("GET")
+     * @Route("/postal-code/{postalCode}", name="api_postal_code", methods={"GET"})
      */
     public function postalCodeAction(string $postalCode): JsonResponse
     {
@@ -21,8 +19,7 @@ class IntlController extends Controller
     }
 
     /**
-     * @Route("/vote-offices/{countryCode}", name="api_vote_offices")
-     * @Method("GET")
+     * @Route("/vote-offices/{countryCode}", name="api_vote_offices", methods={"GET"})
      */
     public function voteOfficesAction(string $countryCode): JsonResponse
     {

--- a/src/Controller/Api/JecouteSurveyController.php
+++ b/src/Controller/Api/JecouteSurveyController.php
@@ -7,7 +7,6 @@ use AppBundle\Repository\Jecoute\LocalSurveyRepository;
 use Doctrine\Common\Persistence\ObjectManager;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
@@ -24,8 +23,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class JecouteSurveyController extends Controller
 {
     /**
-     * @Route("/survey", name="api_surveys_list")
-     * @Method("GET")
+     * @Route("/survey", name="api_surveys_list", methods={"GET"})
      */
     public function surveyListAction(
         LocalSurveyRepository $localSurveyRepository,
@@ -45,8 +43,7 @@ class JecouteSurveyController extends Controller
     }
 
     /**
-     * @Route("/survey/reply", name="api_survey_reply")
-     * @Method("POST")
+     * @Route("/survey/reply", name="api_survey_reply", methods={"POST"})
      */
     public function surveyReplyAction(Request $request, ObjectManager $manager): JsonResponse
     {

--- a/src/Controller/Api/LegislativesController.php
+++ b/src/Controller/Api/LegislativesController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller\Api;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -10,8 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class LegislativesController extends Controller
 {
     /**
-     * @Route("/candidates", name="api_legislatives_candidates")
-     * @Method("GET")
+     * @Route("/candidates", name="api_legislatives_candidates", methods={"GET"})
      */
     public function getCandidatesListAction(): JsonResponse
     {

--- a/src/Controller/Api/MoocController.php
+++ b/src/Controller/Api/MoocController.php
@@ -9,7 +9,6 @@ use AppBundle\Sitemap\SitemapFactory;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer as JMSSerializer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,8 +22,7 @@ use Symfony\Component\Serializer\Serializer;
 class MoocController extends Controller
 {
     /**
-     * @Route("", name="api_mooc_landing")
-     * @Method("GET")
+     * @Route("", name="api_mooc_landing", methods={"GET"})
      */
     public function moocLandingPageAction(MoocRepository $moocRepository, JMSSerializer $serializer): Response
     {
@@ -41,8 +39,7 @@ class MoocController extends Controller
     }
 
     /**
-     * @Route("/sitemap.xml", name="api_mooc_sitemap")
-     * @Method("GET")
+     * @Route("/sitemap.xml", name="api_mooc_sitemap", methods={"GET"})
      */
     public function sitemapAction(SitemapFactory $sitemapFactory): Response
     {
@@ -52,8 +49,7 @@ class MoocController extends Controller
     }
 
     /**
-     * @Route("/{slug}", name="api_mooc")
-     * @Method("GET")
+     * @Route("/{slug}", name="api_mooc", methods={"GET"})
      * @Entity("mooc", expr="repository.findOneBySlug(slug)")
      */
     public function moocAction(Mooc $mooc, MoocNormalizer $normalizer): Response

--- a/src/Controller/Api/ReferentController.php
+++ b/src/Controller/Api/ReferentController.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Repository\CommitteeRepository;
 use AppBundle\Repository\EventRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,8 +31,7 @@ class ReferentController extends Controller
     ];
 
     /**
-     * @Route("/search/autocomplete", name="api_referent_space_search_autocomplete")
-     * @Method("GET")
+     * @Route("/search/autocomplete", name="api_referent_space_search_autocomplete", methods={"GET"})
      *
      * @Entity("referent", expr="repository.findReferent(referent)", converter="querystring")
      */

--- a/src/Controller/Api/ReferentTagController.php
+++ b/src/Controller/Api/ReferentTagController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Api;
 use AppBundle\Entity\ReferentTag;
 use AppBundle\Repository\ReferentTagRepository;
 use JMS\Serializer\SerializerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,8 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ReferentTagController extends Controller
 {
     /**
-     * @Route("/referent-tags", name="api_referent_tag")
-     * @Method("GET")
+     * @Route("/referent-tags", name="api_referent_tag", methods={"GET"})
      */
     public function getReferentTagsAction(
         Request $request,

--- a/src/Controller/Api/ReferentsController.php
+++ b/src/Controller/Api/ReferentsController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller\Api;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -10,8 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ReferentsController extends Controller
 {
     /**
-     * @Route("/referents", name="api_referents")
-     * @Method("GET")
+     * @Route("/referents", name="api_referents", methods={"GET"})
      */
     public function indexAction()
     {

--- a/src/Controller/Api/ReportController.php
+++ b/src/Controller/Api/ReportController.php
@@ -8,7 +8,6 @@ use AppBundle\Report\ReportCommand;
 use AppBundle\Report\ReportCreationCommandHandler;
 use AppBundle\Report\ReportManager;
 use AppBundle\Report\ReportType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -28,9 +27,9 @@ class ReportController extends AbstractController
      *     requirements={
      *         "type": AppBundle\Report\ReportType::TYPES_URI_PATTERN,
      *         "uuid": "%pattern_uuid%"
-     *     }
+     *     },
+     *     methods={"POST"}
      * )
-     * @Method("POST")
      * @Security("is_granted('REPORT')")
      */
     public function reportAction(
@@ -71,8 +70,7 @@ class ReportController extends AbstractController
     }
 
     /**
-     * @Route("/report/reasons", name="api_report_reasons")
-     * @Method("GET")
+     * @Route("/report/reasons", name="api_report_reasons", methods={"GET"})
      * @Security("is_granted('REPORT')")
      */
     public function reasonsAction(TranslatorInterface $translator): Response

--- a/src/Controller/Api/StatsController.php
+++ b/src/Controller/Api/StatsController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Api;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\Event;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class StatsController extends Controller
 {
     /**
-     * @Route("/stats", name="api_stats")
-     * @Method("GET")
+     * @Route("/stats", name="api_stats", methods={"GET"})
      */
     public function indexAction()
     {

--- a/src/Controller/Api/SubscriptionController.php
+++ b/src/Controller/Api/SubscriptionController.php
@@ -18,8 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SubscriptionController extends Controller
 {
     /**
-     * @Route("/change", name="app_change_email_subscriptions_webhook")
-     * @Method({"GET", "POST"})
+     * @Route("/change", name="app_change_email_subscriptions_webhook", methods={"GET", "POST"})
      */
     public function changeEmailSubscriptionsAction(Request $request): Response
     {

--- a/src/Controller/Api/TurnkeyProjectController.php
+++ b/src/Controller/Api/TurnkeyProjectController.php
@@ -7,7 +7,6 @@ use AppBundle\Repository\TurnkeyProjectRepository;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,8 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class TurnkeyProjectController extends Controller
 {
     /**
-     * @Route(name="api_approved_turnkey_projects")
-     * @Method("GET")
+     * @Route(name="api_approved_turnkey_projects", methods={"GET"})
      */
     public function getApprovedTurnkeyProjectAction(
         TurnkeyProjectRepository $repository,
@@ -35,8 +33,7 @@ class TurnkeyProjectController extends Controller
     }
 
     /**
-     * @Route("/count", name="api_count_approved_turnkey_projects")
-     * @Method("GET")
+     * @Route("/count", name="api_count_approved_turnkey_projects", methods={"GET"})
      */
     public function countApprovedTurnkeyProjectAction(TurnkeyProjectRepository $repository): Response
     {
@@ -47,8 +44,7 @@ class TurnkeyProjectController extends Controller
     }
 
     /**
-     * @Route("/pinned", name="api_pinned_turnkey_project")
-     * @Method("GET")
+     * @Route("/pinned", name="api_pinned_turnkey_project", methods={"GET"})
      */
     public function getPinnedTurnkeyProjectAction(
         TurnkeyProjectRepository $repository,
@@ -63,9 +59,8 @@ class TurnkeyProjectController extends Controller
     }
 
     /**
-     * @Route("/{slug}", name="api_turnkey_project")
+     * @Route("/{slug}", name="api_turnkey_project", methods={"GET"})
      * @Entity("turnkeyProject", expr="repository.findOneApprovedBySlug(slug)")
-     * @Method("GET")
      */
     public function getTurnkeyProjectAction(TurnkeyProject $turnkeyProject, Serializer $serializer): Response
     {

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -7,7 +7,6 @@ use AppBundle\OAuth\Model\ApiUser;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,8 +16,7 @@ use Zend\Diactoros\Response;
 class UserController extends Controller
 {
     /**
-     * @Route("/me", name="app_api_user_show_me_for_oauth")
-     * @Method("GET")
+     * @Route("/me", name="app_api_user_show_me_for_oauth", methods={"GET"})
      */
     public function oauthShowMe(Serializer $serializer)
     {
@@ -42,8 +40,7 @@ class UserController extends Controller
 
     /**
      * @Security("is_granted('ROLE_ADHERENT')")
-     * @Route("/users/me", name="app_api_user_show_me")
-     * @Method("GET")
+     * @Route("/users/me", name="app_api_user_show_me", methods={"GET"})
      */
     public function showMe(Serializer $serializer): JsonResponse
     {

--- a/src/Controller/AssetsController.php
+++ b/src/Controller/AssetsController.php
@@ -13,7 +13,6 @@ use League\Glide\Responses\SymfonyResponseFactory;
 use League\Glide\Signatures\SignatureException;
 use League\Glide\Signatures\SignatureFactory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,8 +29,7 @@ class AssetsController extends Controller
     ];
 
     /**
-     * @Route("/assets/{path}", requirements={"path": ".+"}, name="asset_url")
-     * @Method("GET")
+     * @Route("/assets/{path}", requirements={"path": ".+"}, name="asset_url", methods={"GET"})
      * @Cache(maxage=900, smaxage=900)
      */
     public function assetAction(string $path, Request $request)
@@ -76,9 +74,9 @@ class AssetsController extends Controller
      * @Route(
      *     "/maps/{latitude},{longitude}",
      *     requirements={"latitude": "^%pattern_coordinate%$", "longitude": "^%pattern_coordinate%$"},
-     *     name="map_url"
+     *     name="map_url",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      * @Cache(maxage=900, smaxage=900)
      */
     public function mapAction(Request $request, string $latitude, string $longitude)
@@ -94,8 +92,7 @@ class AssetsController extends Controller
     }
 
     /**
-     * @Route("/video/homepage.{format}", requirements={"format": "mov|mp4"}, name="homepage_video_url")
-     * @Method("GET")
+     * @Route("/video/homepage.{format}", requirements={"format": "mov|mp4"}, name="homepage_video_url", methods={"GET"})
      * @Cache(maxage=60, smaxage=60)
      */
     public function videoAction(string $format)
@@ -108,8 +105,7 @@ class AssetsController extends Controller
     }
 
     /**
-     * @Route("/algolia/{type}/{slug}", requirements={"type": "proposal|custom|article|clarification"})
-     * @Method("GET")
+     * @Route("/algolia/{type}/{slug}", requirements={"type": "proposal|custom|article|clarification"}, methods={"GET"})
      * @Cache(maxage=900, smaxage=900)
      */
     public function algoliaAction(Request $request, string $type, string $slug)
@@ -186,8 +182,7 @@ class AssetsController extends Controller
     }
 
     /**
-     * @Route("/image-transformer.jpg", name="asset_timeline")
-     * @Method("GET")
+     * @Route("/image-transformer.jpg", name="asset_timeline", methods={"GET"})
      * @Cache(maxage=900, smaxage=900)
      */
     public function timelineImageAction(Request $request)

--- a/src/Controller/EnMarche/AdherentController.php
+++ b/src/Controller/EnMarche/AdherentController.php
@@ -34,7 +34,6 @@ use AppBundle\Search\SearchResultsProvidersManager;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
 use GuzzleHttp\Exception\ConnectException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -51,8 +50,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class AdherentController extends Controller
 {
     /**
-     * @Route("/accueil", name="app_adherent_home")
-     * @Method("GET")
+     * @Route("/accueil", name="app_adherent_home", methods={"GET"})
      */
     public function homeAction(
         Request $request,
@@ -86,8 +84,7 @@ class AdherentController extends Controller
     }
 
     /**
-     * @Route("/tableau-de-bord", name="app_user_dashboard")
-     * @Method("GET")
+     * @Route("/tableau-de-bord", name="app_user_dashboard", methods={"GET"})
      */
     public function dashboardAction(
         AdherentRepository $adherentRepository,
@@ -114,8 +111,7 @@ class AdherentController extends Controller
     /**
      * This action enables an adherent to pin his/her interests.
      *
-     * @Route("/mon-compte/centres-d-interet", name="app_adherent_pin_interests")
-     * @Method("GET|POST")
+     * @Route("/mon-compte/centres-d-interet", name="app_adherent_pin_interests", methods={"GET", "POST"})
      */
     public function pinInterestsAction(Request $request, EventDispatcherInterface $dispatcher): Response
     {
@@ -142,8 +138,7 @@ class AdherentController extends Controller
     /**
      * This action enables an adherent to create a committee.
      *
-     * @Route("/creer-mon-comite", name="app_adherent_create_committee")
-     * @Method("GET|POST")
+     * @Route("/creer-mon-comite", name="app_adherent_create_committee", methods={"GET", "POST"})
      * @Security("is_granted('CREATE_COMMITTEE')")
      */
     public function createCommitteeAction(Request $request): Response
@@ -168,9 +163,8 @@ class AdherentController extends Controller
     /**
      * This action enables an adherent to create a citizen project.
      *
-     * @Route("/creer-mon-projet-citoyen/{slug}", defaults={"slug": null}, name="app_adherent_create_citizen_project")
+     * @Route("/creer-mon-projet-citoyen/{slug}", defaults={"slug": null}, name="app_adherent_create_citizen_project", methods={"GET", "POST"})
      * @Entity("turnkeyProject", expr="repository.findOneApprovedBySlug(slug)")
-     * @Method("GET|POST")
      */
     public function createCitizenProjectAction(Request $request, TurnkeyProject $turnkeyProject = null): Response
     {
@@ -208,8 +202,7 @@ class AdherentController extends Controller
     }
 
     /**
-     * @Route("/mes-evenements", name="app_adherent_events")
-     * @Method("GET")
+     * @Route("/mes-evenements", name="app_adherent_events", methods={"GET"})
      */
     public function eventsAction(Request $request): Response
     {
@@ -227,8 +220,7 @@ class AdherentController extends Controller
     }
 
     /**
-     * @Route("/contacter/{uuid}", name="app_adherent_contact", requirements={"uuid": "%pattern_uuid%"})
-     * @Method("GET|POST")
+     * @Route("/contacter/{uuid}", name="app_adherent_contact", requirements={"uuid": "%pattern_uuid%"}, methods={"GET", "POST"})
      */
     public function contactAction(Request $request, Adherent $adherent): Response
     {

--- a/src/Controller/EnMarche/ArticleController.php
+++ b/src/Controller/EnMarche/ArticleController.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\Article;
 use AppBundle\Entity\ArticleCategory;
 use Psr\Cache\CacheItemPoolInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,9 +20,9 @@ class ArticleController extends Controller
      *     "/articles/{category}/{page}",
      *     requirements={"category": "\w+", "page": "\d+"},
      *     defaults={"category": "tout", "page": 1},
-     *     name="articles_list"
+     *     name="articles_list",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function actualitesAction(Request $request, string $category, int $page): Response
     {
@@ -61,8 +60,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * @Route("/articles/{categorySlug}/{articleSlug}", name="article_view")
-     * @Method("GET")
+     * @Route("/articles/{categorySlug}/{articleSlug}", name="article_view", methods={"GET"})
      * @Entity("article", expr="repository.findOnePublishedBySlugAndCategorySlug(articleSlug, categorySlug)")
      */
     public function articleAction(Article $article): Response
@@ -76,8 +74,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * @Route("/feed.xml", name="articles_feed")
-     * @Method("GET")
+     * @Route("/feed.xml", name="articles_feed", methods={"GET"})
      */
     public function feedAction(): Response
     {

--- a/src/Controller/EnMarche/BiographyController.php
+++ b/src/Controller/EnMarche/BiographyController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\EnMarche;
 use AppBundle\Entity\Biography\ExecutiveOfficeMember;
 use AppBundle\Repository\Biography\ExecutiveOfficeMemberRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class BiographyController extends Controller
 {
     /**
-     * @Route("/le-mouvement/notre-organisation", name="app_our_organization")
-     * @Method("GET")
+     * @Route("/le-mouvement/notre-organisation", name="app_our_organization", methods={"GET"})
      */
     public function executiveOfficeMemberListAction(ExecutiveOfficeMemberRepository $repository): Response
     {
@@ -27,8 +25,7 @@ class BiographyController extends Controller
     }
 
     /**
-     * @Route("/le-mouvement/notre-organisation/{slug}", name="app_our_organization_show")
-     * @Method("GET")
+     * @Route("/le-mouvement/notre-organisation/{slug}", name="app_our_organization_show", methods={"GET"})
      * @Entity("executiveOfficeMember", expr="repository.findOnePublishedBySlug(slug)")
      */
     public function executiveOfficeMemberAction(ExecutiveOfficeMember $executiveOfficeMember): Response

--- a/src/Controller/EnMarche/BoardMemberController.php
+++ b/src/Controller/EnMarche/BoardMemberController.php
@@ -7,7 +7,6 @@ use AppBundle\BoardMember\BoardMemberMessage;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\BoardMember\BoardMember;
 use AppBundle\Form\BoardMemberMessageType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,8 +22,7 @@ class BoardMemberController extends Controller
     const TOKEN_ID = 'board_member_search';
 
     /**
-     * @Route("/", name="app_board_member_home")
-     * @Method("GET")
+     * @Route("/", name="app_board_member_home", methods={"GET"})
      */
     public function indexAction()
     {
@@ -32,8 +30,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/recherche", name="app_board_member_search")
-     * @Method("GET")
+     * @Route("/recherche", name="app_board_member_search", methods={"GET"})
      */
     public function searchAction(Request $request): Response
     {
@@ -58,8 +55,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/profils-sauvegardes", name="app_board_member_saved_profile")
-     * @Method("GET")
+     * @Route("/profils-sauvegardes", name="app_board_member_saved_profile", methods={"GET"})
      */
     public function savedProfilAction()
     {
@@ -73,8 +69,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/recherche/message", name="app_board_member_message_search")
-     * @Method("GET|POST")
+     * @Route("/recherche/message", name="app_board_member_message_search", methods={"GET", "POST"})
      */
     public function sendMessageToSearchResultsAction(Request $request): Response
     {
@@ -107,8 +102,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/profils-sauvegardes/message", name="app_board_member_message_saved_profile")
-     * @Method("GET|POST")
+     * @Route("/profils-sauvegardes/message", name="app_board_member_message_saved_profile", methods={"GET", "POST"})
      */
     public function sendMessageToSavedProfilesAction(Request $request): Response
     {
@@ -133,8 +127,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/message/{member}", name="app_board_member_message_member")
-     * @Method("GET|POST")
+     * @Route("/message/{member}", name="app_board_member_message_member", methods={"GET", "POST"})
      */
     public function sendMessageToMemberAction(Request $request, Adherent $member): Response
     {
@@ -163,8 +156,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/list/boardmember", name="app_board_add_profile_on_list")
-     * @Method("POST")
+     * @Route("/list/boardmember", name="app_board_add_profile_on_list", methods={"POST"})
      */
     public function addBoardMemberOnListAction(Request $request)
     {
@@ -188,8 +180,7 @@ class BoardMemberController extends Controller
     }
 
     /**
-     * @Route("/list/boardmember/{boardMemberId}", name="app_board_remove_profile_on_list")
-     * @Method("DELETE")
+     * @Route("/list/boardmember/{boardMemberId}", name="app_board_remove_profile_on_list", methods={"DELETE"})
      */
     public function deleteBoardMemberOnListAction($boardMemberId)
     {

--- a/src/Controller/EnMarche/CitizenActionController.php
+++ b/src/Controller/EnMarche/CitizenActionController.php
@@ -14,7 +14,6 @@ use AppBundle\Repository\CitizenProjectMembershipRepository;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
 use Doctrine\ORM\EntityNotFoundException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,8 +31,7 @@ class CitizenActionController extends Controller
     use EntityControllerTrait;
 
     /**
-     * @Route("/{slug}", name="app_citizen_action_show")
-     * @Method("GET")
+     * @Route("/{slug}", name="app_citizen_action_show", methods={"GET"})
      */
     public function showAction(CitizenAction $action, CitizenActionManager $citizenActionManager): Response
     {
@@ -44,8 +42,7 @@ class CitizenActionController extends Controller
     }
 
     /**
-     * @Route("/{slug}/inscription", name="app_citizen_action_attend")
-     * @Method("GET|POST")
+     * @Route("/{slug}/inscription", name="app_citizen_action_attend", methods={"GET", "POST"})
      */
     public function attendAction(Request $request, CitizenAction $citizenAction): Response
     {
@@ -85,8 +82,7 @@ class CitizenActionController extends Controller
     }
 
     /**
-     * @Route("/{slug}/desinscription", name="app_citizen_action_unregistration", condition="request.isXmlHttpRequest()")
-     * @Method("GET|POST")
+     * @Route("/{slug}/desinscription", name="app_citizen_action_unregistration", condition="request.isXmlHttpRequest()", methods={"GET", "POST"})
      * @Security("is_granted('UNREGISTER_CITIZEN_ACTION', citizenAction)")
      */
     public function unregistrationAction(Request $request, CitizenAction $citizenAction): JsonResponse
@@ -111,9 +107,9 @@ class CitizenActionController extends Controller
      * @Route(
      *     path="/{slug}/confirmation",
      *     name="app_citizen_action_attend_confirmation",
-     *     condition="request.query.has('registration')"
+     *     condition="request.query.has('registration')",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function attendConfirmationAction(Request $request, CitizenAction $citizenAction): Response
     {
@@ -138,8 +134,7 @@ class CitizenActionController extends Controller
     }
 
     /**
-     * @Route("/{slug}/ical", name="app_citizen_action_export_ical")
-     * @Method("GET")
+     * @Route("/{slug}/ical", name="app_citizen_action_export_ical", methods={"GET"})
      */
     public function exportIcalAction(CitizenAction $citizenAction): Response
     {
@@ -152,8 +147,7 @@ class CitizenActionController extends Controller
     }
 
     /**
-     * @Route("/{slug}/participants", name="app_citizen_action_list_participants")
-     * @Method("GET")
+     * @Route("/{slug}/participants", name="app_citizen_action_list_participants", methods={"GET"})
      * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
      */
     public function listParticipantsAction(

--- a/src/Controller/EnMarche/CitizenActionManagerController.php
+++ b/src/Controller/EnMarche/CitizenActionManagerController.php
@@ -24,7 +24,6 @@ use AppBundle\Form\ContactMembersType;
 use AppBundle\Repository\CitizenProjectMembershipRepository;
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -52,8 +51,7 @@ class CitizenActionManagerController extends Controller
     ];
 
     /**
-     * @Route("/creer", name="app_citizen_action_manager_create")
-     * @Method("GET|POST")
+     * @Route("/creer", name="app_citizen_action_manager_create", methods={"GET", "POST"})
      * @Security("is_granted('CREATE_CITIZEN_ACTION', project)")
      */
     public function createAction(
@@ -87,8 +85,7 @@ class CitizenActionManagerController extends Controller
     }
 
     /**
-     * @Route("/{slug}/editer", name="app_citizen_action_manager_edit", requirements={"slug": "[A-Za-z0-9\-]+"})
-     * @Method("GET|POST")
+     * @Route("/{slug}/editer", name="app_citizen_action_manager_edit", requirements={"slug": "[A-Za-z0-9\-]+"}, methods={"GET", "POST"})
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
     public function editAction(
@@ -120,8 +117,7 @@ class CitizenActionManagerController extends Controller
     }
 
     /**
-     * @Route("/{slug}/annuler", name="app_citizen_action_manager_cancel")
-     * @Method("GET|POST")
+     * @Route("/{slug}/annuler", name="app_citizen_action_manager_cancel", methods={"GET", "POST"})
      * @Security("is_granted('CANCEL_CITIZEN_ACTION', project)")
      */
     public function cancelAction(
@@ -151,8 +147,7 @@ class CitizenActionManagerController extends Controller
     }
 
     /**
-     * @Route("/{slug}/participants/exporter", name="app_citizen_action_export_participants")
-     * @Method("POST")
+     * @Route("/{slug}/participants/exporter", name="app_citizen_action_export_participants", methods={"POST"})
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
     public function exportParticipantsAction(
@@ -182,8 +177,7 @@ class CitizenActionManagerController extends Controller
     }
 
     /**
-     * @Route("/{slug}/participants/contacter", name="app_citizen_action_contact_participants")
-     * @Method("POST")
+     * @Route("/{slug}/participants/contacter", name="app_citizen_action_contact_participants", methods={"POST"})
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
     public function contactParticipantsAction(
@@ -231,8 +225,7 @@ class CitizenActionManagerController extends Controller
     }
 
     /**
-     * @Route("/{slug}/participants/imprimer", name="app_citizen_action_print_participants")
-     * @Method("POST")
+     * @Route("/{slug}/participants/imprimer", name="app_citizen_action_print_participants", methods={"POST"})
      * @Security("is_granted('EDIT_CITIZEN_ACTION', project)")
      */
     public function printParticipantsAction(

--- a/src/Controller/EnMarche/CitizenProjectController.php
+++ b/src/Controller/EnMarche/CitizenProjectController.php
@@ -13,7 +13,6 @@ use AppBundle\Exception\CitizenProjectNotApprovedException;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
 use AppBundle\Storage\FileRequestHandler;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -28,8 +27,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CitizenProjectController extends Controller
 {
     /**
-     * @Route("/aide", name="app_citizen_project_help")
-     * @Method("GET|POST")
+     * @Route("/aide", name="app_citizen_project_help", methods={"GET", "POST"})
      */
     public function helpAction(): Response
     {
@@ -37,8 +35,7 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{slug}", name="app_citizen_project_show")
-     * @Method("GET")
+     * @Route("/{slug}", name="app_citizen_project_show", methods={"GET"})
      * @Security("is_granted('SHOW_CITIZEN_PROJECT', citizenProject)")
      */
     public function showAction(
@@ -63,9 +60,9 @@ class CitizenProjectController extends Controller
     /**
      * @Route("/skills/autocompletion",
      *     name="app_citizen_project_skills_autocomplete",
-     *     condition="request.isXmlHttpRequest() and request.query.get('category')"
+     *     condition="request.isXmlHttpRequest() and request.query.get('category')",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
      */
     public function skillsAutocompleteAction(Request $request)
@@ -94,9 +91,9 @@ class CitizenProjectController extends Controller
     /**
      * @Route("/comite/autocompletion",
      *     name="app_citizen_project_committee_autocomplete",
-     *     condition="request.isXmlHttpRequest()"
+     *     condition="request.isXmlHttpRequest()",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
      */
     public function committeeAutocompleteAction(Request $request)
@@ -122,9 +119,8 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/mon-comite-soutien/{slug}", name="app_citizen_project_committee_support")
+     * @Route("/mon-comite-soutien/{slug}", name="app_citizen_project_committee_support", methods={"GET", "POST"})
      * @Security("is_granted('ROLE_SUPERVISOR')")
-     * @Method("GET|POST")
      */
     public function committeeSupportAction(
         Request $request,
@@ -174,8 +170,7 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{slug}/acteurs", name="app_citizen_project_list_actors")
-     * @Method("GET")
+     * @Route("/{slug}/acteurs", name="app_citizen_project_list_actors", methods={"GET"})
      * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
      */
     public function listActorsAction(
@@ -191,8 +186,7 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{slug}/rejoindre", name="app_citizen_project_follow", condition="request.request.has('token')")
-     * @Method("POST")
+     * @Route("/{slug}/rejoindre", name="app_citizen_project_follow", condition="request.request.has('token')", methods={"POST"})
      * @Security("is_granted('FOLLOW_CITIZEN_PROJECT', citizenProject)")
      */
     public function followAction(
@@ -216,8 +210,7 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{slug}/quitter", name="app_citizen_project_unfollow", condition="request.request.has('token')")
-     * @Method("POST")
+     * @Route("/{slug}/quitter", name="app_citizen_project_unfollow", condition="request.request.has('token')", methods={"POST"})
      * @Security("is_granted('UNFOLLOW_CITIZEN_PROJECT', citizenProject)")
      */
     public function unfollowAction(
@@ -241,8 +234,7 @@ class CitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/kits/{slug}.{extension}", name="app_citizen_project_kit_file")
-     * @Method("GET")
+     * @Route("/kits/{slug}.{extension}", name="app_citizen_project_kit_file", methods={"GET"})
      * @Cache(maxage=900, smaxage=900)
      */
     public function getKitFile(FileRequestHandler $fileRequestHandler, TurnkeyProjectFile $file): Response

--- a/src/Controller/EnMarche/CitizenProjectManagerController.php
+++ b/src/Controller/EnMarche/CitizenProjectManagerController.php
@@ -10,7 +10,6 @@ use AppBundle\Entity\CitizenProject;
 use AppBundle\Form\CitizenProjectCommandType;
 use AppBundle\Form\CitizenProjectContactActorsType;
 use AppBundle\Utils\GroupUtils;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -26,8 +25,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CitizenProjectManagerController extends Controller
 {
     /**
-     * @Route("/editer", name="app_citizen_project_manager_edit")
-     * @Method("GET|POST")
+     * @Route("/editer", name="app_citizen_project_manager_edit", methods={"GET", "POST"})
      */
     public function editAction(
         Request $request,
@@ -59,8 +57,7 @@ class CitizenProjectManagerController extends Controller
     }
 
     /**
-     * @Route("/acteurs/contact", name="app_citizen_project_contact_actors")
-     * @Method("POST")
+     * @Route("/acteurs/contact", name="app_citizen_project_contact_actors", methods={"POST"})
      */
     public function contactActorsAction(
         Request $request,

--- a/src/Controller/EnMarche/CitizenProjectMediaGeneratorController.php
+++ b/src/Controller/EnMarche/CitizenProjectMediaGeneratorController.php
@@ -7,7 +7,6 @@ use AppBundle\Form\CitizenProjectTractType;
 use AppBundle\MediaGenerator\Image\CitizenProjectCoverGenerator;
 use AppBundle\MediaGenerator\Pdf\CitizenProjectTractGenerator;
 use Knp\Bundle\SnappyBundle\Snappy\Response\PdfResponse;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,8 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CitizenProjectMediaGeneratorController extends Controller
 {
     /**
-     * @Route("/images", name="app_citizen_project_image_generator")
-     * @Method({"GET", "POST"})
+     * @Route("/images", name="app_citizen_project_image_generator", methods={"GET", "POST"})
      */
     public function generateImageAction(Request $request): Response
     {
@@ -45,8 +43,7 @@ class CitizenProjectMediaGeneratorController extends Controller
     }
 
     /**
-     * @Route("/tracts", name="app_citizen_project_tract_generator")
-     * @Method({"GET", "POST"})
+     * @Route("/tracts", name="app_citizen_project_tract_generator", methods={"GET", "POST"})
      */
     public function generateTractAction(Request $request): Response
     {

--- a/src/Controller/EnMarche/CommitteeController.php
+++ b/src/Controller/EnMarche/CommitteeController.php
@@ -12,7 +12,6 @@ use AppBundle\Entity\CommitteeFeedItem;
 use AppBundle\Form\CommitteeFeedItemMessageType;
 use AppBundle\Form\CommitteeFeedMessageType;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -29,8 +28,7 @@ class CommitteeController extends Controller
     use EntityControllerTrait;
 
     /**
-     * @Route(name="app_committee_show")
-     * @Method("GET|POST")
+     * @Route(name="app_committee_show", methods={"GET", "POST"})
      * @Security("is_granted('SHOW_COMMITTEE', committee)")
      */
     public function showAction(Request $request, Committee $committee): Response
@@ -75,10 +73,9 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @Route("/timeline/{id}/modifier", name="app_committee_timeline_edit")
+     * @Route("/timeline/{id}/modifier", name="app_committee_timeline_edit", methods={"GET", "POST"})
      * @ParamConverter("committee", options={"mapping": {"slug": "slug"}})
      * @ParamConverter("committeeFeedItem", options={"mapping": {"id": "id"}})
-     * @Method("GET|POST")
      * @Security("is_granted('ADMIN_FEED_COMMITTEE', committeeFeedItem)")
      */
     public function timelineEditAction(
@@ -112,10 +109,9 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @Route("/timeline/{id}/supprimer", name="app_committee_timeline_delete")
+     * @Route("/timeline/{id}/supprimer", name="app_committee_timeline_delete", methods={"DELETE"})
      * @ParamConverter("committee", options={"mapping": {"slug": "slug"}})
      * @ParamConverter("committeeFeedItem", options={"mapping": {"id": "id"}})
-     * @Method("DELETE")
      * @Security("is_granted('ADMIN_FEED_COMMITTEE', committeeFeedItem)")
      */
     public function timelineDeleteAction(
@@ -139,8 +135,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @Route("/timeline", name="app_committee_timeline")
-     * @Method("GET")
+     * @Route("/timeline", name="app_committee_timeline", methods={"GET"})
      * @Security("is_granted('SHOW_COMMITTEE', committee)")
      */
     public function timelineAction(Request $request, Committee $committee): Response
@@ -161,8 +156,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @Route("/rejoindre", name="app_committee_follow", condition="request.request.has('token')")
-     * @Method("POST")
+     * @Route("/rejoindre", name="app_committee_follow", condition="request.request.has('token')", methods={"POST"})
      * @Security("is_granted('FOLLOW_COMMITTEE', committee)")
      */
     public function followAction(Request $request, Committee $committee): Response
@@ -183,8 +177,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @Route("/quitter", name="app_committee_unfollow", condition="request.request.has('token')")
-     * @Method("POST")
+     * @Route("/quitter", name="app_committee_unfollow", condition="request.request.has('token')", methods={"POST"})
      * @Security("is_granted('UNFOLLOW_COMMITTEE', committee)")
      */
     public function unfollowAction(Request $request, Committee $committee): Response

--- a/src/Controller/EnMarche/CommitteeManagerController.php
+++ b/src/Controller/EnMarche/CommitteeManagerController.php
@@ -15,7 +15,6 @@ use AppBundle\Form\EventCommandType;
 use AppBundle\Serializer\XlsxEncoder;
 use AppBundle\Utils\GroupUtils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -33,8 +32,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 class CommitteeManagerController extends Controller
 {
     /**
-     * @Route("/editer", name="app_committee_manager_edit")
-     * @Method("GET|POST")
+     * @Route("/editer", name="app_committee_manager_edit", methods={"GET", "POST"})
      */
     public function editAction(Request $request, Committee $committee): Response
     {
@@ -59,8 +57,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/evenements/ajouter", name="app_committee_manager_add_event")
-     * @Method("GET|POST")
+     * @Route("/evenements/ajouter", name="app_committee_manager_add_event", methods={"GET", "POST"})
      */
     public function addEventAction(Request $request, Committee $committee, GeoCoder $geoCoder): Response
     {
@@ -90,8 +87,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/membres", name="app_committee_manager_list_members")
-     * @Method("GET")
+     * @Route("/membres", name="app_committee_manager_list_members", methods={"GET"})
      */
     public function listMembersAction(Committee $committee): Response
     {
@@ -105,8 +101,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/membres/export", name="app_committee_manager_export_members")
-     * @Method("POST")
+     * @Route("/membres/export", name="app_committee_manager_export_members", methods={"POST"})
      */
     public function exportMembersAction(
         Request $request,
@@ -146,8 +141,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/membres/contact", name="app_committee_contact_members")
-     * @Method("POST")
+     * @Route("/membres/contact", name="app_committee_contact_members", methods={"POST"})
      */
     public function contactMembersAction(Request $request, Committee $committee): Response
     {
@@ -194,8 +188,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/promouvoir-suppleant/{member_uuid}", name="app_committee_promote_host")
-     * @Method("GET|POST")
+     * @Route("/promouvoir-suppleant/{member_uuid}", name="app_committee_promote_host", methods={"GET", "POST"})
      * @Security("is_granted('SUPERVISE_COMMITTEE', committee)")
      * @Entity("member", expr="repository.findByUuid(member_uuid)")
      */
@@ -231,8 +224,7 @@ class CommitteeManagerController extends Controller
     }
 
     /**
-     * @Route("/retirer-suppleant/{member_uuid}", name="app_committee_demote_host")
-     * @Method("GET|POST")
+     * @Route("/retirer-suppleant/{member_uuid}", name="app_committee_demote_host", methods={"GET", "POST"})
      * @Security("is_granted('SUPERVISE_COMMITTEE', committee)")
      * @Entity("member", expr="repository.findByUuid(member_uuid)")
      */

--- a/src/Controller/EnMarche/Coordinator/CoordinatorCitizenProjectController.php
+++ b/src/Controller/EnMarche/Coordinator/CoordinatorCitizenProjectController.php
@@ -8,7 +8,6 @@ use AppBundle\Coordinator\Filter\CitizenProjectFilter;
 use AppBundle\Entity\CitizenProject;
 use AppBundle\Exception\BaseGroupException;
 use AppBundle\Form\CoordinatorAreaType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,8 +22,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CoordinatorCitizenProjectController extends Controller
 {
     /**
-     * @Route(path="/list", name="app_coordinator_citizen_project")
-     * @Method("GET")
+     * @Route(path="/list", name="app_coordinator_citizen_project", methods={"GET"})
      */
     public function listAction(Request $request): Response
     {
@@ -61,8 +59,7 @@ class CoordinatorCitizenProjectController extends Controller
     }
 
     /**
-     * @Route("/{uuid}/{slug}/pre-valider", name="app_coordinator_citizen_project_validate")
-     * @Method("POST")
+     * @Route("/{uuid}/{slug}/pre-valider", name="app_coordinator_citizen_project_validate", methods={"POST"})
      */
     public function validateAction(Request $request, CitizenProject $project): Response
     {

--- a/src/Controller/EnMarche/Coordinator/CoordinatorCommitteeController.php
+++ b/src/Controller/EnMarche/Coordinator/CoordinatorCommitteeController.php
@@ -6,7 +6,6 @@ use AppBundle\Coordinator\Filter\CommitteeFilter;
 use AppBundle\Entity\Committee;
 use AppBundle\Exception\BaseGroupException;
 use AppBundle\Form\CoordinatorAreaType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,8 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CoordinatorCommitteeController extends Controller
 {
     /**
-     * @Route("/list", name="app_coordinator_committees")
-     * @Method("GET")
+     * @Route("/list", name="app_coordinator_committees", methods={"GET"})
      */
     public function committeesAction(Request $request): Response
     {
@@ -56,8 +54,7 @@ class CoordinatorCommitteeController extends Controller
     /**
      * Pre-approves or pre-refuses a committee.
      *
-     * @Route("/{uuid}/{slug}/pre-valider-comite", name="app_coordinator_committee_validate")
-     * @Method("POST")
+     * @Route("/{uuid}/{slug}/pre-valider-comite", name="app_coordinator_committee_validate", methods={"POST"})
      */
     public function validateAction(Request $request, Committee $committee): Response
     {

--- a/src/Controller/EnMarche/DeputyController.php
+++ b/src/Controller/EnMarche/DeputyController.php
@@ -11,7 +11,6 @@ use AppBundle\Referent\ManagedEventsExporter;
 use AppBundle\Repository\AdherentRepository;
 use AppBundle\Repository\CommitteeRepository;
 use AppBundle\Repository\EventRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,8 +26,7 @@ class DeputyController extends Controller
     use CanaryControllerTrait;
 
     /**
-     * @Route("/utilisateurs/message", name="app_deputy_users_message")
-     * @Method("GET|POST")
+     * @Route("/utilisateurs/message", name="app_deputy_users_message", methods={"GET", "POST"})
      */
     public function usersSendMessageAction(Request $request, AdherentRepository $adherentRepository): Response
     {
@@ -55,8 +53,7 @@ class DeputyController extends Controller
     }
 
     /**
-     * @Route("/evenements", name="app_deputy_events")
-     * @Method("GET")
+     * @Route("/evenements", name="app_deputy_events", methods={"GET"})
      */
     public function listEventsAction(EventRepository $eventRepository, ManagedEventsExporter $eventsExporter): Response
     {
@@ -68,8 +65,7 @@ class DeputyController extends Controller
     }
 
     /**
-     * @Route("/comites", name="app_deputy_committees")
-     * @Method("GET")
+     * @Route("/comites", name="app_deputy_committees", methods={"GET"})
      */
     public function listCommitteesAction(
         CommitteeRepository $committeeRepository,

--- a/src/Controller/EnMarche/DesintoxController.php
+++ b/src/Controller/EnMarche/DesintoxController.php
@@ -6,15 +6,13 @@ use AppBundle\Entity\Clarification;
 use AppBundle\Entity\Page;
 use AppBundle\Repository\ClarificationRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
 class DesintoxController extends Controller
 {
     /**
-     * @Route("/desintox", name="desintox_list")
-     * @Method("GET")
+     * @Route("/desintox", name="desintox_list", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('desintox')")
      */
     public function listAction(Page $page, ClarificationRepository $clarificationRepository)
@@ -26,8 +24,7 @@ class DesintoxController extends Controller
     }
 
     /**
-     * @Route("/desintox/{slug}", name="desintox_view")
-     * @Method("GET")
+     * @Route("/desintox/{slug}", name="desintox_view", methods={"GET"})
      * @Entity("clarification", expr="repository.findPublishedClarification(slug)")
      */
     public function viewAction(Clarification $clarification)

--- a/src/Controller/EnMarche/DocumentsController.php
+++ b/src/Controller/EnMarche/DocumentsController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\EnMarche;
 use AppBundle\Documents\DocumentRepository;
 use AppBundle\Entity\Adherent;
 use League\Flysystem\FileNotFoundException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class DocumentsController extends Controller
 {
     /**
-     * @Route(name="app_documents_index")
-     * @Method("GET")
+     * @Route(name="app_documents_index", methods={"GET"})
      */
     public function indexAction()
     {
@@ -30,9 +28,9 @@ class DocumentsController extends Controller
      * @Route(
      *     "/dossier/{type}/{path}",
      *     requirements={"type": "adherents|animateurs|referents|animateurs-etrangers", "path": ".+"},
-     *     name="app_documents_directory"
+     *     name="app_documents_directory",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function directoryAction($type, $path)
     {
@@ -49,9 +47,9 @@ class DocumentsController extends Controller
      * @Route(
      *     "/telecharger/{type}/{path}",
      *     requirements={"type": "adherents|animateurs|referents|animateurs-etrangers", "path": ".+"},
-     *     name="app_documents_file"
+     *     name="app_documents_file",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function fileAction($type, $path)
     {

--- a/src/Controller/EnMarche/DonationController.php
+++ b/src/Controller/EnMarche/DonationController.php
@@ -22,7 +22,6 @@ use AppBundle\Repository\DonationRepository;
 use AppBundle\Repository\NewsletterSubscriptionRepository;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,8 +37,7 @@ class DonationController extends Controller
     public const RESULT_STATUS_ERREUR = 'erreur';
 
     /**
-     * @Route(name="donation_index")
-     * @Method("GET")
+     * @Route(name="donation_index", methods={"GET"})
      */
     public function indexAction(Request $request): Response
     {
@@ -58,8 +56,7 @@ class DonationController extends Controller
     }
 
     /**
-     * @Route("/coordonnees", name="donation_informations")
-     * @Method({"GET", "POST"})
+     * @Route("/coordonnees", name="donation_informations", methods={"GET", "POST"})
      */
     public function informationsAction(
         Request $request,
@@ -99,8 +96,7 @@ class DonationController extends Controller
     }
 
     /**
-     * @Route("/{uuid}/paiement", requirements={"uuid": "%pattern_uuid%"}, name="donation_pay")
-     * @Method("GET")
+     * @Route("/{uuid}/paiement", requirements={"uuid": "%pattern_uuid%"}, name="donation_pay", methods={"GET"})
      */
     public function payboxAction(PayboxFormFactory $payboxFormFactory, Donation $donation): Response
     {
@@ -113,8 +109,7 @@ class DonationController extends Controller
     }
 
     /**
-     * @Route("/callback/{_callback_token}", name="donation_callback")
-     * @Method("GET")
+     * @Route("/callback/{_callback_token}", name="donation_callback", methods={"GET"})
      */
     public function callbackAction(
         Request $request,
@@ -134,10 +129,10 @@ class DonationController extends Controller
      * @Route(
      *     "/{uuid}/{status}",
      *     requirements={"status": "effectue|erreur", "uuid": "%pattern_uuid%"},
-     *     name="donation_result"
+     *     name="donation_result",
+     *     methods={"GET"}
      * )
      * @ParamConverter("donation", options={"mapping": {"uuid": "uuid"}})
-     * @Method("GET")
      */
     public function resultAction(
         Request $request,
@@ -178,8 +173,7 @@ class DonationController extends Controller
     }
 
     /**
-     * @Route("/mensuel/annuler", name="donation_subscription_cancel")
-     * @Method({"GET", "POST"})
+     * @Route("/mensuel/annuler", name="donation_subscription_cancel", methods={"GET", "POST"})
      */
     public function cancelSubscriptionAction(
         Request $request,

--- a/src/Controller/EnMarche/EventController.php
+++ b/src/Controller/EnMarche/EventController.php
@@ -13,7 +13,6 @@ use AppBundle\Form\EventRegistrationType;
 use AppBundle\Repository\EventRepository;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +28,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class EventController extends Controller
 {
     /**
-     * @Route(name="app_event_show")
-     * @Method("GET")
+     * @Route(name="app_event_show", methods={"GET"})
      */
     public function showAction(Event $event, EventRepository $eventRepository): Response
     {
@@ -42,8 +40,7 @@ class EventController extends Controller
     }
 
     /**
-     * @Route("/ical", name="app_event_export_ical")
-     * @Method("GET")
+     * @Route("/ical", name="app_event_export_ical", methods={"GET"})
      */
     public function exportIcalAction(Event $event): Response
     {
@@ -57,8 +54,7 @@ class EventController extends Controller
     }
 
     /**
-     * @Route("/inscription", name="app_event_attend")
-     * @Method("GET|POST")
+     * @Route("/inscription", name="app_event_attend", methods={"GET", "POST"})
      * @Entity("event", expr="repository.findOneActiveBySlug(slug)")
      */
     public function attendAction(Request $request, Event $event): Response
@@ -99,9 +95,9 @@ class EventController extends Controller
      * @Route(
      *     path="/confirmation",
      *     name="app_event_attend_confirmation",
-     *     condition="request.query.has('registration')"
+     *     condition="request.query.has('registration')",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function attendConfirmationAction(Request $request, Event $event): Response
     {
@@ -127,8 +123,7 @@ class EventController extends Controller
     }
 
     /**
-     * @Route("/invitation", name="app_event_invite")
-     * @Method("GET|POST")
+     * @Route("/invitation", name="app_event_invite", methods={"GET", "POST"})
      */
     public function inviteAction(Request $request, Event $event): Response
     {
@@ -160,8 +155,7 @@ class EventController extends Controller
     }
 
     /**
-     * @Route("/invitation/merci", name="app_event_invitation_sent")
-     * @Method("GET")
+     * @Route("/invitation/merci", name="app_event_invitation_sent", methods={"GET"})
      */
     public function invitationSentAction(Request $request, Event $event): Response
     {
@@ -178,8 +172,7 @@ class EventController extends Controller
     }
 
     /**
-     * @Route("/desinscription", name="app_event_unregistration", condition="request.isXmlHttpRequest()")
-     * @Method("GET|POST")
+     * @Route("/desinscription", name="app_event_unregistration", condition="request.isXmlHttpRequest()", methods={"GET", "POST"})
      */
     public function unregistrationAction(
         Request $request,

--- a/src/Controller/EnMarche/EventManagerController.php
+++ b/src/Controller/EnMarche/EventManagerController.php
@@ -14,7 +14,6 @@ use AppBundle\Form\ContactMembersType;
 use AppBundle\Form\EventCommandType;
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -41,8 +40,7 @@ class EventManagerController extends Controller
     ];
 
     /**
-     * @Route("/modifier", name="app_event_edit")
-     * @Method("GET|POST")
+     * @Route("/modifier", name="app_event_edit", methods={"GET", "POST"})
      * @Entity("event", expr="repository.findOneActiveBySlug(slug)")
      */
     public function editAction(Request $request, Event $event): Response
@@ -67,8 +65,7 @@ class EventManagerController extends Controller
     }
 
     /**
-     * @Route("/annuler", name="app_event_cancel")
-     * @Method("GET|POST")
+     * @Route("/annuler", name="app_event_cancel", methods={"GET", "POST"})
      * @Entity("event", expr="repository.findOneActiveBySlug(slug)")
      */
     public function cancelAction(Request $request, Event $event, EventCanceledHandler $eventCanceledHandler): Response
@@ -93,8 +90,7 @@ class EventManagerController extends Controller
     }
 
     /**
-     * @Route("/inscrits", name="app_event_members")
-     * @Method("GET")
+     * @Route("/inscrits", name="app_event_members", methods={"GET"})
      */
     public function membersAction(Event $event): Response
     {
@@ -108,8 +104,7 @@ class EventManagerController extends Controller
     }
 
     /**
-     * @Route("/inscrits/exporter", name="app_event_export_members")
-     * @Method("POST")
+     * @Route("/inscrits/exporter", name="app_event_export_members", methods={"POST"})
      */
     public function exportMembersAction(Request $request, Event $event): Response
     {
@@ -127,8 +122,7 @@ class EventManagerController extends Controller
     }
 
     /**
-     * @Route("/inscrits/contacter", name="app_event_contact_members")
-     * @Method("POST")
+     * @Route("/inscrits/contacter", name="app_event_contact_members", methods={"POST"})
      */
     public function contactMembersAction(Request $request, Event $event): Response
     {
@@ -169,8 +163,7 @@ class EventManagerController extends Controller
     }
 
     /**
-     * @Route("/inscrits/imprimer", name="app_event_print_members")
-     * @Method("POST")
+     * @Route("/inscrits/imprimer", name="app_event_print_members", methods={"POST"})
      */
     public function printMembersAction(Request $request, Event $event): Response
     {

--- a/src/Controller/EnMarche/ExplainerController.php
+++ b/src/Controller/EnMarche/ExplainerController.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\OrderArticle;
 use AppBundle\Entity\OrderSection;
 use AppBundle\Entity\Page;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ExplainerController extends AbstractController
 {
     /**
-     * @Route(name="app_explainer_index")
-     * @Method("GET")
+     * @Route(name="app_explainer_index", methods={"GET"})
      */
     public function indexAction()
     {
@@ -28,8 +26,7 @@ class ExplainerController extends AbstractController
     }
 
     /**
-     * @Route("/{slug}", name="app_explainer_article_show")
-     * @Method("GET")
+     * @Route("/{slug}", name="app_explainer_article_show", methods={"GET"})
      * @Entity("article", expr="repository.findPublishedArticle(slug)")
      */
     public function proposalAction(OrderArticle $article)

--- a/src/Controller/EnMarche/FacebookController.php
+++ b/src/Controller/EnMarche/FacebookController.php
@@ -7,7 +7,6 @@ use AppBundle\Exception\BadUuidRequestException;
 use AppBundle\Exception\InvalidUuidException;
 use AppBundle\Repository\FacebookProfileRepository;
 use Facebook\Exceptions\FacebookSDKException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,8 +20,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class FacebookController extends Controller
 {
     /**
-     * @Route("", name="app_facebook_index")
-     * @Method("GET")
+     * @Route("", name="app_facebook_index", methods={"GET"})
      */
     public function indexAction(): Response
     {
@@ -30,8 +28,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/connexion", name="app_facebook_auth")
-     * @Method("GET")
+     * @Route("/connexion", name="app_facebook_auth", methods={"GET"})
      */
     public function authAction(Request $request): RedirectResponse
     {
@@ -48,8 +45,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/import", name="app_facebook_user_id")
-     * @Method("GET")
+     * @Route("/import", name="app_facebook_user_id", methods={"GET"})
      */
     public function importAction(Request $request): RedirectResponse
     {
@@ -75,8 +71,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/choisir-une-image", name="app_facebook_picture_choose")
-     * @Method("GET")
+     * @Route("/choisir-une-image", name="app_facebook_picture_choose", methods={"GET"})
      */
     public function choosePictureAction(Request $request): Response
     {
@@ -112,8 +107,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/build", name="app_facebook_picture_build")
-     * @Method("GET")
+     * @Route("/build", name="app_facebook_picture_build", methods={"GET"})
      */
     public function buildPictureAction(Request $request): Response
     {
@@ -129,8 +123,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/upload/permission", name="app_facebook_picture_upload_permission")
-     * @Method("GET")
+     * @Route("/upload/permission", name="app_facebook_picture_upload_permission", methods={"GET"})
      */
     public function uploadPicturePermissionAction(Request $request): Response
     {
@@ -156,8 +149,7 @@ class FacebookController extends Controller
     }
 
     /**
-     * @Route("/upload/executer", name="app_facebook_picture_upload_execute")
-     * @Method("GET")
+     * @Route("/upload/executer", name="app_facebook_picture_upload_execute", methods={"GET"})
      */
     public function uploadPictureExecuteAction(Request $request): Response
     {

--- a/src/Controller/EnMarche/HomeController.php
+++ b/src/Controller/EnMarche/HomeController.php
@@ -8,7 +8,6 @@ use AppBundle\Entity\NewsletterSubscription;
 use AppBundle\Exception\SitemapException;
 use AppBundle\Form\NewsletterSubscriptionType;
 use AppBundle\Sitemap\SitemapFactory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,8 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class HomeController extends Controller
 {
     /**
-     * @Route("/", name="homepage")
-     * @Method("GET")
+     * @Route("/", name="homepage", methods={"GET"})
      */
     public function indexAction(Request $request, GeoCoder $geoCoder): Response
     {
@@ -40,8 +38,7 @@ class HomeController extends Controller
     }
 
     /**
-     * @Route("/sitemap.xml", name="app_sitemap_index")
-     * @Method("GET")
+     * @Route("/sitemap.xml", name="app_sitemap_index", methods={"GET"})
      */
     public function sitemapIndexAction(): Response
     {
@@ -53,9 +50,9 @@ class HomeController extends Controller
      *     "/sitemap_{type}_{page}.xml",
      *     requirements={"type": AppBundle\Sitemap\SitemapFactory::ALL_TYPES, "page": "\d+"},
      *     defaults={"page": "1"},
-     *     name="app_sitemap"
+     *     name="app_sitemap",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function sitemapAction(string $type, int $page): Response
     {

--- a/src/Controller/EnMarche/InteractiveController.php
+++ b/src/Controller/EnMarche/InteractiveController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\MyEuropeInvitation;
 use AppBundle\Form\MyEuropeType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,8 +14,7 @@ class InteractiveController extends Controller
     public const MESSAGE_SUBJECT = 'Pour une Renaissance européenne';
 
     /**
-     * @Route("/mon-europe", name="app_my_europe")
-     * @Method("GET|POST")
+     * @Route("/mon-europe", name="app_my_europe", methods={"GET", "POST"})
      */
     public function myEuropeAction(Request $request): Response
     {
@@ -49,8 +47,7 @@ class InteractiveController extends Controller
     }
 
     /**
-     * @Route("/mon-europe/recommencer", name="app_my_europe_restart")
-     * @Method("GET")
+     * @Route("/mon-europe/recommencer", name="app_my_europe_restart", methods={"GET"})
      */
     public function restartMyEuropeAction(Request $request): Response
     {
@@ -60,8 +57,7 @@ class InteractiveController extends Controller
     }
 
     /**
-     * @Route("/mon-europe/{uuid}/merci", name="app_my_europe_mail_sent")
-     * @Method("GET")
+     * @Route("/mon-europe/{uuid}/merci", name="app_my_europe_mail_sent", methods={"GET"})
      */
     public function mailSentAction(MyEuropeInvitation $myEurope): Response
     {

--- a/src/Controller/EnMarche/InvitationController.php
+++ b/src/Controller/EnMarche/InvitationController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\Invite;
 use AppBundle\Form\InvitationType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class InvitationController extends Controller
 {
     /**
-     * @Route("/invitation", name="invitation_form")
-     * @Method({"GET", "POST"})
+     * @Route("/invitation", name="invitation_form", methods={"GET", "POST"})
      */
     public function invitationAction(Request $request)
     {

--- a/src/Controller/EnMarche/JeMarcheController.php
+++ b/src/Controller/EnMarche/JeMarcheController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\JeMarcheReport;
 use AppBundle\Form\JeMarcheReportType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class JeMarcheController extends Controller
 {
     /**
-     * @Route("/jagis", name="app_je_marche")
-     * @Method("GET")
+     * @Route("/jagis", name="app_je_marche", methods={"GET"})
      */
     public function indexAction(): Response
     {
@@ -22,8 +20,7 @@ class JeMarcheController extends Controller
     }
 
     /**
-     * @Route("/jemarche", name="app_je_marche_action")
-     * @Method("GET|POST")
+     * @Route("/jemarche", name="app_je_marche_action", methods={"GET", "POST"})
      */
     public function actionAction(Request $request): Response
     {
@@ -44,8 +41,7 @@ class JeMarcheController extends Controller
     }
 
     /**
-     * @Route("/jemarche/merci", name="app_je_marche_thanks")
-     * @Method("GET")
+     * @Route("/jemarche/merci", name="app_je_marche_thanks", methods={"GET"})
      */
     public function thanksAction(): Response
     {
@@ -53,8 +49,7 @@ class JeMarcheController extends Controller
     }
 
     /**
-     * @Route("/je-marche", name="app_je_marche_redirect")
-     * @Method("GET")
+     * @Route("/je-marche", name="app_je_marche_redirect", methods={"GET"})
      */
     public function redirectAction(): Response
     {

--- a/src/Controller/EnMarche/LegacyController.php
+++ b/src/Controller/EnMarche/LegacyController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\EnMarche;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\Event;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class LegacyController extends Controller
 {
     /**
-     * @Route("/espaceperso/evenement/{id}-{slug}", requirements={"id": "\d+"})
-     * @Method("GET")
+     * @Route("/espaceperso/evenement/{id}-{slug}", requirements={"id": "\d+"}, methods={"GET"})
      * @Entity("event", expr="repository.find(id)")
      */
     public function redirectEventAction(Event $event): Response
@@ -25,8 +23,7 @@ class LegacyController extends Controller
     }
 
     /**
-     * @Route("/espaceperso/comite/{id}-{slug}", requirements={"id": "\d+"})
-     * @Method("GET")
+     * @Route("/espaceperso/comite/{id}-{slug}", requirements={"id": "\d+"}, methods={"GET"})
      * @Entity("committee", expr="repository.find(id)")
      */
     public function redirectCommitteeAction(Committee $committee): Response

--- a/src/Controller/EnMarche/LegislativeCandidateController.php
+++ b/src/Controller/EnMarche/LegislativeCandidateController.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Form\LegislativeCampaignContactMessageType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,8 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class LegislativeCandidateController extends Controller
 {
     /**
-     * @Route("", name="app_legislative_candidates_platform")
-     * @Method("GET")
+     * @Route("", name="app_legislative_candidates_platform", methods={"GET"})
      */
     public function indexAction(): Response
     {
@@ -26,8 +24,7 @@ class LegislativeCandidateController extends Controller
     }
 
     /**
-     * @Route("/contact", name="app_legislative_candidates_platform_contact")
-     * @Method("GET|POST")
+     * @Route("/contact", name="app_legislative_candidates_platform_contact", methods={"GET", "POST"})
      */
     public function contactAction(Request $request): Response
     {

--- a/src/Controller/EnMarche/MapController.php
+++ b/src/Controller/EnMarche/MapController.php
@@ -6,15 +6,13 @@ use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Committee;
 use AppBundle\Entity\Event;
 use AppBundle\Entity\EventCategory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
 class MapController extends Controller
 {
     /**
-     * @Route("/le-mouvement/la-carte", name="map_committees")
-     * @Method("GET")
+     * @Route("/le-mouvement/la-carte", name="map_committees", methods={"GET"})
      */
     public function committeesAction()
     {

--- a/src/Controller/EnMarche/MembershipController.php
+++ b/src/Controller/EnMarche/MembershipController.php
@@ -25,7 +25,6 @@ use AppBundle\Repository\AdherentRepository;
 use AppBundle\Security\Http\Session\AnonymousFollowerSession;
 use GuzzleHttp\Exception\ConnectException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -39,8 +38,7 @@ class MembershipController extends Controller
     /**
      * This action enables a guest user to adhere to the community.
      *
-     * @Route("/inscription-utilisateur", name="app_membership_register")
-     * @Method("GET|POST")
+     * @Route("/inscription-utilisateur", name="app_membership_register", methods={"GET", "POST"})
      */
     public function registerAction(
         Request $request,
@@ -79,8 +77,7 @@ class MembershipController extends Controller
     /**
      * This action enables a guest user to adhere to the community.
      *
-     * @Route("/adhesion", name="app_membership_join")
-     * @Method("GET|POST")
+     * @Route("/adhesion", name="app_membership_join", methods={"GET", "POST"})
      */
     public function adhesionAction(Request $request, GeoCoder $geoCoder): Response
     {
@@ -163,8 +160,7 @@ class MembershipController extends Controller
     /**
      * This action is the landing page at the end of the subscription process.
      *
-     * @Route("/presque-fini", name="app_membership_complete")
-     * @Method("GET")
+     * @Route("/presque-fini", name="app_membership_complete", methods={"GET"})
      */
     public function completeAction(MembershipRegistrationProcess $membershipRegistrationProcess): Response
     {
@@ -187,9 +183,9 @@ class MembershipController extends Controller
      *     requirements={
      *         "adherent_uuid": "%pattern_uuid%",
      *         "activation_token": "%pattern_sha1%"
-     *     }
+     *     },
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      * @Entity("adherent", expr="repository.findOneByUuid(adherent_uuid)")
      * @Entity("activationToken", expr="repository.findByToken(activation_token)")
      */
@@ -237,8 +233,7 @@ class MembershipController extends Controller
     /**
      * This action enables a new user to pin his/her interests during the registration process.
      *
-     * @Route("/inscription/centre-interets", name="app_membership_pin_interests")
-     * @Method("GET|POST")
+     * @Route("/inscription/centre-interets", name="app_membership_pin_interests", methods={"GET", "POST"})
      * @Security("is_granted('MEMBERSHIP_REGISTRATION_IN_PROGRESS')")
      */
     public function pinInterestsAction(
@@ -271,8 +266,7 @@ class MembershipController extends Controller
     /**
      * This action enables a user to follow some committees during the registration process.
      *
-     * @Route("/inscription/choisir-des-comites", name="app_membership_choose_committees_around_adherent")
-     * @Method("GET|POST")
+     * @Route("/inscription/choisir-des-comites", name="app_membership_choose_committees_around_adherent", methods={"GET", "POST"})
      * @Security("is_granted('MEMBERSHIP_REGISTRATION_IN_PROGRESS')")
      */
     public function chooseCommitteesAction(
@@ -321,8 +315,7 @@ class MembershipController extends Controller
     /**
      * This action enables a user to donate during the registration process.
      *
-     * @Route("/inscription/don", name="app_membership_donation")
-     * @Method("GET")
+     * @Route("/inscription/don", name="app_membership_donation", methods={"GET"})
      * @Security("is_granted('MEMBERSHIP_REGISTRATION_IN_PROGRESS')")
      */
     public function donationAction(

--- a/src/Controller/EnMarche/NewsletterController.php
+++ b/src/Controller/EnMarche/NewsletterController.php
@@ -8,7 +8,6 @@ use AppBundle\Form\NewsletterInvitationType;
 use AppBundle\Form\NewsletterSubscriptionType;
 use AppBundle\Form\NewsletterUnsubscribeType;
 use AppBundle\Newsletter\Invitation;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
@@ -17,8 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class NewsletterController extends Controller
 {
     /**
-     * @Route("/newsletter", name="newsletter_subscription")
-     * @Method({"GET", "POST"})
+     * @Route("/newsletter", name="newsletter_subscription", methods={"GET", "POST"})
      */
     public function subscriptionAction(Request $request, GeoCoder $geoCoder)
     {
@@ -55,8 +53,7 @@ class NewsletterController extends Controller
     }
 
     /**
-     * @Route("/newsletter/merci", name="newsletter_subscription_subscribed")
-     * @Method("GET")
+     * @Route("/newsletter/merci", name="newsletter_subscription_subscribed", methods={"GET"})
      */
     public function subscribedAction()
     {
@@ -64,8 +61,7 @@ class NewsletterController extends Controller
     }
 
     /**
-     * @Route("/newsletter/desinscription", name="newsletter_unsubscribe")
-     * @Method({"GET", "POST"})
+     * @Route("/newsletter/desinscription", name="newsletter_unsubscribe", methods={"GET", "POST"})
      */
     public function unsubscribeAction(Request $request)
     {
@@ -84,8 +80,7 @@ class NewsletterController extends Controller
     }
 
     /**
-     * @Route("/newsletter/desinscription/desinscrit", name="newsletter_unsubscribe_unsubscribed")
-     * @Method("GET")
+     * @Route("/newsletter/desinscription/desinscrit", name="newsletter_unsubscribe_unsubscribed", methods={"GET"})
      */
     public function unsubscribedAction()
     {
@@ -93,8 +88,7 @@ class NewsletterController extends Controller
     }
 
     /**
-     * @Route("/newsletter/invitation", name="newsletter_invitation")
-     * @Method("GET|POST")
+     * @Route("/newsletter/invitation", name="newsletter_invitation", methods={"GET", "POST"})
      */
     public function invitationAction(Request $request)
     {
@@ -117,8 +111,7 @@ class NewsletterController extends Controller
     }
 
     /**
-     * @Route("/newsletter/invitation/merci", name="newsletter_invitation_sent")
-     * @Method("GET")
+     * @Route("/newsletter/invitation/merci", name="newsletter_invitation_sent", methods={"GET"})
      */
     public function invitationSentAction(Request $request)
     {

--- a/src/Controller/EnMarche/PageController.php
+++ b/src/Controller/EnMarche/PageController.php
@@ -6,7 +6,6 @@ use AppBundle\Controller\CanaryControllerTrait;
 use AppBundle\Entity\FacebookVideo;
 use AppBundle\Entity\Page;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -20,8 +19,7 @@ class PageController extends Controller
     use CanaryControllerTrait;
 
     /**
-     * @Route("/formation", name="page_campus")
-     * @Method("GET")
+     * @Route("/formation", name="page_campus", methods={"GET"})
      */
     public function campusAction()
     {
@@ -29,8 +27,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/formation/dificultes-internet", name="page_campus_internet")
-     * @Method("GET")
+     * @Route("/formation/dificultes-internet", name="page_campus_internet", methods={"GET"})
      */
     public function campusInternetAction()
     {
@@ -38,8 +35,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/emmanuel-macron", name="page_emmanuel_macron")
-     * @Method("GET")
+     * @Route("/emmanuel-macron", name="page_emmanuel_macron", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('emmanuel-macron')")
      */
     public function emmanuelMacronAction(Page $page)
@@ -48,8 +44,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/emmanuel-macron/revolution", name="page_emmanuel_macron_revolution")
-     * @Method("GET")
+     * @Route("/emmanuel-macron/revolution", name="page_emmanuel_macron_revolution", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('emmanuel-macron/revolution')")
      */
     public function emmanuelMacronRevolutionAction(Page $page)
@@ -58,8 +53,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/emmanuel-macron/videos", name="page_emmanuel_macron_videos")
-     * @Method("GET")
+     * @Route("/emmanuel-macron/videos", name="page_emmanuel_macron_videos", methods={"GET"})
      */
     public function emmanuelMacronVideosAction()
     {
@@ -69,8 +63,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/le-mouvement", name="page_le_mouvement")
-     * @Method("GET")
+     * @Route("/le-mouvement", name="page_le_mouvement", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('le-mouvement')")
      */
     public function mouvementValeursAction(Page $page)
@@ -79,8 +72,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/le-mouvement/legislatives", name="page_le_mouvement_legislatives")
-     * @Method("GET")
+     * @Route("/le-mouvement/legislatives", name="page_le_mouvement_legislatives", methods={"GET"})
      */
     public function mouvementLegislativesAction()
     {
@@ -88,8 +80,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/le-mouvement/les-comites", name="page_le_mouvement_les_comites")
-     * @Method("GET")
+     * @Route("/le-mouvement/les-comites", name="page_le_mouvement_les_comites", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('le-mouvement/les-comites')")
      */
     public function mouvementComitesAction(Page $page)
@@ -98,8 +89,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/le-mouvement/devenez-benevole", name="page_le_mouvement_devenez_benevole")
-     * @Method("GET")
+     * @Route("/le-mouvement/devenez-benevole", name="page_le_mouvement_devenez_benevole", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('le-mouvement/devenez-benevole')")
      */
     public function mouvementBenevoleAction(Page $page)
@@ -108,8 +98,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/mentions-legales", name="page_mentions_legales")
-     * @Method("GET")
+     * @Route("/mentions-legales", name="page_mentions_legales", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('mentions-legales')")
      */
     public function mentionsLegalesAction(Page $page)
@@ -118,8 +107,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/politique-cookies", name="page_politique_cookies")
-     * @Method("GET")
+     * @Route("/politique-cookies", name="page_politique_cookies", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('politique-cookies')")
      */
     public function politiqueCookiesAction(Page $page)
@@ -128,8 +116,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/okcandidatlegislatives", name="legislatives_confirm_newsletter")
-     * @Method("GET")
+     * @Route("/okcandidatlegislatives", name="legislatives_confirm_newsletter", methods={"GET"})
      */
     public function legislativesConfirmNewsletterAction()
     {
@@ -137,8 +124,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/elles-marchent", name="page_elles_marchent")
-     * @Method("GET")
+     * @Route("/elles-marchent", name="page_elles_marchent", methods={"GET"})
      */
     public function ellesMarchentAction()
     {
@@ -146,8 +132,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/candidatures-delegue-general-et-bureau-executif", name="page_burex")
-     * @Method("GET")
+     * @Route("/candidatures-delegue-general-et-bureau-executif", name="page_burex", methods={"GET"})
      */
     public function burexAction()
     {
@@ -155,8 +140,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/1000-talents", name="page_1000_talents")
-     * @Method("GET")
+     * @Route("/1000-talents", name="page_1000_talents", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('1000-talents')")
      */
     public function page1000TalentsAction(Page $page)
@@ -165,8 +149,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/cestduconcret", name="page_concrete")
-     * @Method("GET")
+     * @Route("/cestduconcret", name="page_concrete", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('concrete')")
      */
     public function concreteAction(Page $page)
@@ -175,8 +158,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/action-talents", name="page_action_talents")
-     * @Method("GET")
+     * @Route("/action-talents", name="page_action_talents", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('action-talents')")
      */
     public function actionTalentsAction(Page $page)
@@ -185,8 +167,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/grande-marche-europe", name="page_grande_marche_europe")
-     * @Method("GET")
+     * @Route("/grande-marche-europe", name="page_grande_marche_europe", methods={"GET"})
      */
     public function grandeMarcheEuropeAction()
     {
@@ -194,8 +175,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/action-talents/candidater", name="page_action_talents_apply")
-     * @Method("GET")
+     * @Route("/action-talents/candidater", name="page_action_talents_apply", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('action-talents/candidater')")
      */
     public function actionTalentsApplicationAction(Page $page)
@@ -204,8 +184,7 @@ class PageController extends Controller
     }
 
     /**
-     * @Route("/nos-offres", name="page_jobs")
-     * @Method("GET")
+     * @Route("/nos-offres", name="page_jobs", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('nos-offres')")
      */
     public function jobsAction(Page $page)

--- a/src/Controller/EnMarche/ProcurationController.php
+++ b/src/Controller/EnMarche/ProcurationController.php
@@ -13,7 +13,6 @@ use AppBundle\Form\Procuration\ProcurationRequestType;
 use AppBundle\Procuration\ElectionContext;
 use AppBundle\Procuration\ProcurationManager;
 use AppBundle\Procuration\ProcurationSession;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,8 +24,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ProcurationController extends Controller
 {
     /**
-     * @Route(name="app_procuration_landing")
-     * @Method("GET")
+     * @Route(name="app_procuration_landing", methods={"GET"})
      */
     public function landingAction(ProcurationSession $procurationSession): Response
     {
@@ -41,9 +39,9 @@ class ProcurationController extends Controller
      * @Route(
      *     "/choisir/{action}",
      *     requirements={"action": AppBundle\Procuration\ElectionContext::CONTROLLER_ACTION_REQUIREMENT},
-     *     name="app_procuration_choose_election"
+     *     name="app_procuration_choose_election",
+     *     methods={"GET", "POST"}
      * )
-     * @Method("GET|POST")
      */
     public function chooseElectionAction(
         Request $request,
@@ -71,13 +69,12 @@ class ProcurationController extends Controller
     }
 
     /**
-     * @Route("/je-demande", name="app_procuration_index_legacy")
+     * @Route("/je-demande", name="app_procuration_index_legacy", methods={"GET", "POST"})
      * @Route(
      *     "/je-demande/{step}",
      *     requirements={"step": "mon-lieu-de-vote|mes-coordonnees|ma-procuration"},
      *     name="app_procuration_request"
      * )
-     * @Method("GET|POST")
      */
     public function requestAction(
         Request $request,
@@ -130,8 +127,7 @@ class ProcurationController extends Controller
     }
 
     /**
-     * @Route("/je-demande/merci", name="app_procuration_request_thanks")
-     * @Method("GET")
+     * @Route("/je-demande/merci", name="app_procuration_request_thanks", methods={"GET"})
      */
     public function requestThanksAction(): Response
     {
@@ -139,8 +135,7 @@ class ProcurationController extends Controller
     }
 
     /**
-     * @Route("/je-propose", name="app_procuration_proxy_proposal")
-     * @Method("GET|POST")
+     * @Route("/je-propose", name="app_procuration_proxy_proposal", methods={"GET", "POST"})
      */
     public function proxyProposalAction(
         Request $request,
@@ -193,8 +188,7 @@ class ProcurationController extends Controller
     }
 
     /**
-     * @Route("/je-propose/merci", name="app_procuration_proposal_thanks")
-     * @Method("GET")
+     * @Route("/je-propose/merci", name="app_procuration_proposal_thanks", methods={"GET"})
      */
     public function proposalThanksAction(Request $request): Response
     {
@@ -204,8 +198,7 @@ class ProcurationController extends Controller
     }
 
     /**
-     * @Route("/ma-demande/{id}/{token}", requirements={"token": "%pattern_uuid%"}, name="app_procuration_my_request")
-     * @Method("GET")
+     * @Route("/ma-demande/{id}/{token}", requirements={"token": "%pattern_uuid%"}, name="app_procuration_my_request", methods={"GET"})
      */
     public function myRequestAction(ProcurationRequest $request, string $token): Response
     {

--- a/src/Controller/EnMarche/ProcurationManagerController.php
+++ b/src/Controller/EnMarche/ProcurationManagerController.php
@@ -11,7 +11,6 @@ use AppBundle\Procuration\Filter\ProcurationRequestFilters;
 use AppBundle\Procuration\ProcurationManager;
 use AppBundle\Repository\ProcurationRequestRepository;
 use Doctrine\DBAL\Driver\DriverException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -29,8 +28,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ProcurationManagerController extends Controller
 {
     /**
-     * @Route(name="app_procuration_manager_requests")
-     * @Method("GET")
+     * @Route(name="app_procuration_manager_requests", methods={"GET"})
      */
     public function requestsAction(Request $request, ProcurationManager $manager): Response
     {
@@ -51,8 +49,7 @@ class ProcurationManagerController extends Controller
     }
 
     /**
-     * @Route("/plus", name="app_procuration_manager_requests_list", condition="request.isXmlHttpRequest()")
-     * @Method("GET")
+     * @Route("/plus", name="app_procuration_manager_requests_list", condition="request.isXmlHttpRequest()", methods={"GET"})
      */
     public function requestsMoreAction(Request $request, ProcurationManager $manager): Response
     {
@@ -72,8 +69,7 @@ class ProcurationManagerController extends Controller
     }
 
     /**
-     * @Route("/mandataires", name="app_procuration_manager_proposals")
-     * @Method("GET")
+     * @Route("/mandataires", name="app_procuration_manager_proposals", methods={"GET"})
      */
     public function proposalsAction(Request $request, ProcurationManager $manager): Response
     {
@@ -94,8 +90,7 @@ class ProcurationManagerController extends Controller
     }
 
     /**
-     * @Route("/mandataires/plus", name="app_procuration_manager_proposals_list", condition="request.isXmlHttpRequest()")
-     * @Method("GET")
+     * @Route("/mandataires/plus", name="app_procuration_manager_proposals_list", condition="request.isXmlHttpRequest()", methods={"GET"})
      */
     public function proposalsMoreAction(Request $request, ProcurationManager $manager): Response
     {
@@ -118,9 +113,9 @@ class ProcurationManagerController extends Controller
      * @Route(
      *     "/mandataires/{id}/{action}",
      *     requirements={ "id": "\d+", "action": AppBundle\Entity\ProcurationProxy::ACTIONS_URI_REGEX },
-     *     name="app_procuration_manager_proposal_transform"
+     *     name="app_procuration_manager_proposal_transform",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function proposalTransformAction(int $id, string $action, ProcurationManager $manager): Response
     {
@@ -143,9 +138,9 @@ class ProcurationManagerController extends Controller
      * @Route(
      *     "/demande/{id}",
      *     requirements={"id": "\d+"},
-     *     name="app_procuration_manager_request"
+     *     name="app_procuration_manager_request",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function requestAction(int $id, ProcurationManager $manager): Response
     {
@@ -163,9 +158,9 @@ class ProcurationManagerController extends Controller
      * @Route(
      *     "/demande/{id}/{action}/{token}",
      *     requirements={"id": "\d+", "action": AppBundle\Entity\ProcurationRequest::ACTIONS_URI_REGEX},
-     *     name="app_procuration_manager_request_transform"
+     *     name="app_procuration_manager_request_transform",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function requestTransformAction(
         int $id,
@@ -196,9 +191,9 @@ class ProcurationManagerController extends Controller
      * @Route(
      *     "/demande/{id}/associer/{proxyId}",
      *     requirements={"id": "\d+"},
-     *     name="app_procuration_manager_request_associate"
+     *     name="app_procuration_manager_request_associate",
+     *     methods={"GET", "POST"}
      * )
-     * @Method("GET|POST")
      * @ParamConverter("proxy", class="AppBundle\Entity\ProcurationProxy", options={"id": "proxyId"})
      */
     public function requestAssociateAction(
@@ -243,9 +238,9 @@ class ProcurationManagerController extends Controller
      * @Route(
      *     "/demande/{id}/desassocier",
      *     requirements={"id": "\d+"},
-     *     name="app_procuration_manager_request_deassociate"
+     *     name="app_procuration_manager_request_deassociate",
+     *     methods={"GET", "POST"}
      * )
-     * @Method("GET|POST")
      */
     public function requestDessociateAction(
         Request $sfRequest,

--- a/src/Controller/EnMarche/ProgramController.php
+++ b/src/Controller/EnMarche/ProgramController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\EnMarche;
 use AppBundle\Entity\Page;
 use AppBundle\Entity\Proposal;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -15,9 +14,8 @@ class ProgramController extends AbstractController
     /**
      * Redirection to the program.
      *
-     * @Route("/programme")
+     * @Route("/programme", methods={"GET"})
      * @Route("/le-programme")
-     * @Method("GET")
      */
     public function redirectAction()
     {
@@ -25,8 +23,7 @@ class ProgramController extends AbstractController
     }
 
     /**
-     * @Route("/emmanuel-macron/le-programme", name="program_index")
-     * @Method("GET")
+     * @Route("/emmanuel-macron/le-programme", name="program_index", methods={"GET"})
      * @Entity("page", expr="repository.findOneBySlug('emmanuel-macron-propositions')")
      */
     public function indexAction(Page $page)
@@ -38,8 +35,7 @@ class ProgramController extends AbstractController
     }
 
     /**
-     * @Route("/emmanuel-macron/le-programme/{slug}", name="program_proposal")
-     * @Method("GET")
+     * @Route("/emmanuel-macron/le-programme/{slug}", name="program_proposal", methods={"GET"})
      * @Entity("proposal", expr="repository.findPublishedProposal(slug)")
      */
     public function proposalAction(Proposal $proposal)

--- a/src/Controller/EnMarche/ReferentController.php
+++ b/src/Controller/EnMarche/ReferentController.php
@@ -43,7 +43,6 @@ use AppBundle\Repository\ReferentOrganizationalChart\ReferentPersonLinkRepositor
 use AppBundle\Repository\ReferentRepository;
 use Doctrine\Common\Persistence\ObjectManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -60,8 +59,7 @@ class ReferentController extends Controller
     public const TOKEN_ID = 'referent_managed_users';
 
     /**
-     * @Route("/utilisateurs", name="app_referent_users")
-     * @Method("GET")
+     * @Route("/utilisateurs", name="app_referent_users", methods={"GET"})
      */
     public function usersAction(Request $request): Response
     {
@@ -86,8 +84,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/utilisateurs/message", name="app_referent_users_message")
-     * @Method("GET|POST")
+     * @Route("/utilisateurs/message", name="app_referent_users_message", methods={"GET", "POST"})
      */
     public function usersSendMessageAction(Request $request): Response
     {
@@ -122,8 +119,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/evenements", name="app_referent_events")
-     * @Method("GET")
+     * @Route("/evenements", name="app_referent_events", methods={"GET"})
      */
     public function eventsAction(EventRepository $eventRepository, ManagedEventsExporter $eventsExporter): Response
     {
@@ -133,8 +129,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/evenements/creer", name="app_referent_events_create")
-     * @Method("GET|POST")
+     * @Route("/evenements/creer", name="app_referent_events_create", methods={"GET", "POST"})
      */
     public function eventsCreateAction(Request $request, GeoCoder $geoCoder): Response
     {
@@ -163,8 +158,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/evenements-institutionnels", name="app_referent_institutional_events")
-     * @Method("GET")
+     * @Route("/evenements-institutionnels", name="app_referent_institutional_events", methods={"GET"})
      */
     public function institutionalEventsAction(
         InstitutionalEventRepository $institutionalEventRepository,
@@ -178,8 +172,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/evenements-institutionnels/creer", name="app_referent_institutional_events_create")
-     * @Method("GET|POST")
+     * @Route("/evenements-institutionnels/creer", name="app_referent_institutional_events_create", methods={"GET", "POST"})
      */
     public function institutionalEventsCreateAction(
         Request $request,
@@ -270,8 +263,7 @@ class ReferentController extends Controller
     }
 
     /**
-     * @Route("/comites", name="app_referent_committees")
-     * @Method("GET")
+     * @Route("/comites", name="app_referent_committees", methods={"GET"})
      */
     public function committeesAction(
         CommitteeRepository $committeeRepository,

--- a/src/Controller/EnMarche/ReferentNominationController.php
+++ b/src/Controller/EnMarche/ReferentNominationController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\Referent;
 use AppBundle\Entity\ReferentArea;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ReferentNominationController extends Controller
 {
     /**
-     * @Route("", name="our_referents_homepage")
-     * @Method("GET")
+     * @Route("", name="our_referents_homepage", methods={"GET"})
      */
     public function indexAction(Request $request): Response
     {
@@ -32,8 +30,7 @@ class ReferentNominationController extends Controller
     }
 
     /**
-     * @Route("/{slug}", name="our_referents_referent")
-     * @Method("GET")
+     * @Route("/{slug}", name="our_referents_referent", methods={"GET"})
      */
     public function candidateAction(Referent $referent): Response
     {

--- a/src/Controller/EnMarche/ReportController.php
+++ b/src/Controller/EnMarche/ReportController.php
@@ -7,7 +7,6 @@ use AppBundle\Report\ReportCommand;
 use AppBundle\Report\ReportCreationCommandHandler;
 use AppBundle\Report\ReportManager;
 use AppBundle\Report\ReportType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,9 +24,9 @@ class ReportController extends AbstractController
      *     requirements={
      *         "type": AppBundle\Report\ReportType::TYPES_URI_PATTERN,
      *         "uuid": "%pattern_uuid%"
-     *     }
+     *     },
+     *     methods={"GET", "POST"}
      * )
-     * @Method("GET|POST")
      * @Security("is_granted('REPORT')")
      */
     public function reportAction(

--- a/src/Controller/EnMarche/SearchController.php
+++ b/src/Controller/EnMarche/SearchController.php
@@ -11,7 +11,6 @@ use AppBundle\Entity\EventGroupCategory;
 use AppBundle\Geocoder\Exception\GeocodingException;
 use AppBundle\Search\SearchParametersFilter;
 use AppBundle\Search\SearchResultsProvidersManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,9 +19,8 @@ use Symfony\Component\Routing\Annotation\Route;
 class SearchController extends Controller
 {
     /**
-     * @Route("/evenements", name="app_search_events")
+     * @Route("/evenements", name="app_search_events", methods={"GET"})
      * @Route("/evenements/categorie/{slug}", name="app_search_events_by_category")
-     * @Method("GET")
      */
     public function searchEventsAction(Request $request, string $slug = null)
     {
@@ -61,8 +59,7 @@ class SearchController extends Controller
     }
 
     /**
-     * @Route("/comites", name="app_search_committees")
-     * @Method("GET")
+     * @Route("/comites", name="app_search_committees", methods={"GET"})
      */
     public function searchCommitteesAction(Request $request)
     {
@@ -88,8 +85,7 @@ class SearchController extends Controller
     }
 
     /**
-     * @Route("/recherche/projets-citoyens", name="app_search_citizen_projects")
-     * @Method("GET")
+     * @Route("/recherche/projets-citoyens", name="app_search_citizen_projects", methods={"GET"})
      */
     public function searchCitizenProjectsAction()
     {
@@ -97,8 +93,7 @@ class SearchController extends Controller
     }
 
     /**
-     * @Route("/recherche", name="app_search")
-     * @Method("GET")
+     * @Route("/recherche", name="app_search", methods={"GET"})
      */
     public function resultsAction(Request $request)
     {
@@ -118,8 +113,7 @@ class SearchController extends Controller
     }
 
     /**
-     * @Route("/tous-les-evenements/{page}", requirements={"page": "\d+"}, name="app_search_all_events")
-     * @Method("GET")
+     * @Route("/tous-les-evenements/{page}", requirements={"page": "\d+"}, name="app_search_all_events", methods={"GET"})
      */
     public function allEventsAction(int $page = 1)
     {
@@ -142,8 +136,7 @@ class SearchController extends Controller
     }
 
     /**
-     * @Route("/tous-les-comites/{page}", requirements={"page": "\d+"}, name="app_search_all_committees")
-     * @Method("GET")
+     * @Route("/tous-les-comites/{page}", requirements={"page": "\d+"}, name="app_search_all_committees", methods={"GET"})
      */
     public function allCommitteesAction(int $page = 1)
     {

--- a/src/Controller/EnMarche/Security/AdminSecurityController.php
+++ b/src/Controller/EnMarche/Security/AdminSecurityController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\EnMarche\Security;
 use AppBundle\Entity\Administrator;
 use AppBundle\Form\LoginType;
 use AppBundle\Security\QrCodeResponseFactory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AdminSecurityController extends Controller
 {
     /**
-     * @Route("/login", name="app_admin_login")
-     * @Method("GET")
+     * @Route("/login", name="app_admin_login", methods={"GET"})
      */
     public function loginAction(): Response
     {
@@ -44,8 +42,7 @@ class AdminSecurityController extends Controller
     }
 
     /**
-     * @Route("/login", name="app_admin_login_check")
-     * @Method("POST")
+     * @Route("/login", name="app_admin_login_check", methods={"POST"})
      */
     public function loginCheckAction()
     {
@@ -54,8 +51,7 @@ class AdminSecurityController extends Controller
     /**
      * QR-code generator to be used with Google Authenticator.
      *
-     * @Route("/qr-code/{id}", name="app_admin_qr_code")
-     * @Method("GET")
+     * @Route("/qr-code/{id}", name="app_admin_qr_code", methods={"GET"})
      */
     public function qrCodeAction(QrCodeResponseFactory $qrCodeResponseFactory, Administrator $administrator): Response
     {

--- a/src/Controller/EnMarche/Security/SecurityController.php
+++ b/src/Controller/EnMarche/Security/SecurityController.php
@@ -12,7 +12,6 @@ use AppBundle\Membership\AdherentChangeEmailHandler;
 use AppBundle\Membership\MembershipRequestHandler;
 use AppBundle\Repository\AdherentRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,8 +24,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class SecurityController extends Controller
 {
     /**
-     * @Route("/connexion", name="app_user_login")
-     * @Method("GET")
+     * @Route("/connexion", name="app_user_login", methods={"GET"})
      */
     public function loginAction(): Response
     {
@@ -47,24 +45,21 @@ class SecurityController extends Controller
     }
 
     /**
-     * @Route("/connexion/check", name="app_user_login_check")
-     * @Method("POST")
+     * @Route("/connexion/check", name="app_user_login_check", methods={"POST"})
      */
     public function loginCheckAction()
     {
     }
 
     /**
-     * @Route("/deconnexion", name="logout")
-     * @Method("GET")
+     * @Route("/deconnexion", name="logout", methods={"GET"})
      */
     public function logoutAction()
     {
     }
 
     /**
-     * @Route("/mot-de-passe-oublie", name="forgot_password")
-     * @Method("GET|POST")
+     * @Route("/mot-de-passe-oublie", name="forgot_password", methods={"GET", "POST"})
      */
     public function retrieveForgotPasswordAction(Request $request)
     {
@@ -103,9 +98,9 @@ class SecurityController extends Controller
      *     requirements={
      *         "adherent_uuid": "%pattern_uuid%",
      *         "reset_password_token": "%pattern_sha1%"
-     *     }
+     *     },
+     *     methods={"GET", "POST"}
      * )
-     * @Method("GET|POST")
      * @Entity("adherent", expr="repository.findOneByUuid(adherent_uuid)")
      * @Entity("resetPasswordToken", expr="repository.findByToken(reset_password_token)")
      */
@@ -143,8 +138,7 @@ class SecurityController extends Controller
     }
 
     /**
-     * @Route("/renvoyer-validation", name="adherent_resend_validation")
-     * @Method("GET")
+     * @Route("/renvoyer-validation", name="adherent_resend_validation", methods={"GET"})
      */
     public function resendValidationEmailAction(
         MembershipRequestHandler $membershipRequestHandler,
@@ -169,9 +163,9 @@ class SecurityController extends Controller
      *     requirements={
      *         "adherent_uuid": "%pattern_uuid%",
      *         "change_email_token": "%pattern_sha1%"
-     *     }
+     *     },
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      * @Entity("adherent", expr="repository.findOneByUuid(adherent_uuid)")
      * @Entity("token", expr="repository.findByToken(change_email_token)")
      */

--- a/src/Controller/EnMarche/SocialShareController.php
+++ b/src/Controller/EnMarche/SocialShareController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\SocialShare;
 use AppBundle\Entity\SocialShareCategory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -12,8 +11,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SocialShareController extends Controller
 {
     /**
-     * @Route("/jepartage", name="app_social_share_list")
-     * @Method("GET")
+     * @Route("/jepartage", name="app_social_share_list", methods={"GET"})
      */
     public function listAction(): Response
     {
@@ -27,8 +25,7 @@ class SocialShareController extends Controller
     }
 
     /**
-     * @Route("/jepartage/{slug}", name="app_social_share_show")
-     * @Method("GET")
+     * @Route("/jepartage/{slug}", name="app_social_share_show", methods={"GET"})
      */
     public function showAction(SocialShareCategory $category): Response
     {
@@ -42,8 +39,7 @@ class SocialShareController extends Controller
     }
 
     /**
-     * @Route("/je-partage")
-     * @Method("GET")
+     * @Route("/je-partage", methods={"GET"})
      */
     public function redirectAction(): Response
     {

--- a/src/Controller/EnMarche/SummaryController.php
+++ b/src/Controller/EnMarche/SummaryController.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\Summary;
 use AppBundle\Membership\MemberActivityTracker;
 use AppBundle\Summary\SummaryManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,8 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SummaryController extends Controller
 {
     /**
-     * @Route(name="app_summary_index")
-     * @Method("GET")
+     * @Route(name="app_summary_index", methods={"GET"})
      * @Entity("summary", expr="repository.findOneBySlug(slug)")
      */
     public function indexAction(Summary $summary): Response

--- a/src/Controller/EnMarche/SummaryManagerController.php
+++ b/src/Controller/EnMarche/SummaryManagerController.php
@@ -14,7 +14,6 @@ use AppBundle\Form\TrainingType;
 use AppBundle\Membership\MemberActivityTracker;
 use AppBundle\Repository\SkillRepository;
 use AppBundle\Summary\SummaryManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +28,7 @@ class SummaryManagerController extends Controller
     use EntityControllerTrait;
 
     /**
-     * @Route(name="app_summary_manager_index")
-     * @Method("GET")
+     * @Route(name="app_summary_manager_index", methods={"GET"})
      */
     public function indexAction()
     {
@@ -46,8 +44,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/activites_recentes/cacher_afficher", name="app_summary_manager_toggle_showing_recent_activities")
-     * @Method("GET")
+     * @Route("/activites_recentes/cacher_afficher", name="app_summary_manager_toggle_showing_recent_activities", methods={"GET"})
      */
     public function toggleShowingRecentActivitiesAction()
     {
@@ -62,8 +59,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/experience/{id}", defaults={"id": ""}, name="app_summary_manager_handle_experience")
-     * @Method("GET|POST")
+     * @Route("/experience/{id}", defaults={"id": ""}, name="app_summary_manager_handle_experience", methods={"GET", "POST"})
      */
     public function handleExperienceAction(Request $request, ?JobExperience $experience)
     {
@@ -88,8 +84,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/experience/{id}/supprimer", name="app_summary_manager_remove_experience")
-     * @Method("DELETE")
+     * @Route("/experience/{id}/supprimer", name="app_summary_manager_remove_experience", methods={"DELETE"})
      */
     public function removeExperienceAction(Request $request, JobExperience $experience)
     {
@@ -107,8 +102,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/formation/{id}", defaults={"id": ""}, name="app_summary_manager_handle_training")
-     * @Method("GET|POST")
+     * @Route("/formation/{id}", defaults={"id": ""}, name="app_summary_manager_handle_training", methods={"GET", "POST"})
      */
     public function handleTrainingAction(Request $request, ?Training $training)
     {
@@ -133,8 +127,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/formation/{id}/supprimer", name="app_summary_manager_remove_training")
-     * @Method("DELETE")
+     * @Route("/formation/{id}/supprimer", name="app_summary_manager_remove_training", methods={"DELETE"})
      */
     public function removeTrainingAction(Request $request, Training $training)
     {
@@ -152,8 +145,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/langue/{id}", defaults={"id": ""}, name="app_summary_manager_handle_language")
-     * @Method("GET|POST")
+     * @Route("/langue/{id}", defaults={"id": ""}, name="app_summary_manager_handle_language", methods={"GET", "POST"})
      */
     public function handleLanguageAction(Request $request, ?Language $language)
     {
@@ -172,8 +164,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/langue/{id}/supprimer", name="app_summary_manager_remove_language")
-     * @Method("DELETE")
+     * @Route("/langue/{id}/supprimer", name="app_summary_manager_remove_language", methods={"DELETE"})
      */
     public function removeLanguageAction(Request $request, Language $language)
     {
@@ -191,8 +182,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/publier", name="app_summary_manager_publish")
-     * @Method("GET")
+     * @Route("/publier", name="app_summary_manager_publish", methods={"GET"})
      */
     public function publishAction()
     {
@@ -207,8 +197,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/depublier", name="app_summary_manager_unpublish")
-     * @Method("GET")
+     * @Route("/depublier", name="app_summary_manager_unpublish", methods={"GET"})
      */
     public function unpublishAction()
     {
@@ -224,9 +213,9 @@ class SummaryManagerController extends Controller
     /**
      * @Route("/competences/autocompletion",
      *     name="app_summary_manager_skills_autocomplete",
-     *     condition="request.isXmlHttpRequest()"
+     *     condition="request.isXmlHttpRequest()",
+     *     methods={"GET"}
      * )
-     * @Method("GET")
      */
     public function skillsAutocompleteAction(Request $request)
     {
@@ -238,8 +227,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/{step}", name="app_summary_manager_step")
-     * @Method("GET|POST")
+     * @Route("/{step}", name="app_summary_manager_step", methods={"GET", "POST"})
      */
     public function stepAction(Request $request, string $step)
     {
@@ -266,8 +254,7 @@ class SummaryManagerController extends Controller
     }
 
     /**
-     * @Route("/photo/supprimer", name="app_summary_manager_remove_photo")
-     * @Method("DELETE")
+     * @Route("/photo/supprimer", name="app_summary_manager_remove_photo", methods={"DELETE"})
      */
     public function removePhotoAction(Request $request): Response
     {

--- a/src/Controller/EnMarche/TonMacronController.php
+++ b/src/Controller/EnMarche/TonMacronController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\EnMarche;
 
 use AppBundle\Entity\TonMacronFriendInvitation;
 use AppBundle\Form\TonMacronInvitationType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class TonMacronController extends Controller
 {
     /**
-     * @Route("/pourquoi-voter-macron")
-     * @Method("GET")
+     * @Route("/pourquoi-voter-macron", methods={"GET"})
      */
     public function redirectAction(): Response
     {
@@ -22,8 +20,7 @@ class TonMacronController extends Controller
     }
 
     /**
-     * @Route("/pourquoi-voter-le-candidat-la-republique-en-marche")
-     * @Method("GET")
+     * @Route("/pourquoi-voter-le-candidat-la-republique-en-marche", methods={"GET"})
      */
     public function redirectLegislativesAction(): Response
     {
@@ -31,8 +28,7 @@ class TonMacronController extends Controller
     }
 
     /**
-     * @Route("/pourquoivoterenmarche", name="app_ton_macron_invite")
-     * @Method("GET|POST")
+     * @Route("/pourquoivoterenmarche", name="app_ton_macron_invite", methods={"GET", "POST"})
      */
     public function inviteAction(Request $request): Response
     {
@@ -62,8 +58,7 @@ class TonMacronController extends Controller
     }
 
     /**
-     * @Route("/pourquoivoterenmarche/recommencer", name="app_ton_macron_invite_restart")
-     * @Method("GET")
+     * @Route("/pourquoivoterenmarche/recommencer", name="app_ton_macron_invite_restart", methods={"GET"})
      */
     public function restartInviteAction(Request $request): Response
     {
@@ -73,8 +68,7 @@ class TonMacronController extends Controller
     }
 
     /**
-     * @Route("/pourquoivoterenmarche/{uuid}/merci", name="app_ton_macron_invite_sent")
-     * @Method("GET")
+     * @Route("/pourquoivoterenmarche/{uuid}/merci", name="app_ton_macron_invite_sent", methods={"GET"})
      */
     public function inviteSentAction(TonMacronFriendInvitation $invitation): Response
     {

--- a/src/Controller/EnMarche/UserController.php
+++ b/src/Controller/EnMarche/UserController.php
@@ -21,7 +21,6 @@ use AppBundle\Repository\SubscriptionTypeRepository;
 use AppBundle\Repository\TransactionRepository;
 use AppBundle\Subscription\SubscriptionTypeEnum;
 use Doctrine\Common\Persistence\ObjectManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -39,8 +38,7 @@ class UserController extends Controller
     private const UNREGISTER_TOKEN = 'unregister_token';
 
     /**
-     * @Route("", name="app_user_profile")
-     * @Method("GET")
+     * @Route("", name="app_user_profile", methods={"GET"})
      */
     public function profileOverviewAction(): Response
     {
@@ -48,8 +46,7 @@ class UserController extends Controller
     }
 
     /**
-     * @Route("/mes-dons", name="app_user_profile_donation")
-     * @Method("GET")
+     * @Route("/mes-dons", name="app_user_profile_donation", methods={"GET"})
      */
     public function profileDonationAction(
         DonationRepository $donationRepository,
@@ -65,8 +62,7 @@ class UserController extends Controller
     }
 
     /**
-     * @Route("/modifier", name="app_user_edit")
-     * @Method("GET|POST")
+     * @Route("/modifier", name="app_user_edit", methods={"GET", "POST"})
      */
     public function profileAction(Request $request): Response
     {
@@ -88,8 +84,7 @@ class UserController extends Controller
     }
 
     /**
-     * @Route("/modifier-email", name="app_user_change_email")
-     * @Method({"POST", "GET"})
+     * @Route("/modifier-email", name="app_user_change_email", methods={"POST", "GET"})
      */
     public function changeEmailAction(Request $request, AdherentChangeEmailHandler $handler): Response
     {
@@ -110,8 +105,7 @@ class UserController extends Controller
     /**
      * This action enables an adherent to change his/her current password.
      *
-     * @Route("/changer-mot-de-passe", name="app_user_change_password")
-     * @Method("GET|POST")
+     * @Route("/changer-mot-de-passe", name="app_user_change_password", methods={"GET", "POST"})
      */
     public function changePasswordAction(Request $request): Response
     {
@@ -132,8 +126,7 @@ class UserController extends Controller
     /**
      * This action enables an adherent to choose his/her email notifications.
      *
-     * @Route("/preferences-des-emails", name="app_user_set_email_notifications")
-     * @Method("GET|POST")
+     * @Route("/preferences-des-emails", name="app_user_set_email_notifications", methods={"GET", "POST"})
      */
     public function setEmailNotificationsAction(
         Request $request,
@@ -166,8 +159,7 @@ class UserController extends Controller
     }
 
     /**
-     * @Route("/desadherer", name="app_user_terminate_membership")
-     * @Method("GET|POST")
+     * @Route("/desadherer", name="app_user_terminate_membership", methods={"GET", "POST"})
      * @Security("is_granted('UNREGISTER')")
      */
     public function terminateMembershipAction(Request $request): Response
@@ -204,9 +196,9 @@ class UserController extends Controller
     /**
      * @Route("/chart",
      *     name="app_user_set_accept_chart",
-     *     condition="request.isXmlHttpRequest()"
+     *     condition="request.isXmlHttpRequest()",
+     *     methods={"PUT"}
      * )
-     * @Method("PUT")
      */
     public function chartAcceptationAction(ObjectManager $manager): JsonResponse
     {

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -10,8 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class HealthController extends Controller
 {
     /**
-     * @Route("/health", name="health")
-     * @Method("GET")
+     * @Route("/health", name="health", methods={"GET"})
      */
     public function healthAction()
     {

--- a/src/Controller/Legislatives/HomeController.php
+++ b/src/Controller/Legislatives/HomeController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Legislatives;
 
 use AppBundle\Entity\LegislativeCandidate;
 use AppBundle\Entity\LegislativeDistrictZone;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,8 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class HomeController extends Controller
 {
     /**
-     * @Route("/", name="legislatives_homepage")
-     * @Method("GET")
+     * @Route("/", name="legislatives_homepage", methods={"GET"})
      */
     public function indexAction(Request $request): Response
     {
@@ -35,8 +33,7 @@ class HomeController extends Controller
     }
 
     /**
-     * @Route("/redirection-en-marche", name="legislatives_redirect_en_marche")
-     * @Method("GET")
+     * @Route("/redirection-en-marche", name="legislatives_redirect_en_marche", methods={"GET"})
      */
     public function redirectEnMarcheAction(): Response
     {
@@ -44,8 +41,7 @@ class HomeController extends Controller
     }
 
     /**
-     * @Route("/candidat/{slug}", name="legislatives_candidate")
-     * @Method("GET")
+     * @Route("/candidat/{slug}", name="legislatives_candidate", methods={"GET"})
      */
     public function candidateAction(LegislativeCandidate $candidate): Response
     {

--- a/src/Controller/Legislatives/MapsController.php
+++ b/src/Controller/Legislatives/MapsController.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Controller\Legislatives;
 
 use AppBundle\Entity\Event;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -11,8 +10,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class MapsController extends Controller
 {
     /**
-     * @Route("/la-carte", name="legislatives_map")
-     * @Method("GET")
+     * @Route("/la-carte", name="legislatives_map", methods={"GET"})
      */
     public function candidatesAction(): Response
     {
@@ -20,8 +18,7 @@ class MapsController extends Controller
     }
 
     /**
-     * @Route("/les-evenements", name="legislatives_events")
-     * @Method("GET")
+     * @Route("/les-evenements", name="legislatives_events", methods={"GET"})
      */
     public function eventsAction(): Response
     {

--- a/src/Controller/MoocController.php
+++ b/src/Controller/MoocController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Mooc\AttachmentFile;
 use AppBundle\Storage\FileRequestHandler;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class MoocController extends Controller
 {
     /**
-     * @Route("/file/{slug}.{extension}", name="mooc_get_file")
-     * @Method("GET")
+     * @Route("/file/{slug}.{extension}", name="mooc_get_file", methods={"GET"})
      * @Cache(maxage=900, smaxage=900)
      */
     public function getFile(FileRequestHandler $fileRequestHandler, AttachmentFile $file): Response

--- a/src/Controller/OAuth/OAuthServerController.php
+++ b/src/Controller/OAuth/OAuthServerController.php
@@ -11,7 +11,6 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Ramsey\Uuid\Uuid;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -31,8 +30,7 @@ class OAuthServerController extends Controller
     }
 
     /**
-     * @Route("/auth", name="app_front_oauth_authorize")
-     * @Method("GET|POST")
+     * @Route("/auth", name="app_front_oauth_authorize", methods={"GET", "POST"})
      * @Security("is_granted('IS_AUTHENTICATED_FULLY') and not is_granted('ROLE_ADMIN_DASHBOARD')")
      */
     public function authorizeAction(Request $request, ClientRepository $repository, OAuthAuthorizationManager $manager)
@@ -72,8 +70,7 @@ class OAuthServerController extends Controller
     }
 
     /**
-     * @Route("/token", name="app_front_oauth_get_access_token")
-     * @Method("POST")
+     * @Route("/token", name="app_front_oauth_get_access_token", methods={"POST"})
      */
     public function getAccessTokenAction(Request $request)
     {
@@ -87,8 +84,7 @@ class OAuthServerController extends Controller
     }
 
     /**
-     * @Route("/tokeninfo", name="app_front_oauth_get_access_token_info")
-     * @Method("GET")
+     * @Route("/tokeninfo", name="app_front_oauth_get_access_token_info", methods={"GET"})
      */
     public function getAccessTokenInfo(Request $request, ResourceServer $resourceServer, ClientRepository $repository)
     {

--- a/src/Controller/UploadDocumentController.php
+++ b/src/Controller/UploadDocumentController.php
@@ -6,7 +6,6 @@ use AppBundle\Entity\UserDocument;
 use AppBundle\UserDocument\UserDocumentManager;
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
 use League\Flysystem\FileNotFoundException;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,8 +17,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class UploadDocumentController extends Controller
 {
     /**
-     * @Route("/upload/{type}", name="app_filebrowser_upload")
-     * @Method("POST")
+     * @Route("/upload/{type}", name="app_filebrowser_upload", methods={"POST"})
      * @Security("is_granted('FILE_UPLOAD', type)")
      */
     public function filebrowserUploadAction(string $type, Request $request)
@@ -49,8 +47,7 @@ class UploadDocumentController extends Controller
     }
 
     /**
-     * @Route("/documents-partages/{uuid}/{filename}", requirements={"uuid": "%pattern_uuid%"}, name="app_download_user_document")
-     * @Method("GET")
+     * @Route("/documents-partages/{uuid}/{filename}", requirements={"uuid": "%pattern_uuid%"}, name="app_download_user_document", methods={"GET"})
      */
     public function downloadDocumentAction(UserDocument $document, string $filename)
     {

--- a/src/Fixer/MethodToRouteAnnotationFixer.php
+++ b/src/Fixer/MethodToRouteAnnotationFixer.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace AppBundle\Fixer;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class MethodToRouteAnnotationFixer extends AbstractFixer
+{
+    public function getName()
+    {
+        return 'App/'.parent::getName();
+    }
+
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Replace @Method annotation by @Route(..., methods={})',
+            [
+                new CodeSample(
+                    '<?php 
+/**
+ * @Route("/hello-world", name="hello_world")
+ * @Method("GET")
+ */
+public function helloWorldAction(){
+//...
+}                          
+'
+                ),
+            ]
+        );
+    }
+
+    public function isRisky()
+    {
+        return false;
+    }
+
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([\T_DOC_COMMENT]);
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return preg_match('/Controller$/', $file->getBasename('.php'));
+    }
+
+    public function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind([\T_DOC_COMMENT])) {
+                continue;
+            }
+
+            if ($token->isGivenKind(\T_DOC_COMMENT)
+                && false !== strpos($token->getContent(), '@Route')
+                && false !== strpos($token->getContent(), '@Method')
+            ) {
+                $token->setContent($this->replaceMethodToRouteAnnotation($token->getContent()));
+            }
+        }
+    }
+
+    private function replaceMethodToRouteAnnotation(string $content)
+    {
+        $methodAnnotationStart = strpos($content, '@Method');
+        $methodAnnotationEnd = strpos($content, ')', $methodAnnotationStart) + 1;
+
+        return $this->addMethodArgInRoute(
+            $this->removeMethodLine($content, $methodAnnotationEnd),
+            $this->getMethodsToMove(substr(
+                $content,
+                $methodAnnotationStart,
+                $methodAnnotationEnd - $methodAnnotationStart
+            ))
+        );
+    }
+
+    private function addMethodArgInRoute(string $content, array $methodsToMove)
+    {
+        $routeAnnotationStart = strpos($content, '@Route');
+        $openingBraceOfRoute = strpos($content, '(', $routeAnnotationStart);
+
+        if (false !== $openingBraceOfFunction = strpos($content, 'condition', $openingBraceOfRoute + 1)) {
+            $closingBraceOfFunction = strpos($content, '"', $openingBraceOfFunction + \strlen('condition=') + 1);
+            $routeAnnotationEnd = strpos($content, ')', $closingBraceOfFunction + 1);
+        } else {
+            $routeAnnotationEnd = strpos($content, ')', $routeAnnotationStart);
+        }
+
+        $routeLine = substr($content, $routeAnnotationStart, $routeAnnotationEnd - $routeAnnotationStart);
+
+        $newRouteLine = substr_count($routeLine, "\n") > 1
+            ? $this->addMethodArgInMultiLineRoute($routeLine, $methodsToMove, $routeAnnotationEnd)
+            : $newRouteLine = $this->addMethodArgInSingleLineRoute($routeLine, $methodsToMove)
+        ;
+
+        return str_replace($routeLine, $newRouteLine, $content);
+    }
+
+    private function addMethodArgInMultiLineRoute(string $routeLine, array $methodsToMove)
+    {
+        $lastLineBreak = strrpos($routeLine, "\n");
+        $replacement = ",\n     *     methods={".implode(', ', $methodsToMove).'}';
+
+        return substr_replace($routeLine, $replacement, $lastLineBreak, 0);
+    }
+
+    private function addMethodArgInSingleLineRoute(string $routeLine, array $methodsToMove)
+    {
+        return str_replace($routeLine, $routeLine.', methods={'.implode(', ', $methodsToMove).'}', $routeLine);
+    }
+
+    private function removeMethodLine(string $content, int $methodAnnotationEnd)
+    {
+        $newLineIndexes = $this->getNewLineIndexes($content);
+        $startIndexToRemove = $newLineIndexes[array_search($methodAnnotationEnd, $newLineIndexes) - 1] + 1;
+        $endIndexToRemove = $methodAnnotationEnd + \strlen("\n");
+        $lineToRemove = substr($content, $startIndexToRemove, $endIndexToRemove - $startIndexToRemove);
+
+        return str_replace($lineToRemove, '', $content);
+    }
+
+    private function getNewLineIndexes(string $content)
+    {
+        $lastPos = 0;
+        $indexes = [];
+
+        while (false !== ($lastPos = strpos($content, "\n", $lastPos))) {
+            $indexes[] = $lastPos;
+            $lastPos = $lastPos + \strlen("\n");
+        }
+
+        return $indexes;
+    }
+
+    private function getMethodsToMove(string $methodLine)
+    {
+        $methodLine = str_replace('|', ',', $methodLine);
+        $methodLine = str_replace('"', '', $methodLine);
+        $methodLine = str_replace('\'', '', $methodLine);
+        $methodLine = str_replace('{', '', $methodLine);
+        $methodLine = str_replace('}', '', $methodLine);
+        $parenthesisStart = strpos($methodLine, '(') + 1;
+        $parenthesisEnd = strpos($methodLine, ')');
+        $methodArgs = substr($methodLine, $parenthesisStart, $parenthesisEnd - $parenthesisStart);
+        $methodArgs = explode(',', $methodArgs);
+
+        foreach ($methodArgs as $key => $arg) {
+            $methodArgs[$key] = '"'.trim($arg).'"';
+        }
+
+        return $methodArgs;
+    }
+}


### PR DESCRIPTION
This new rule `App/method_to_route_annotation` will remove all `@Method` and add methods inside the `@Route` annotation.