### PR TITLE
[Behat] Enabled Behatch DebugContext

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,6 +5,7 @@ default:
                 - Behat\MinkExtension\Context\MinkContext
                 - Behatch\Context\BrowserContext:
                     timeout: 3
+                - Behatch\Context\DebugContext
                 - Behatch\Context\XmlContext
                 - FixtureContext:
                     manager: "@doctrine.orm.default_entity_manager"


### PR DESCRIPTION
This context is useful to debug Behat tests (breakpoint, screenshots, etc)

Example with the `And I put a breakpoint` step :

![Capture d’écran de 2019-06-21 17-17-47](https://user-images.githubusercontent.com/6014143/59932995-c24ea180-9448-11e9-88f6-703a22a538ce.png)
