### PR TITLE
Introduce Municipal Manager Supervisor role

### DIFF
--- a/migrations/Version20200226153640.php
+++ b/migrations/Version20200226153640.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20200226153640 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE municipal_manager_supervisor_role (
+          id INT AUTO_INCREMENT NOT NULL, 
+          referent_id INT UNSIGNED NOT NULL, 
+          INDEX IDX_F304FF35E47E35 (referent_id), 
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE 
+          municipal_manager_supervisor_role 
+        ADD 
+          CONSTRAINT FK_F304FF35E47E35 FOREIGN KEY (referent_id) REFERENCES adherents (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE adherents ADD municipal_manager_supervisor_role_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE 
+          adherents 
+        ADD 
+          CONSTRAINT FK_562C7DA39801977F FOREIGN KEY (
+            municipal_manager_supervisor_role_id
+          ) REFERENCES municipal_manager_supervisor_role (id) ON DELETE 
+        SET 
+          NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_562C7DA39801977F ON adherents (municipal_manager_supervisor_role_id)');
+        $this->addSql('ALTER TABLE 
+          referent_person_link 
+        ADD 
+          is_municipal_manager_supervisor TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE adherents DROP FOREIGN KEY FK_562C7DA39801977F');
+        $this->addSql('DROP TABLE municipal_manager_supervisor_role');
+        $this->addSql('DROP INDEX UNIQ_562C7DA39801977F ON adherents');
+        $this->addSql('ALTER TABLE adherents DROP municipal_manager_supervisor_role_id');
+        $this->addSql('ALTER TABLE referent_person_link DROP is_municipal_manager_supervisor');
+    }
+}

--- a/src/Adherent/AdherentRoleEnum.php
+++ b/src/Adherent/AdherentRoleEnum.php
@@ -35,6 +35,7 @@ class AdherentRoleEnum extends Enum
 
     public const MUNICIPAL_CHIEF = 'municipal_chief';
     public const MUNICIPAL_MANAGER = 'municipal_manager';
+    public const MUNICIPAL_MANAGER_SUPERVISOR = 'municipal_manager_supervisor';
 
     public const PRINT_PRIVILEGE = 'print_privilege';
     public const ELECTION_RESULTS_REPORTER = 'election_results_reporter';

--- a/src/Admin/AdherentAdmin.php
+++ b/src/Admin/AdherentAdmin.php
@@ -629,6 +629,12 @@ HELP
                         $where->add('municipalManagerRole IS NOT NULL');
                     }
 
+                    // Municipal Manager Supervisor
+                    if (\in_array(AdherentRoleEnum::MUNICIPAL_MANAGER_SUPERVISOR, $value['value'], true)) {
+                        $qb->leftJoin(sprintf('%s.municipalManagerSupervisorRole', $alias), 'municipalManagerSupervisorRole');
+                        $where->add('municipalManagerSupervisorRole IS NOT NULL');
+                    }
+
                     // Election results reporter
                     if (\in_array(AdherentRoleEnum::ELECTION_RESULTS_REPORTER, $value['value'], true)) {
                         $where->add(sprintf('%s.electionResultsReporter = :election_result_reporter', $alias));

--- a/src/Controller/EnMarche/AssessorSpace/ReferentAssessorSpaceController.php
+++ b/src/Controller/EnMarche/AssessorSpace/ReferentAssessorSpaceController.php
@@ -7,16 +7,9 @@ use AppBundle\Assessor\Filter\AssociationVotePlaceFilter;
 use AppBundle\Entity\Adherent;
 use AppBundle\Entity\Election;
 use AppBundle\Form\Assessor\ReferentVotePlaceFilterType;
-use AppBundle\Form\MunicipalManagerCityListType;
-use AppBundle\Form\ReferentCityFilterType;
-use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
-use AppBundle\MunicipalManager\MunicipalManagerRole\MunicipalManagerAssociationManager;
-use AppBundle\Repository\CityRepository;
 use Doctrine\ORM\Query;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -27,65 +20,6 @@ use Symfony\Component\Routing\Annotation\Route;
 class ReferentAssessorSpaceController extends AbstractAssessorSpaceController
 {
     private const SPACE_NAME = 'referent';
-
-    /**
-     * @Route("/communes", name="_municipal_manager_attribution_form", methods={"GET", "POST"})
-     */
-    public function municipalManagerAttributionAction(
-        Request $request,
-        CityRepository $cityRepository,
-        MunicipalManagerAssociationManager $manager
-    ): Response {
-        $this->disableInProduction();
-
-        $filterForm = $this
-            ->createForm(ReferentCityFilterType::class, $filter = $this->createCityFilter())
-            ->handleRequest($request)
-        ;
-
-        if ($filterForm->isSubmitted() && !$filterForm->isValid()) {
-            $filter = $this->createCityFilter();
-        }
-
-        $paginator = $cityRepository->findAllForFilter(
-            $filter,
-            $request->query->getInt('page', 1),
-            self::PAGE_LIMIT
-        );
-
-        $form = $this
-            ->createForm(MunicipalManagerCityListType::class, $manager->getAssociationValueObjectsFromCities(
-                iterator_to_array($paginator)
-            ))
-            ->handleRequest($request)
-        ;
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $manager->handleUpdate($form->getData());
-
-            $this->addFlash('info', 'Les modifications ont bien été sauvegardées');
-
-            return $this->redirectToRoute(
-                'app_assessors_referent_municipal_manager_attribution_form',
-                $this->getRouteParams($request)
-            );
-        }
-
-        return $this->render('referent/municipal_manager/attribution_form.html.twig', [
-            'cities' => $paginator,
-            'form' => $form->createView(),
-            'filter_form' => $filterForm->createView(),
-            'route_params' => $this->getRouteParams($request),
-        ]);
-    }
-
-    private function createCityFilter(): AssociationCityFilter
-    {
-        $filter = new AssociationCityFilter();
-        $filter->setTags($this->getReferentTags());
-
-        return $filter;
-    }
 
     protected function getSpaceType(): string
     {

--- a/src/Controller/EnMarche/MunicipalManagerAttribution/AbstractMunicipalManagerAttributionController.php
+++ b/src/Controller/EnMarche/MunicipalManagerAttribution/AbstractMunicipalManagerAttributionController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace AppBundle\Controller\EnMarche\MunicipalManagerAttribution;
+
+use AppBundle\Controller\CanaryControllerTrait;
+use AppBundle\Form\MunicipalManagerCityListType;
+use AppBundle\Form\ReferentCityFilterType;
+use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
+use AppBundle\MunicipalManager\MunicipalManagerRole\MunicipalManagerAssociationManager;
+use AppBundle\Repository\CityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+abstract class AbstractMunicipalManagerAttributionController extends Controller
+{
+    use CanaryControllerTrait;
+
+    protected const PAGE_LIMIT = 10;
+
+    /**
+     * @Route("/responsables-communaux", name="_attribution_form", methods={"GET", "POST"})
+     */
+    public function municipalManagerAttributionAction(
+        Request $request,
+        CityRepository $cityRepository,
+        MunicipalManagerAssociationManager $manager
+    ): Response {
+        $this->disableInProduction();
+
+        $filterForm = $this
+            ->createForm(ReferentCityFilterType::class, $filter = $this->createCityFilter())
+            ->handleRequest($request)
+        ;
+
+        if ($filterForm->isSubmitted() && !$filterForm->isValid()) {
+            $filter = $this->createCityFilter();
+        }
+
+        $paginator = $cityRepository->findAllForFilter(
+            $filter,
+            $request->query->getInt('page', 1),
+            self::PAGE_LIMIT
+        );
+
+        $form = $this
+            ->createForm(MunicipalManagerCityListType::class, $manager->getAssociationValueObjectsFromCities(
+                iterator_to_array($paginator)
+            ))
+            ->handleRequest($request)
+        ;
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $manager->handleUpdate($form->getData());
+
+            $this->addFlash('info', 'Les modifications ont bien été sauvegardées');
+
+            return $this->redirectToRoute(
+                'app_assessors_referent_municipal_manager_attribution_form',
+                $this->getRouteParams($request)
+            );
+        }
+
+        return $this->renderTemplate(sprintf('municipal_manager_attribution/index.html.twig', static::getSpaceType()), [
+            'cities' => $paginator,
+            'form' => $form->createView(),
+            'filter_form' => $filterForm->createView(),
+            'route_params' => $this->getRouteParams($request),
+        ]);
+    }
+
+    protected function getRouteParams(Request $request): array
+    {
+        $params = [];
+
+        if ($request->query->has('f')) {
+            $params['f'] = (array) $request->query->get('f');
+        }
+
+        if ($request->query->has('page')) {
+            $params['page'] = $request->query->getInt('page');
+        }
+
+        return $params;
+    }
+
+    protected function renderTemplate(string $template, array $parameters = []): Response
+    {
+        return $this->render($template, array_merge(
+            $parameters,
+            [
+                'base_template' => sprintf('municipal_manager_attribution/_base_%s_space.html.twig', $spaceType = static::getSpaceType()),
+                'space_type' => $spaceType,
+            ]
+        ));
+    }
+
+    abstract protected function createCityFilter(): AssociationCityFilter;
+
+    abstract protected function getSpaceType(): string;
+}

--- a/src/Controller/EnMarche/MunicipalManagerAttribution/AbstractMunicipalManagerAttributionController.php
+++ b/src/Controller/EnMarche/MunicipalManagerAttribution/AbstractMunicipalManagerAttributionController.php
@@ -57,7 +57,7 @@ abstract class AbstractMunicipalManagerAttributionController extends Controller
             $this->addFlash('info', 'Les modifications ont bien été sauvegardées');
 
             return $this->redirectToRoute(
-                'app_assessors_referent_municipal_manager_attribution_form',
+                sprintf('app_municipal_manager_%s_attribution_form', static::getSpaceType()),
                 $this->getRouteParams($request)
             );
         }

