### PR TITLE
[Jecoute] Added surveys visibility by managed areas

### DIFF
--- a/app/config/services/services.xml
+++ b/app/config/services/services.xml
@@ -228,6 +228,7 @@
 
         <!-- J'écoute -->
         <service id="AppBundle\Command\ImportJecouteSurveysCommand" />
+        <service id="AppBundle\Command\UpdateLocalSurveysTagsCommand" />
         <service id="AppBundle\Form\Jecoute\DataSurveyFormType" />
         <service id="AppBundle\Form\Jecoute\SurveyFormType" />
         <service id="AppBundle\Validator\SurveyQuestionTypeChoiceValidator" />

--- a/features/referent_space.feature
+++ b/features/referent_space.feature
@@ -112,7 +112,7 @@ Feature:
     When I am on "/espace-referent/jecoute"
     And I should see "Questionnaires locaux"
     And I wait until I see "Questionnaire numéro 1"
-    And I should not see "Un deuxième questionnaire"
+    And I should see "Un deuxième questionnaire"
 
     Given I click the "survey-edit-0" element
     Then I should see "Nom du questionnaire"

--- a/features/surveys.feature
+++ b/features/surveys.feature
@@ -14,7 +14,7 @@ Feature:
     Given I am logged as "damien.schmidt@example.ch"
     When I am on "/espace-responsable-jecoute"
     Then I should see "Mon espace J'écoute"
-    And I should see "Vous gérez : CH"
+    And I should see "Vous gérez : CH, ES, 92, 76, 77, 13, 59"
 
     # Create
     Given I am on "/espace-responsable-jecoute/questionnaire/creer"
@@ -30,7 +30,7 @@ Feature:
 
     # Edit
     Given I should see "Un questionnaire jecoute manager"
-    When I click the "survey-edit-0" element
+    When I click the "survey-edit-2" element
     And I should see "Nom du questionnaire"
     And I should see "Enregistrer le questionnaire"
 
@@ -40,7 +40,7 @@ Feature:
 
     # Show statistics
     Given I wait until I see "Un questionnaire jecoute manager (modifié)"
-    And I click the "survey-stats-0" element
+    And I click the "survey-stats-2" element
     Then I should see "Statistiques : Un questionnaire jecoute manager (modifié)"
     And I should see "Une question ?"
     And I should see "Aucune donnée n'est disponible pour le moment."

--- a/migrations/Version20190719115840.php
+++ b/migrations/Version20190719115840.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20190719115840 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE jecoute_survey ADD tags LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:simple_array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE jecoute_survey DROP tags');
+    }
+}

--- a/src/Command/UpdateLocalSurveysTagsCommand.php
+++ b/src/Command/UpdateLocalSurveysTagsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AppBundle\Command;
+
+use AppBundle\Entity\Jecoute\LocalSurvey;
+use AppBundle\Repository\Jecoute\LocalSurveyRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class UpdateLocalSurveysTagsCommand extends Command
+{
+    protected static $defaultName = 'app:jecoute-surveys:add-tags';
+
+    private $em;
+
+    private $repository;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(EntityManagerInterface $em, LocalSurveyRepository $repository)
+    {
+        $this->em = $em;
+        $this->repository = $repository;
+
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io->text('Start updating local surveys...');
+        $result = $this->repository->findAll();
+
+        $this->io->progressStart(\count($result));
+
+        /** @var LocalSurvey $survey */
+        foreach ($result as $survey) {
+            if ($survey->getAuthor()->isReferent()) {
+                $tags = $survey->getAuthor()->getManagedAreaTagCodes();
+            } else {
+                $tags = $survey->getAuthor()->getJecouteManagedArea()->getCodes();
+            }
+
+            $survey->setTags($tags);
+
+            $this->io->progressAdvance();
+        }
+
+        $this->io->progressFinish();
+        $this->em->flush();
+        $this->io->success('Local surveys has been updated.');
+    }
+}

--- a/src/DataFixtures/ORM/LoadAdherentData.php
+++ b/src/DataFixtures/ORM/LoadAdherentData.php
@@ -335,8 +335,6 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         ]);
         $adherent14->setSubscriptionTypes($this->getStandardSubscriptionTypes());
         $adherent14->addReferentTag($this->getReference('referent_tag_ch'));
