### PR TITLE
Update symfony/symfony & symfony/phpunit-bridge

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9734,16 +9734,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.4.25",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "24454234816e061b4b9c5787eaa2bb6326ead1da"
+                "reference": "1b89e7baec9891c323bbf1ec81af77d901fc60c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/24454234816e061b4b9c5787eaa2bb6326ead1da",
-                "reference": "24454234816e061b4b9c5787eaa2bb6326ead1da",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/1b89e7baec9891c323bbf1ec81af77d901fc60c9",
+                "reference": "1b89e7baec9891c323bbf1ec81af77d901fc60c9",
                 "shasum": ""
             },
             "require": {
@@ -9885,7 +9885,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2019-04-16T06:02:31+00:00"
+            "time": "2019-04-17T15:57:27+00:00"
         },
         {
             "name": "symfony/thanks",
@@ -13011,16 +13011,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.4.11",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "63cdae00a75862fa543b765ba63d55f6b6397d0c"
+                "reference": "a43a2f6c465a2d99635fea0addbebddc3864ad97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/63cdae00a75862fa543b765ba63d55f6b6397d0c",
-                "reference": "63cdae00a75862fa543b765ba63d55f6b6397d0c",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/a43a2f6c465a2d99635fea0addbebddc3864ad97",
+                "reference": "a43a2f6c465a2d99635fea0addbebddc3864ad97",
                 "shasum": ""
             },
             "require": {
@@ -13030,7 +13030,6 @@
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "suggest": {
-                "ext-zip": "Zip support is required when using bin/simple-phpunit",
                 "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
@@ -13073,7 +13072,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T12:49:49+00:00"
+            "time": "2019-04-16T09:03:16+00:00"
         },
         {
             "name": "symfony/polyfill-php72",


### PR DESCRIPTION
```
Symfony Security Check Report
=============================

2 packages have known vulnerabilities.

symfony/phpunit-bridge (v3.4.11)
--------------------------------

 * [CVE-2019-10912][]: Prevent destructors with side-effects from being unserialized

symfony/symfony (v3.4.25)
-------------------------

 * [CVE-2019-10909][]: Escape validation messages in the PHP templating engine
 * [CVE-2019-10910][]: Check service IDs are valid
 * [CVE-2019-10911][]: Add a separator in the remember me cookie hash
 * [CVE-2019-10912][]: Prevent destructors with side-effects from being unserialized
 * [CVE-2019-10913][]: Reject invalid HTTP method overrides

[CVE-2019-10912]: https://symfony.com/cve-2019-10912
[CVE-2019-10909]: https://symfony.com/cve-2019-10909
[CVE-2019-10910]: https://symfony.com/cve-2019-10910
[CVE-2019-10911]: https://symfony.com/cve-2019-10911
[CVE-2019-10912]: https://symfony.com/cve-2019-10912
[CVE-2019-10913]: https://symfony.com/cve-2019-10913
```

```
- Updating symfony/phpunit-bridge (v3.4.11 => v3.4.26)
- Updating symfony/symfony (v3.4.25 => v3.4.26)
```