--- a/src/Controller/EnMarche/MunicipalManagerAttribution/MunicipalChiefMunicipalManagerAttributionController.php
+++ b/src/Controller/EnMarche/MunicipalManagerAttribution/MunicipalChiefMunicipalManagerAttributionController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AppBundle\Controller\EnMarche\MunicipalManagerAttribution;
+
+use AppBundle\Entity\Adherent;
+use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path="/espace-municipales-2020", name="app_municipal_manager_municipal_chief")
+ *
+ * @Security("is_granted('ROLE_MUNICIPAL_CHIEF')")
+ */
+class MunicipalChiefMunicipalManagerAttributionController extends AbstractMunicipalManagerAttributionController
+{
+    private const SPACE_NAME = 'municipal_chief';
+
+    protected function getSpaceType(): string
+    {
+        return self::SPACE_NAME;
+    }
+
+    protected function createCityFilter(): AssociationCityFilter
+    {
+        $filter = new AssociationCityFilter();
+        $filter->setManagedInseeCode($this->getManagedInseeCode());
+
+        return $filter;
+    }
+
+    private function getManagedInseeCode(): ?string
+    {
+        /** @var Adherent $adherent */
+        $adherent = $this->getUser();
+
+        return $adherent
+            ->getMunicipalChiefManagedArea()
+            ->getInseeCode()
+        ;
+    }
+}

--- a/src/Controller/EnMarche/MunicipalManagerAttribution/MunicipalManagerSupervisorMunicipalManagerAttributionController.php
+++ b/src/Controller/EnMarche/MunicipalManagerAttribution/MunicipalManagerSupervisorMunicipalManagerAttributionController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AppBundle\Controller\EnMarche\MunicipalManagerAttribution;
+
+use AppBundle\Entity\Adherent;
+use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path="/espace-responsable-attribution", name="app_municipal_manager_municipal_manager_supervisor")
+ *
+ * @Security("is_granted('ROLE_MUNICIPAL_MANAGER_SUPERVISOR')")
+ */
+class MunicipalManagerSupervisorMunicipalManagerAttributionController extends AbstractMunicipalManagerAttributionController
+{
+    private const SPACE_NAME = 'municipal_manager_supervisor';
+
+    protected function getSpaceType(): string
+    {
+        return self::SPACE_NAME;
+    }
+
+    protected function createCityFilter(): AssociationCityFilter
+    {
+        $filter = new AssociationCityFilter();
+        $filter->setManagedTags($this->getReferentTags());
+
+        return $filter;
+    }
+
+    private function getReferentTags(): array
+    {
+        /** @var Adherent $referent */
+        $referent = $this->getUser();
+
+        return $referent
+            ->getMunicipalManagerSupervisorRole()
+            ->getReferent()
+            ->getManagedArea()
+            ->getTags()
+            ->toArray()
+        ;
+    }
+}

--- a/src/Controller/EnMarche/MunicipalManagerAttribution/ReferentMunicipalManagerAttributionController.php
+++ b/src/Controller/EnMarche/MunicipalManagerAttribution/ReferentMunicipalManagerAttributionController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AppBundle\Controller\EnMarche\MunicipalManagerAttribution;
+
+use AppBundle\Entity\Adherent;
+use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path="/espace-referent", name="app_municipal_manager_referent")
+ *
+ * @Security("is_granted('ROLE_REFERENT')")
+ */
+class ReferentMunicipalManagerAttributionController extends AbstractMunicipalManagerAttributionController
+{
+    private const SPACE_NAME = 'referent';
+
+    protected function getSpaceType(): string
+    {
+        return self::SPACE_NAME;
+    }
+
+    protected function createCityFilter(): AssociationCityFilter
+    {
+        $filter = new AssociationCityFilter();
+        $filter->setManagedTags($this->getReferentTags());
+
+        return $filter;
+    }
+
+    private function getReferentTags(): array
+    {
+        /** @var Adherent $referent */
+        $referent = $this->getUser();
+
+        return $referent->getManagedArea()->getTags()->toArray();
+    }
+}

--- a/src/DataFixtures/ORM/LoadAdherentData.php
+++ b/src/DataFixtures/ORM/LoadAdherentData.php
@@ -15,6 +15,7 @@ use AppBundle\Entity\BoardMember\BoardMember;
 use AppBundle\Entity\CoordinatorManagedArea;
 use AppBundle\Entity\MunicipalChiefManagedArea;
 use AppBundle\Entity\MunicipalManagerRoleAssociation;