-        $adherent14->setJecouteManagedAreaCodesAsString('CH');
-        $this->addReference('adherent-14', $adherent14);
 
         // Non activated, enabled adherent
         $adherent15 = $adherentFactory->createFromArray([
@@ -854,6 +852,9 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $adherent6->setReferentTeamMember(new ReferentTeamMember($this->getReference('adherent-8')));
         // For Organizational chart: adherent which is co-referent in another referent team
         $adherent4->setReferentTeamMember(new ReferentTeamMember($this->getReference('adherent-19')));
+
+        $adherent14->setJecouteManagedAreaCodesAsString($referent->getManagedArea()->getReferentTagCodesAsString());
+        $this->addReference('adherent-14', $adherent14);
 
         $manager->persist($key1);
         $manager->persist($key2);

--- a/src/DataFixtures/ORM/LoadJecouteSurveyData.php
+++ b/src/DataFixtures/ORM/LoadJecouteSurveyData.php
@@ -57,12 +57,16 @@ class LoadJecouteSurveyData extends Fixture
         $localSurvey1->addQuestion($surveyQuestion3);
         $localSurvey1->addQuestion($surveyQuestion4);
 
+        $localSurvey1->setTags($referent1->getManagedArea()->getReferentTagCodes());
+
         /** @var Question $question4 */
         $question4 = $this->getReference('question-4');
 
         $localSurvey2Question1 = new SurveyQuestion($localSurvey2, $question4);
 
         $localSurvey2->addQuestion($localSurvey2Question1);
+
+        $localSurvey2->setTags($referent2->getManagedArea()->getReferentTagCodes());
 
         $manager->persist($localSurvey1);
         $manager->persist($localSurvey2);
@@ -104,6 +108,7 @@ class LoadJecouteSurveyData extends Fixture
     public function getDependencies()
     {
         return [
+            LoadReferentData::class,
             LoadAdherentData::class,
             LoadAdminData::class,
             LoadJecouteQuestionData::class,

--- a/src/Entity/Jecoute/LocalSurvey.php
+++ b/src/Entity/Jecoute/LocalSurvey.php
@@ -29,6 +29,11 @@ class LocalSurvey extends Survey implements AuthoredInterface
      */
     private $city;
 
+    /**
+     * @ORM\Column(type="simple_array", nullable=true)
+     */
+    private $tags = [];
+
     public function __construct(
         ?Adherent $author = null,
         ?string $name = null,
@@ -59,6 +64,16 @@ class LocalSurvey extends Survey implements AuthoredInterface
     public function setCity(?string $city): void
     {
         $this->city = $city;
+    }
+
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    public function setTags(array $tags): void
+    {
+        $this->tags = $tags;
     }
 
     public function getType(): string

--- a/src/Entity/ReferentManagedArea.php
+++ b/src/Entity/ReferentManagedArea.php
@@ -122,4 +122,9 @@ class ReferentManagedArea
     {
         return array_map(function (ReferentTag $tag) { return $tag->getCode(); }, $this->getTags()->toArray());
     }
+
+    public function getReferentTagCodesAsString(): string
+    {
+        return !empty($this->getTags()) ? implode(', ', $this->getReferentTagCodes()) : '';
+    }
 }

--- a/src/Security/Voter/SurveyManagedAreaVoter.php
+++ b/src/Security/Voter/SurveyManagedAreaVoter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AppBundle\Security\Voter;
+
+use AppBundle\Entity\Adherent;
+use AppBundle\Entity\Jecoute\LocalSurvey;
+use AppBundle\Repository\Jecoute\LocalSurveyRepository;
+
+class SurveyManagedAreaVoter extends AbstractAdherentVoter
+{
+    public const PERMISSION = 'IS_SURVEY_MANAGER_OF';
+
+    private $localSurveyRepository;
+
+    public function __construct(LocalSurveyRepository $localSurveyRepository)
+    {
+        $this->localSurveyRepository = $localSurveyRepository;
+    }
+
+    protected function doVoteOnAttribute(string $attribute, Adherent $adherent, $subject): bool
+    {
+        $tags = $adherent->isJecouteManager() ? $adherent->getJecouteManagedArea()->getCodes() :
+            $adherent->getManagedArea()->getReferentTagCodes()
+        ;
+
+        /** @var LocalSurvey $subject */
+        return !empty(array_intersect($subject->getTags(), $tags));
+    }
+
+    protected function supports($attribute, $subject)
+    {
+        return self::PERMISSION === $attribute && $subject instanceof LocalSurvey;
+    }
+}

--- a/templates/jecoute/_manager_space_layout.html.twig
+++ b/templates/jecoute/_manager_space_layout.html.twig
@@ -11,7 +11,7 @@
                 <div class="l__wrapper">
                     <div class="first-section">
                         <div class="manager-information">
-                            <p>Vous gérez : <span>{{ app.user.getJecouteManagedAreaCodesAsString }}</span> </p>
+                            <p>Vous gérez : <span>{{ app.user.getJecouteManagedAreaCodesAsString }}</span></p>
                         </div>
                         <p class="report">🐛 Bug ? Nouveau besoin ?
                             <a href="https://t.me/joinchat/EmY0e1J2fyTv4Fd-cHEMHg" target="_blank" class="text--blue--dark link--no-decor">Écrivez-nous !</a>


### PR DESCRIPTION
This PR changes the surveys management behavior.

Now, when a local survey is created, the survey is tagged by area codes.

In the referent space and the jecoute manager space, we can now see and manage all surveys by area codes.