### PR TITLE
[Procuration] Fix widget conflict

### DIFF
--- a/front/pages/procuration_proxy.js
+++ b/front/pages/procuration_proxy.js
@@ -3,7 +3,8 @@ import AddressObject from '../services/address/AddressObject';
 import changeFieldsVisibility from '../services/form/changeFieldsVisibility';
 
 export default (countryFieldSelector, postalCodeFieldSelector, stateFieldSelector) => {
-    (new AutocompletedAddressForm(
+    const countryElement = dom(countryFieldSelector);
+    const autocompleteAddressForm = new AutocompletedAddressForm(
         dom('.address-autocomplete'),
         dom('.address-block'),
         new AddressObject(
@@ -13,7 +14,15 @@ export default (countryFieldSelector, postalCodeFieldSelector, stateFieldSelecto
             null,
             dom('#app_procuration_proposal_country')
         )
-    )).buildWidget();
+    );
 
-    changeFieldsVisibility(countryFieldSelector, postalCodeFieldSelector, stateFieldSelector);
+    autocompleteAddressForm.once('changed', () => {
+        countryElement.dispatchEvent(new CustomEvent('change', {
+            target: countryElement,
+        }));
+    });
+
+    autocompleteAddressForm.buildWidget();
+
+    changeFieldsVisibility(countryElement, postalCodeFieldSelector, stateFieldSelector);
 };

--- a/front/pages/procuration_request.js
+++ b/front/pages/procuration_request.js
@@ -3,7 +3,8 @@ import AddressObject from '../services/address/AddressObject';
 import changeFieldsVisibility from '../services/form/changeFieldsVisibility';
 
 export default (countryFieldSelector, postalCodeFieldSelector, stateFieldSelector) => {
-    (new AutocompletedAddressForm(
+    const countryElement = dom(countryFieldSelector);
+    const autocompleteAddressForm = new AutocompletedAddressForm(
         dom('.address-autocomplete'),
         dom('.address-block'),
         new AddressObject(
@@ -13,7 +14,15 @@ export default (countryFieldSelector, postalCodeFieldSelector, stateFieldSelecto
             null,
             dom('#app_procuration_request_country')
         )
-    )).buildWidget();
+    );
 
-    changeFieldsVisibility(countryFieldSelector, postalCodeFieldSelector, stateFieldSelector);
+    autocompleteAddressForm.once('changed', () => {
+        countryElement.dispatchEvent(new CustomEvent('change', {
+            target: countryElement,
+        }));
+    });
+
+    autocompleteAddressForm.buildWidget();
+
+    changeFieldsVisibility(countryElement, postalCodeFieldSelector, stateFieldSelector);
 };

--- a/front/services/form/changeFieldsVisibility.js
+++ b/front/services/form/changeFieldsVisibility.js
@@ -1,9 +1,8 @@
 export default function (
-    countryFieldSelector,
+    countryElement,
     postalCodeFieldSelector,
     stateFieldSelector
 ) {
-    const countryElement = dom(countryFieldSelector);
     const postalCodeElement = dom(postalCodeFieldSelector);
     const stateElement = dom(stateFieldSelector);
 
@@ -15,9 +14,11 @@ export default function (
 function changeFieldsVisibility(country, postalCode, state) {
     if ('FR' === country.value) {
         state.classList.add('hidden');
+        state.value = '';
         postalCode.classList.remove('hidden');
     } else {
         state.classList.remove('hidden');
         postalCode.classList.add('hidden');
+        postalCode.value = '';
     }
 }


### PR DESCRIPTION
1) Fix when user autocomplete address and state is not displayed
2) Add codePostal and State clear to avoid wrong validation logic 