### PR TITLE
[Assessor] Fixed nullable var for confirmation message

### DIFF
--- a/src/Mailer/Message/AssessorRequestConfirmationMessage.php
+++ b/src/Mailer/Message/AssessorRequestConfirmationMessage.php
@@ -18,7 +18,7 @@ final class AssessorRequestConfirmationMessage extends Message
             '',
             [
                 'firstname' => $assessorRequest->getFirstName(),
-                'city_name_candidacy' => $assessorRequest->getAssessorCity(),
+                'city_name_candidacy' => (string) $assessorRequest->getAssessorCity(),
                 'country_name_candidacy' => Intl::getRegionBundle()->getCountryName(
                     $assessorRequest->getAssessorCountry()
                 ),


### PR DESCRIPTION
Mailjet API does not allow null vars for templates.