### PR TITLE
[Behat] Added screenshots artifacts for the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,10 @@ jobs:
                 esac
             - store_test_results:
                 path: ./behat
+            - store_artifacts:
+                path: var/behat
+                destination: screenshots
+                when: on_fail
 
     deployment:
         <<: *working_directory

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,7 +5,8 @@ default:
                 - Behat\MinkExtension\Context\MinkContext
                 - Behatch\Context\BrowserContext:
                     timeout: 3
-                - Behatch\Context\DebugContext
+                - Behatch\Context\DebugContext:
+                    screenshotDir: 'var/behat'
                 - Behatch\Context\XmlContext
                 - FixtureContext:
                     manager: "@doctrine.orm.default_entity_manager"


### PR DESCRIPTION
When the Behat test suite has failed, a screenshot is uploaded and visible via the "Artifacts" panel : 

![Capture d’écran de 2019-06-24 15-23-40](https://user-images.githubusercontent.com/6014143/60022461-29ac6180-9694-11e9-9dce-3380da0c635a.png)


Example : https://49724-76485630-gh.circle-artifacts.com/1/screenshots/fail_1561382244_default__I_can_create_a_local_survey%252C_edit_it_and_show_the_statistics_page.png