+use AppBundle\Entity\MunicipalManagerSupervisorRole;
 use AppBundle\Entity\PostAddress;
 use AppBundle\Entity\ReferentTeamMember;
 use AppBundle\Entity\SenatorArea;
@@ -923,8 +924,9 @@ class LoadAdherentData extends AbstractFixture implements ContainerAwareInterfac
         $manager->persist($assessor);
         $manager->persist($municipalManager);
 
-        // For Organizational chart: adherent which is co-referent in the referent@en-marche-dev.fr team
+        // For Organizational chart: adherent which is co-referent and municipal manager supervisor in the referent@en-marche-dev.fr team
         $adherent6->setReferentTeamMember(new ReferentTeamMember($this->getReference('adherent-8')));
+        $adherent6->setMunicipalManagerSupervisorRole(new MunicipalManagerSupervisorRole($this->getReference('adherent-8')));
         // For Organizational chart: adherent which is co-referent in another referent team
         $adherent4->setReferentTeamMember(new ReferentTeamMember($this->getReference('adherent-19')));
 

--- a/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
+++ b/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
@@ -55,6 +55,7 @@ class LoadOrganizationalChartItemData extends Fixture
                                                         'postalAddress' => '39 rue de Crimée, Marseille',
                                                         'referent' => 'referent3',
                                                         'isCoReferent' => true,
+                                                        'isMunicipalManagerSupervisor' => true,
                                                         'adherent' => 'adherent-6',
                                                     ],
                                                 ],

--- a/src/Entity/Adherent.php
+++ b/src/Entity/Adherent.php
@@ -259,6 +259,14 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
     private $municipalManagerRole;
 
     /**
+     * @var MunicipalManagerSupervisorRole|null
+     *
+     * @ORM\OneToOne(targetEntity="AppBundle\Entity\MunicipalManagerSupervisorRole", cascade={"all"}, orphanRemoval=true)
+     * @ORM\JoinColumn(onDelete="SET NULL")
+     */
+    private $municipalManagerSupervisorRole;
+
+    /**
      * @var BoardMember|null
      *
      * @ORM\OneToOne(targetEntity="AppBundle\Entity\BoardMember\BoardMember", mappedBy="adherent", cascade={"all"}, orphanRemoval=true)
@@ -657,6 +665,10 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
             $roles[] = 'ROLE_MUNICIPAL_MANAGER';
         }
 
+        if ($this->isMunicipalManagerSupervisor()) {
+            $roles[] = 'ROLE_MUNICIPAL_MANAGER_SUPERVISOR';
+        }
+
         if ($this->isJecouteManager()) {
             $roles[] = 'ROLE_JECOUTE_MANAGER';
         }
@@ -728,6 +740,7 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
             || $this->isMunicipalChief()
             || $this->isMunicipalManager()
             || $this->isElectionResultsReporter()
+            || $this->isMunicipalManagerSupervisor()
         ;
     }
 
@@ -1176,6 +1189,27 @@ class Adherent implements UserInterface, UserEntityInterface, GeoPointInterface,
     public function setMunicipalManagerRole(?MunicipalManagerRoleAssociation $municipalManagerRole): void
     {
         $this->municipalManagerRole = $municipalManagerRole;
+    }
+
+    public function getMunicipalManagerSupervisorRole(): ?MunicipalManagerSupervisorRole
+    {
+        return $this->municipalManagerSupervisorRole;
+    }
+
+    public function setMunicipalManagerSupervisorRole(
+        ?MunicipalManagerSupervisorRole $municipalManagerSupervisorRole
+    ): void {
+        $this->municipalManagerSupervisorRole = $municipalManagerSupervisorRole;
+    }
+
+    public function revokeMunicipalManagerSupervisorRole(): void
+    {
+        $this->municipalManagerSupervisorRole = null;
+    }
+
+    public function isMunicipalManagerSupervisor(): bool
+    {
+        return $this->municipalManagerSupervisorRole instanceof MunicipalManagerSupervisorRole;
     }
 
     public function getBoardMember(): ?BoardMember

--- a/src/Entity/MunicipalManagerSupervisorRole.php
+++ b/src/Entity/MunicipalManagerSupervisorRole.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Table(name="municipal_manager_supervisor_role")
+ * @ORM\Table
  * @ORM\Entity
  *
  * @Algolia\Index(autoIndex=false)

--- a/src/Entity/MunicipalManagerSupervisorRole.php
+++ b/src/Entity/MunicipalManagerSupervisorRole.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="municipal_manager_supervisor_role")
+ * @ORM\Entity
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class MunicipalManagerSupervisorRole
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var Adherent
+     *
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Adherent")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $referent;
+
+    public function __construct(Adherent $referent)
+    {
+        $this->referent = $referent;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getReferent(): Adherent
+    {
+        return $this->referent;
+    }
+}

--- a/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
+++ b/src/Entity/ReferentOrganizationalChart/ReferentPersonLink.php
@@ -98,6 +98,13 @@ class ReferentPersonLink
      */
     private $isJecouteManager = false;
 
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", options={"default": false})
+     */
+    private $isMunicipalManagerSupervisor = false;
+
     public function __construct(PersonOrganizationalChartItem $personOrganizationalChartItem, Referent $referent)
     {
         $this->personOrganizationalChartItem = $personOrganizationalChartItem;
@@ -202,6 +209,16 @@ class ReferentPersonLink
     public function setIsJecouteManager(bool $isJecouteManager): void
     {
         $this->isJecouteManager = $isJecouteManager;
+    }
+
+    public function isMunicipalManagerSupervisor(): bool
+    {
+        return $this->isMunicipalManagerSupervisor;
+    }
+
+    public function setIsMunicipalManagerSupervisor(bool $isMunicipalManagerSupervisor): void
+    {
+        $this->isMunicipalManagerSupervisor = $isMunicipalManagerSupervisor;
     }
 
     public function getPersonOrganizationalChartItem(): ?PersonOrganizationalChartItem

--- a/src/Form/ReferentCityFilterType.php
+++ b/src/Form/ReferentCityFilterType.php
@@ -4,7 +4,6 @@ namespace AppBundle\Form;
 
 use AppBundle\MunicipalManager\Filter\AssociationCityFilter;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,9 +23,6 @@ class ReferentCityFilterType extends AbstractType
                 'required' => false,
             ])
             ->add('inseeCode', TextType::class, [
-                'required' => false,
-            ])
-            ->add('country', CountryType::class, [
                 'required' => false,
             ])
             ->add('municipalManagerFirstName', TextType::class, [

--- a/src/Form/ReferentPersonLinkType.php
+++ b/src/Form/ReferentPersonLinkType.php
@@ -49,6 +49,9 @@ class ReferentPersonLinkType extends AbstractType
             ->add('isJecouteManager', CheckboxType::class, [
                 'required' => false,
             ])
+            ->add('isMunicipalManagerSupervisor', CheckboxType::class, [
+                'required' => false,
+            ])
         ;
 
         $builder->addModelTransformer(new CallbackTransformer(

--- a/src/MunicipalManager/Filter/AssociationCityFilter.php
+++ b/src/MunicipalManager/Filter/AssociationCityFilter.php
@@ -19,11 +19,6 @@ class AssociationCityFilter
     /**
      * @var string|null
      */
-    private $country;
-
-    /**
-     * @var string|null
-     */
     private $municipalManagerFirstName;
 
     /**
@@ -37,9 +32,14 @@ class AssociationCityFilter
     private $municipalManagerEmail;
 
     /**
+     * @var string|null
+     */
+    private $managedInseeCode;
+
+    /**
      * @var ReferentTag[]
      */
-    private $tags = [];
+    private $managedTags = [];
 
     public function getName(): ?string
     {
@@ -59,16 +59,6 @@ class AssociationCityFilter
     public function setInseeCode(?string $inseeCode): void
     {
         $this->inseeCode = $inseeCode;
-    }
-
-    public function getCountry(): ?string
-    {
-        return $this->country;
-    }
-
-    public function setCountry(?string $country): void
-    {
-        $this->country = $country;
     }
 
     public function getMunicipalManagerFirstName(): ?string
@@ -101,13 +91,23 @@ class AssociationCityFilter
         $this->municipalManagerEmail = $municipalManagerEmail;
     }
 
-    public function getTags(): array
+    public function getManagedInseeCode(): ?string
     {
-        return $this->tags;
+        return $this->managedInseeCode;
     }
 
-    public function setTags(array $tags): void
+    public function setManagedInseeCode(?string $managedInseeCode): void
     {
-        $this->tags = $tags;
+        $this->managedInseeCode = $managedInseeCode;
+    }
+
+    public function getManagedTags(): array
+    {
+        return $this->managedTags;
+    }
+
+    public function setManagedTags(array $managedTags): void
+    {
+        $this->managedTags = $managedTags;
     }
 }

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -30,8 +30,15 @@ class CityRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder(self::ALIAS);
 
-        if ($tags = $filter->getTags()) {
-            $this->applyGeoFilter($qb, $tags, self::ALIAS, 'country', 'inseeCode');
+        if ($managedTags = $filter->getManagedTags()) {
+            $this->applyGeoFilter($qb, $managedTags, self::ALIAS, 'country', 'inseeCode');
+        }
+
+        if ($managedInseeCode = $filter->getManagedInseeCode()) {
+            $qb
+                ->andWhere(self::ALIAS.'.inseeCode = :managed_insee_code')
+                ->setParameter('managed_insee_code', $managedInseeCode)
+            ;
         }
 
         if ($name = $filter->getName()) {
@@ -48,13 +55,6 @@ class CityRepository extends ServiceEntityRepository
             ;
         }
 
-        if ($country = $filter->getCountry()) {
-            $qb
-                ->andWhere(self::ALIAS.'.country = :country')
-                ->setParameter('country', $country)
-            ;
-        }
-
         $municipalManagerFirstName = $filter->getMunicipalManagerFirstName();
         $municipalManagerLastName = $filter->getMunicipalManagerLastName();
         $municipalManagerEmail = $filter->getMunicipalManagerEmail();
@@ -65,7 +65,7 @@ class CityRepository extends ServiceEntityRepository
                     MunicipalManagerRoleAssociation::class,
                     'municipal_manager_role',
                     Join::WITH,
-                    self::ALIAS.' = municipal_manager_role.city'
+                    self::ALIAS.' MEMBER OF municipal_manager_role.cities'
                 )
                 ->leftJoin(
                     Adherent::class,

--- a/templates/adherent/_list_my_sections.html.twig
+++ b/templates/adherent/_list_my_sections.html.twig
@@ -69,3 +69,10 @@
         <a href="{{ path('app_election_results_reporter_space_cities_list') }}">Espace Rapporteur résultats</a>
     </li>
 {% endif %}
+{% if is_canary_enabled() and app.user.isMunicipalManagerSupervisor %}
+    <li>
+        <a href="{{ path('app_municipal_manager_municipal_manager_supervisor_attribution_form') }}">
+            Espace Responsable attribution
+        </a>
+    </li>
+{% endif %}

--- a/templates/admin/adherent/list_status.html.twig
+++ b/templates/admin/adherent/list_status.html.twig
@@ -79,6 +79,14 @@
             </span>
             <br/>
         {% endif %}
+
+        {% if object.isMunicipalManager %}
+            <span class="label label-primary" style="padding: 2px;">Responsable communale</span>
+        {% endif %}
+
+        {% if object.isMunicipalManagerSupervisor %}
+            <span class="label label-primary" style="padding: 2px;">Responsable attribution</span>
+        {% endif %}
     {% elseif object.isAdherent %}
         <span class="label label-primary">Adhérent</span>
     {% else %}

--- a/templates/admin/adherent/list_status.html.twig
+++ b/templates/admin/adherent/list_status.html.twig
@@ -81,7 +81,7 @@
         {% endif %}
 
         {% if object.isMunicipalManager %}
-            <span class="label label-primary" style="padding: 2px;">Responsable communale</span>
+            <span class="label label-primary" style="padding: 2px;">Responsable communal</span>
         {% endif %}
 
         {% if object.isMunicipalManagerSupervisor %}

--- a/templates/assessor_attribution/_base_municipal_chief_space.html.twig
+++ b/templates/assessor_attribution/_base_municipal_chief_space.html.twig
@@ -1,31 +1,7 @@
 {% extends 'municipal_chief/_layout.html.twig' %}
 
 {% block municipal_chief_content %}
-    {% if is_canary_enabled() %}
-        <div class="datagrid__table__tabs">
-            <div class="datagrid__table__tabs__items">
-                <h3>
-                    {% if is_active_route(app.request, 'app_assessors_municipal_chief_attribution_form') %}
-                        Bureaux de votes
-                    {% else %}
-                        <a href="{{ path('app_assessors_municipal_chief_attribution_form') }}">
-                            Bureaux de votes
-                        </a>
-                    {% endif %}
-                </h3>
-                <span class="separator"></span>
-                <h3>
-                    {% if is_active_route(app.request, 'app_municipal_manager_municipal_chief_attribution_form') %}
-                        Communes
-                    {% else %}
-                        <a href="{{ path('app_municipal_manager_municipal_chief_attribution_form') }}">
-                            Communes
-                        </a>
-                    {% endif %}
-                </h3>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'assessor_attribution/_sub_menu.html.twig' %}
 
     {% block assessor_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/assessor_attribution/_base_referent_space.html.twig
+++ b/templates/assessor_attribution/_base_referent_space.html.twig
@@ -1,31 +1,7 @@
 {% extends 'referent/_layout.html.twig' %}
 
 {% block referent_content %}
-    {% if is_canary_enabled() %}
-        <div class="datagrid__table__tabs">
-            <div class="datagrid__table__tabs__items">
-                <h3>
-                    {% if is_active_route(app.request, 'app_assessors_referent_attribution_form') %}
-                        Bureaux de votes
-                    {% else %}
-                        <a href="{{ path('app_assessors_referent_attribution_form') }}">
-                            Bureaux de votes
-                        </a>
-                    {% endif %}
-                </h3>
-                <span class="separator"></span>
-                <h3>
-                    {% if is_active_route(app.request, 'app_municipal_manager_referent_attribution_form') %}
-                        Communes
-                    {% else %}
-                        <a href="{{ path('app_municipal_manager_referent_attribution_form') }}">
-                            Communes
-                        </a>
-                    {% endif %}
-                </h3>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'assessor_attribution/_sub_menu.html.twig' %}
 
     {% block assessor_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/assessor_attribution/_base_referent_space.html.twig
+++ b/templates/assessor_attribution/_base_referent_space.html.twig
@@ -15,10 +15,10 @@
                 </h3>
                 <span class="separator"></span>
                 <h3>
-                    {% if is_active_route(app.request, 'app_assessors_referent_municipal_manager_attribution_form') %}
+                    {% if is_active_route(app.request, 'app_municipal_manager_referent_attribution_form') %}
                         Communes
                     {% else %}
-                        <a href="{{ path('app_assessors_referent_municipal_manager_attribution_form') }}">
+                        <a href="{{ path('app_municipal_manager_referent_attribution_form') }}">
                             Communes
                         </a>
                     {% endif %}

--- a/templates/assessor_attribution/_sub_menu.html.twig
+++ b/templates/assessor_attribution/_sub_menu.html.twig
@@ -1,0 +1,25 @@
+{% if is_canary_enabled() %}
+    <div class="datagrid__table__tabs">
+        <div class="datagrid__table__tabs__items">
+            <h3>
+                {% if is_active_route(app.request, "app_assessors_#{space_type}_attribution_form") %}
+                    Bureaux de votes
+                {% else %}
+                    <a href="{{ path("app_assessors_#{space_type}_attribution_form") }}">
+                        Bureaux de votes
+                    </a>
+                {% endif %}
+            </h3>
+            <span class="separator"></span>
+            <h3>
+                {% if is_active_route(app.request, "app_municipal_manager_#{space_type}_attribution_form") %}
+                    Communes
+                {% else %}
+                    <a href="{{ path("app_municipal_manager_#{space_type}_attribution_form") }}">
+                        Communes
+                    </a>
+                {% endif %}
+            </h3>
+        </div>
+    </div>
+{% endif %}

--- a/templates/components/_nav_desktop.html.twig
+++ b/templates/components/_nav_desktop.html.twig
@@ -250,7 +250,8 @@
     is_granted('ROLE_JECOUTE_MANAGER') or
     is_granted('ROLE_ASSESSOR') or
     is_granted('ROLE_ELECTION_RESULTS_REPORTER') or
-    is_granted('ROLE_MUNICIPAL_MANAGER')
+    is_granted('ROLE_MUNICIPAL_MANAGER') or
+    is_granted('ROLE_MUNICIPAL_MANAGER_SUPERVISOR')
 %}
     {% set totalSections =
         (app.user.isSupervisor or app.user.isHost) +
@@ -263,6 +264,7 @@
         app.user.isAssessorManager +
         app.user.isMunicipalChief +
         app.user.isJecouteManager +
+        app.user.isMunicipalManagerSupervisor +
         app.user.isAssessor +
         app.user.isMunicipalManager +
         app.user.isElectionResultsReporter +

--- a/templates/components/_nav_mobile.html.twig
+++ b/templates/components/_nav_mobile.html.twig
@@ -98,6 +98,13 @@
                             <a href="{{ path('app_municipal_chief_home') }}">Espace Municipales 2020 🇫🇷</a>
                         </li>
                     {% endif %}
+                    {% if is_canary_enabled() and app.user.isMunicipalManagerSupervisor %}
+                        <li>
+                            <a href="{{ path('app_municipal_manager_municipal_manager_supervisor_attribution_form') }}">
+                                Espace superviseur de responsables communaux
+                            </a>
+                        </li>
+                    {% endif %}
                 </ul>
                 <ul>
                     <li>

--- a/templates/components/_nav_mobile.html.twig
+++ b/templates/components/_nav_mobile.html.twig
@@ -101,7 +101,7 @@
                     {% if is_canary_enabled() and app.user.isMunicipalManagerSupervisor %}
                         <li>
                             <a href="{{ path('app_municipal_manager_municipal_manager_supervisor_attribution_form') }}">
-                                Espace superviseur de responsables communaux
+                                Espace Responsable attribution
                             </a>
                         </li>
                     {% endif %}

--- a/templates/municipal_manager_attribution/_base_municipal_chief_space.html.twig
+++ b/templates/municipal_manager_attribution/_base_municipal_chief_space.html.twig
@@ -27,5 +27,5 @@
         </div>
     {% endif %}
 
-    {% block assessor_attribution_main_block %}{% endblock %}
+    {% block municipal_manager_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/municipal_manager_attribution/_base_municipal_chief_space.html.twig
+++ b/templates/municipal_manager_attribution/_base_municipal_chief_space.html.twig
@@ -1,31 +1,7 @@
 {% extends 'municipal_chief/_layout.html.twig' %}
 
 {% block municipal_chief_content %}
-    {% if is_canary_enabled() %}
-        <div class="datagrid__table__tabs">
-            <div class="datagrid__table__tabs__items">
-                <h3>
-                    {% if is_active_route(app.request, 'app_assessors_municipal_chief_attribution_form') %}
-                        Bureaux de votes
-                    {% else %}
-                        <a href="{{ path('app_assessors_municipal_chief_attribution_form') }}">
-                            Bureaux de votes
-                        </a>
-                    {% endif %}
-                </h3>
-                <span class="separator"></span>
-                <h3>
-                    {% if is_active_route(app.request, 'app_municipal_manager_municipal_chief_attribution_form') %}
-                        Communes
-                    {% else %}
-                        <a href="{{ path('app_municipal_manager_municipal_chief_attribution_form') }}">
-                            Communes
-                        </a>
-                    {% endif %}
-                </h3>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'assessor_attribution/_sub_menu.html.twig' %}
 
     {% block municipal_manager_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/municipal_manager_attribution/_base_municipal_manager_supervisor_space.html.twig
+++ b/templates/municipal_manager_attribution/_base_municipal_manager_supervisor_space.html.twig
@@ -1,0 +1,5 @@
+{% extends 'municipal_manager_supervisor/_layout.html.twig' %}
+
+{% block municipal_manager_supervisor_content %}
+    {% block municipal_manager_attribution_main_block %}{% endblock %}
+{% endblock %}

--- a/templates/municipal_manager_attribution/_base_referent_space.html.twig
+++ b/templates/municipal_manager_attribution/_base_referent_space.html.twig
@@ -1,31 +1,7 @@
 {% extends 'referent/_layout.html.twig' %}
 
 {% block referent_content %}
-    {% if is_canary_enabled() %}
-        <div class="datagrid__table__tabs">
-            <div class="datagrid__table__tabs__items">
-                <h3>
-                    {% if is_active_route(app.request, 'app_assessors_referent_attribution_form') %}
-                        Bureaux de votes
-                    {% else %}
-                        <a href="{{ path('app_assessors_referent_attribution_form') }}">
-                            Bureaux de votes
-                        </a>
-                    {% endif %}
-                </h3>
-                <span class="separator"></span>
-                <h3>
-                    {% if is_active_route(app.request, 'app_municipal_manager_referent_attribution_form') %}
-                        Communes
-                    {% else %}
-                        <a href="{{ path('app_municipal_manager_referent_attribution_form') }}">
-                            Communes
-                        </a>
-                    {% endif %}
-                </h3>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'assessor_attribution/_sub_menu.html.twig' %}
 
     {% block municipal_manager_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/municipal_manager_attribution/_base_referent_space.html.twig
+++ b/templates/municipal_manager_attribution/_base_referent_space.html.twig
@@ -1,24 +1,24 @@
-{% extends 'municipal_chief/_layout.html.twig' %}
+{% extends 'referent/_layout.html.twig' %}
 
-{% block municipal_chief_content %}
+{% block referent_content %}
     {% if is_canary_enabled() %}
         <div class="datagrid__table__tabs">
             <div class="datagrid__table__tabs__items">
                 <h3>
-                    {% if is_active_route(app.request, 'app_assessors_municipal_chief_attribution_form') %}
+                    {% if is_active_route(app.request, 'app_assessors_referent_attribution_form') %}
                         Bureaux de votes
                     {% else %}
-                        <a href="{{ path('app_assessors_municipal_chief_attribution_form') }}">
+                        <a href="{{ path('app_assessors_referent_attribution_form') }}">
                             Bureaux de votes
                         </a>
                     {% endif %}
                 </h3>
                 <span class="separator"></span>
                 <h3>
-                    {% if is_active_route(app.request, 'app_municipal_manager_municipal_chief_attribution_form') %}
+                    {% if is_active_route(app.request, 'app_municipal_manager_referent_attribution_form') %}
                         Communes
                     {% else %}
-                        <a href="{{ path('app_municipal_manager_municipal_chief_attribution_form') }}">
+                        <a href="{{ path('app_municipal_manager_referent_attribution_form') }}">
                             Communes
                         </a>
                     {% endif %}
@@ -27,5 +27,5 @@
         </div>
     {% endif %}
 
-    {% block assessor_attribution_main_block %}{% endblock %}
+    {% block municipal_manager_attribution_main_block %}{% endblock %}
 {% endblock %}

--- a/templates/municipal_manager_attribution/_layout.html.twig
+++ b/templates/municipal_manager_attribution/_layout.html.twig
@@ -1,0 +1,9 @@
+{% extends base_template %}
+
+{% block municipal_manager_attribution_main_block %}
+    <main>
+        <section class="b__nudge--bottom-huge">
+            {% block municipal_manager_attribution_content %}{% endblock %}
+        </section>
+    </main>
+{% endblock %}

--- a/templates/municipal_manager_attribution/index.html.twig
+++ b/templates/municipal_manager_attribution/index.html.twig
@@ -1,0 +1,148 @@
+{% extends 'municipal_manager_attribution/_layout.html.twig' %}
+
+{% block municipal_manager_attribution_main_block %}
+    <section>
+        <div class="manager__filters">
+            <div class="manager__filters__form">
+                {{ form_start(filter_form) }}
+
+                {{ form_errors(filter_form) }}
+
+                <div class="manager__filters__row">
+                    <div class="manager__filters__section">
+                        <div class="manager__filters__group">
+                            <div class="filter__row">
+                                {{ form_row(filter_form.name, {
+                                    label: 'Nom de ville',
+                                    label_attr: { class: 'filter__label' },
+                                    attr: { class: 'filter__field', placeholder: 'Saisissez un nom' }
+                                }) }}
+                            </div>
+
+                            <div class="filter__row">
+                                {{ form_row(filter_form.inseeCode, {
+                                    label: 'Code INSEE',
+                                    label_attr: { class: 'filter__label' },
+                                    attr: { class: 'filter__field', placeholder: 'Saisissez un code INSEE'}
+                                }) }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="manager__filters__section">
+                        <div class="manager__filters__group">
+                            <div class="filter__row">
+                                {{ form_row(filter_form.municipalManagerFirstName, {
+                                    label: 'Prénom du responsable communale',
+                                    label_attr: { class: 'filter__label' },
+                                    attr: { class: 'filter__field', placeholder: 'Saisissez un prénom' }
+                                }) }}
+                            </div>
+
+                            <div class="filter__row">
+                                {{ form_row(filter_form.municipalManagerLastName, {
+                                    label: 'Nom du responsable communale',
+                                    label_attr: { class: 'filter__label' },
+                                    attr: { class: 'filter__field', placeholder: 'Sélectionnez un nom' }
+                                }) }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="manager__filters__section">
+                        <div class="manager__filters__group">
+                            <div class="filter__row">
+                                {{ form_row(filter_form.municipalManagerEmail, {
+                                    label: 'Email du responsable communale',
+                                    label_attr: { class: 'filter__label' },
+                                    attr: { class: 'filter__field', placeholder: 'Saisissez un email' }
+                                }) }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="manager__filters__actions b__nudge--top">
+                    <button type="submit" class="btn btn--black b__nudge--bottom-medium">Filtrer</button>
+                    <a href="{{ path("app_municipal_manager_#{space_type}_attribution_form") }}" class="btn btn--no-border b__nudge--bottom-medium btn-filter--reset">
+                        Réinitialiser le filtre
+                    </a>
+                </div>
+
+                {{ form_end(filter_form) }}
+            </div>
+        </div>
+
+        {{ form_start(form) }}
+            <div class="text--right b__nudge--bottom">
+                <button type="submit" class="btn btn--blue--soft">Sauvegarder les choix</button>
+            </div>
+
+            {% if not form.vars.valid %}
+                <p class="text--error text--center">Le formulaire n'est pas valide</p>
+            {% endif %}
+
+            <table class="datagrid__table-manager">
+                <thead>
+                    <tr>
+                        <td class="space--0-15">Ville</td>
+                        <td>Adhérent - Responsable communale</td>
+                        <td>Téléphone</td>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for index, city in cities %}
+                        <tr>
+                            <td>
+                                <div class="l__row l__row--h-start">
+                                    <div class="l__col">
+                                        <strong>{{ city.name }} ({{ city.inseeCode }})</strong>
+                                        <br>
+                                        <span class="text--small">
+                                            {{ city.postalCodes|first }}, {{ city.country|countryName }}
+                                        </span>
+                                    </div>
+                                </div>
+                                {% if form[index] is defined %}
+                                    {{ form_row(form[index].city) }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if form[index] is defined %}
+                                    {{ form_row(form[index].adherent) }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if form[index] is defined %}
+                                    {% set adherent = form[index].vars.data.adherent %}
+
+                                    {% if adherent and adherent.phone %}
+                                        {{ adherent.phone|phone_number_format }}
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td colspan="3" class="text--center">
+                                <img src="{{ asset('/images/icons/icn_no-result.svg') }}" class="icn--no-result" width="30" />
+                                Aucun résultat
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            <div class="text--right b__nudge--top-15">
+                <button type="submit" class="btn btn--blue--soft">Sauvegarder les choix</button>
+            </div>
+
+        {{ form_end(form) }}
+
+        {% include 'components/_modern_pagination.html.twig' with {
+            current_page: cities.currentPage,
+            total_pages: cities.lastPage,
+            pagination_route_params: route_params
+        } %}
+    </section>
+{% endblock %}

--- a/templates/municipal_manager_attribution/index.html.twig
+++ b/templates/municipal_manager_attribution/index.html.twig
@@ -33,7 +33,7 @@
                         <div class="manager__filters__group">
                             <div class="filter__row">
                                 {{ form_row(filter_form.municipalManagerFirstName, {
-                                    label: 'Prénom du responsable communale',
+                                    label: 'Prénom du responsable communal',
                                     label_attr: { class: 'filter__label' },
                                     attr: { class: 'filter__field', placeholder: 'Saisissez un prénom' }
                                 }) }}
@@ -41,7 +41,7 @@
 
                             <div class="filter__row">
                                 {{ form_row(filter_form.municipalManagerLastName, {
-                                    label: 'Nom du responsable communale',
+                                    label: 'Nom du responsable communal',
                                     label_attr: { class: 'filter__label' },
                                     attr: { class: 'filter__field', placeholder: 'Sélectionnez un nom' }
                                 }) }}
@@ -53,7 +53,7 @@
                         <div class="manager__filters__group">
                             <div class="filter__row">
                                 {{ form_row(filter_form.municipalManagerEmail, {
-                                    label: 'Email du responsable communale',
+                                    label: 'Email du responsable communal',
                                     label_attr: { class: 'filter__label' },
                                     attr: { class: 'filter__field', placeholder: 'Saisissez un email' }
                                 }) }}
@@ -86,7 +86,7 @@
                 <thead>
                     <tr>
                         <td class="space--0-15">Ville</td>
-                        <td>Adhérent - Responsable communale</td>
+                        <td>Adhérent - Responsable communal</td>
                         <td>Téléphone</td>
                     </tr>
                 </thead>

--- a/templates/municipal_manager_supervisor/_layout.html.twig
+++ b/templates/municipal_manager_supervisor/_layout.html.twig
@@ -1,0 +1,56 @@
+{% extends 'base.html.twig' %}
+
+{% block page_title 'Mon espace superviseur de responsable communaux' %}
+{% block canonical_url url('app_municipal_manager_municipal_manager_supervisor_attribution_form') %}
+
+{% block banner '' %}
+
+{% block content %}
+    {% set managedAreaTags = app.user.municipalManagerSupervisorRole.referent.managedArea.tags|join(', ') %}
+    <main>
+        <section class="manager-space referent procuration-manager b__nudge--bottom-huge">
+            <header class="manager-header">
+                <div class="l__wrapper">
+                    <div class="first-section">
+                        <div class="manager-information">
+                            <p>Vous gérez : <span>{{ managedAreaTags }}</span></p>
+                        </div>
+                        <p class="report">🐛 Bug ? Nouveau besoin ?
+                            <a href="https://t.me/joinchat/EmY0e1J2fyTv4Fd-cHEMHg" target="_blank" class="text--blue--dark link--no-decor">Écrivez-nous !</a>
+                        </p>
+                    </div>
+                    <div class="second-section">
+                        <h1 class="page-title text--large b__nudge--bottom">
+                            {{ block('page_title') }}
+                        </h1>
+                    </div>
+                </div>
+            </header>
+
+            <div class="l__wrapper procuration-manager__content text--body">
+                {% block municipal_manager_supervisor_content %}{% endblock %}
+            </div>
+
+            <div id="managerOnScroll" class="manager__fixed-bar">
+                <div class="l__wrapper manager__fixed-bar__content">
+                    <p>Vous gérez : <span>{{ managedAreaTags }}</span></p>
+                </div>
+            </div>
+        </section>
+    </main>
+{% endblock %}
+
+{% block final_javascripts %}
+    <script type="text/javascript" src={{ asset('bundles/sonataadmin/vendor/jquery/dist/jquery.min.js') }}></script>
+    <script type="text/javascript" src={{ asset('bundles/sonataadmin/vendor/jqueryui/ui/jquery-ui.js') }}></script>
+
+    {% if js is not defined %}
+        {% import 'javascript.js.twig' as js %}
+    {% endif %}
+
+    <script type="text/javascript">
+        Kernel.onLoad(function() {
+            {{ js.manager_sticky_header('#managerOnScroll') }}
+        });
+    </script>
+{% endblock %}

--- a/templates/municipal_manager_supervisor/_layout.html.twig
+++ b/templates/municipal_manager_supervisor/_layout.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block page_title 'Mon espace superviseur de responsable communaux' %}
+{% block page_title 'Mon espace responsable attribution' %}
 {% block canonical_url url('app_municipal_manager_municipal_manager_supervisor_attribution_form') %}
 
 {% block banner '' %}

--- a/templates/referent/edit_referent_person_link.html.twig
+++ b/templates/referent/edit_referent_person_link.html.twig
@@ -43,6 +43,13 @@
             </label>
         </div>
 
+        <div class="form__checkbox">
+            {{ form_widget(form.isMunicipalManagerSupervisor) }}
+            <label class="form form__label" for="{{ form.isMunicipalManagerSupervisor.vars.id }}">
+                {{ 'referent.checkbox.municipal_manager_supervisor'|trans|raw }}
+            </label>
+        </div>
+
         <div class="form__row text--center b__nudge--top-50">
             <p>
                 <button type="submit" class="btn btn--blue btn--large-and-full">Sauvegarder</button>

--- a/templates/referent/municipal_manager/attribution_form.html.twig
+++ b/templates/referent/municipal_manager/attribution_form.html.twig
@@ -28,11 +28,11 @@
                     <div class="manager__filters__section">
                         <div class="manager__filters__group">
                             <div class="filter__row">
-                                {{ form_row(filter_form.municipalManagerFirstName, {label: 'Prénom du responsable communale', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Saisissez un prénom'}}) }}
+                                {{ form_row(filter_form.municipalManagerFirstName, {label: 'Prénom du responsable communal', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Saisissez un prénom'}}) }}
                             </div>
 
                             <div class="filter__row">
-                                {{ form_row(filter_form.municipalManagerLastName, {label: 'Nom du responsable communale', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Sélectionnez un nom'}}) }}
+                                {{ form_row(filter_form.municipalManagerLastName, {label: 'Nom du responsable communal', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Sélectionnez un nom'}}) }}
                             </div>
                         </div>
                     </div>
@@ -40,7 +40,7 @@
                     <div class="manager__filters__section">
                         <div class="manager__filters__group">
                             <div class="filter__row">
-                                {{ form_row(filter_form.municipalManagerEmail, {label: 'Email du responsable communale', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Saisissez un email'}}) }}
+                                {{ form_row(filter_form.municipalManagerEmail, {label: 'Email du responsable communal', label_attr: {class: 'filter__label'}, attr: {class: 'filter__field', placeholder: 'Saisissez un email'}}) }}
                             </div>
                         </div>
                     </div>
@@ -68,7 +68,7 @@
                 <thead>
                     <tr>
                         <td class="space--0-15">Ville</td>
-                        <td>Adhérent - Responsable communale</td>
+                        <td>Adhérent - Responsable communal</td>
                         <td>Téléphone</td>
                         <td>Action</td>
                     </tr>

--- a/templates/referent/organizational_chart_macros.html.twig
+++ b/templates/referent/organizational_chart_macros.html.twig
@@ -35,6 +35,9 @@
                             {% if ref_person_link.isJecouteManager %}
                                 <span class="referent-person-link">{{ 'common.jecoute_manager'|trans }}</span>
                             {% endif %}
+                            {% if ref_person_link.isMunicipalManagerSupervisor %}
+                                <span class="referent-person-link">{{ 'referent.municipal_managers_access'|trans }}</span>
+                            {% endif %}
                         {% endif %}
                 {% if editable %}
                     </a>

--- a/tests/Controller/EnMarche/MunicipalManagerAttribution/MunicipalChiefMunicipalManagerAttributionControllerTest.php
+++ b/tests/Controller/EnMarche/MunicipalManagerAttribution/MunicipalChiefMunicipalManagerAttributionControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\AppBundle\Controller\EnMarche;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\Controller\ControllerTestTrait;
+
+/**
+ * @group functional
+ */
+class MunicipalChiefMunicipalManagerAttributionControllerTest extends WebTestCase
+{
+    use ControllerTestTrait;
+
+    public function testReferentCanReachMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'municipal-chief@en-marche-dev.fr');
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/');
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Espace Municipales 2020')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Assesseurs')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Communes')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $cities = $crawler->filter('.datagrid__table-manager tbody tr');
+        $this->assertCount(1, $cities);
+
+        $this->assertContains('Lille (59350)', $cities->eq(0)->text());
+    }
+
+    public function testAdherentCanNotSeeMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'michel.vasseur@example.ch');
+
+        $this->client->request(Request::METHOD_GET, '/espace-municipales-2020/responsables-communaux');
+        $this->assertResponseStatusCode(Response::HTTP_FORBIDDEN, $this->client->getResponse());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->init();
+    }
+
+    protected function tearDown()
+    {
+        $this->kill();
+
+        parent::tearDown();
+    }
+}

--- a/tests/Controller/EnMarche/MunicipalManagerAttribution/MunicipalManagerSupervisorMunicipalManagerAttributionControllerTest.php
+++ b/tests/Controller/EnMarche/MunicipalManagerAttribution/MunicipalManagerSupervisorMunicipalManagerAttributionControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\AppBundle\Controller\EnMarche;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\Controller\ControllerTestTrait;
+
+/**
+ * @group functional
+ */
+class MunicipalManagerSupervisorMunicipalManagerAttributionControllerTest extends WebTestCase
+{
+    use ControllerTestTrait;
+
+    public function testReferentCanReachMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'benjyd@aol.com');
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/');
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Espace Responsable attribution')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $cities = $crawler->filter('.datagrid__table-manager tbody tr');
+        $this->assertCount(3, $cities);
+
+        $this->assertContains('Lille (59350)', $cities->eq(0)->text());
+        $this->assertContains('Roubaix (59512)', $cities->eq(1)->text());
+        $this->assertContains('Seclin (59560)', $cities->eq(2)->text());
+    }
+
+    public function testAdherentCanNotSeeMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'michel.vasseur@example.ch');
+
+        $this->client->request(Request::METHOD_GET, '/espace-responsable-attribution/responsables-communaux');
+        $this->assertResponseStatusCode(Response::HTTP_FORBIDDEN, $this->client->getResponse());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->init();
+    }
+
+    protected function tearDown()
+    {
+        $this->kill();
+
+        parent::tearDown();
+    }
+}

--- a/tests/Controller/EnMarche/MunicipalManagerAttribution/ReferentMunicipalManagerAttributionControllerTest.php
+++ b/tests/Controller/EnMarche/MunicipalManagerAttribution/ReferentMunicipalManagerAttributionControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\AppBundle\Controller\EnMarche;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AppBundle\Controller\ControllerTestTrait;
+
+/**
+ * @group functional
+ */
+class ReferentMunicipalManagerAttributionControllerTest extends WebTestCase
+{
+    use ControllerTestTrait;
+
+    public function testReferentCanReachMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'referent@en-marche-dev.fr');
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/');
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Espace référent')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Assesseurs')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $crawler = $this->client->click($crawler->selectLink('Communes')->link());
+        $this->assertResponseStatusCode(Response::HTTP_OK, $this->client->getResponse());
+
+        $cities = $crawler->filter('.datagrid__table-manager tbody tr');
+        $this->assertCount(3, $cities);
+
+        $this->assertContains('Lille (59350)', $cities->eq(0)->text());
+        $this->assertContains('Roubaix (59512)', $cities->eq(1)->text());
+        $this->assertContains('Seclin (59560)', $cities->eq(2)->text());
+    }
+
+    public function testAdherentCanNotSeeMunicipalManagerAttributionForm()
+    {
+        $this->authenticateAsAdherent($this->client, 'michel.vasseur@example.ch');
+
+        $this->client->request(Request::METHOD_GET, '/espace-referent/responsables-communaux');
+        $this->assertResponseStatusCode(Response::HTTP_FORBIDDEN, $this->client->getResponse());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->init();
+    }
+
+    protected function tearDown()
+    {
+        $this->kill();
+
+        parent::tearDown();
+    }
+}

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -77,6 +77,7 @@ user: utilisateur
 citizen_project_holder: porteur de projet
 municipal_chief: Candidat Municipales 2020 🇫🇷
 municipal_manager: Responsable communal
+municipal_manager_supervisor: Responsable attribution
 election_results_reporter: Rapporteur résultats
 print_privilege: Accès LMI
 
@@ -292,7 +293,9 @@ referent.filter.interests: Choisissez des centres d'intérêt
 referent.managed_area: Zone gérée
 referent.checkbox.co_referent: Donner un accès à l'onglet&nbsp;<i>Adhérents</i>
 referent.checkbox.jecoute_manager: Donner un accès à l'espace&nbsp;<i>J'écoute</i>
+referent.checkbox.municipal_manager_supervisor: Donner un accès à l'onglet&nbsp;<i>Responsables Communaux</i>
 referent.coreferent_access: Accès adhérents
+referent.municipal_managers_access: Accès responsables communaux
 referent.email.unchangeable: Pour pouvoir modifier l'e-mail, veuillez décocher la case donnant les droits d'accès à la rubrique <i>Adhérents</i> et sauvegarder la modification.
 referent.save: Enregistrer
 


### PR DESCRIPTION
1/
Root referents can now assign "municipal manager supervisor" role to their team members in the organizational chart

2/
3 roles can access the municipal manager attributon form:
- referents (Espace référent > Assesseurs > Communes)
- municipal chiefs (Espace Municipales 2020 > Assesseurs Communes)
- municipal manager supervisors (Espace Responsable attribution)