### PR TITLE
Add cascades on election results

### DIFF
--- a/migrations/Version20200319132336.php
+++ b/migrations/Version20200319132336.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20200319132336 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE vote_result_list DROP FOREIGN KEY FK_677ED502DB567AF4');
+        $this->addSql('ALTER TABLE 
+          vote_result_list 
+        ADD 
+          CONSTRAINT FK_677ED502DB567AF4 FOREIGN KEY (list_collection_id) REFERENCES vote_result_list_collection (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE vote_result DROP FOREIGN KEY FK_1F8DB3498BAC62AF');
+        $this->addSql('ALTER TABLE vote_result DROP FOREIGN KEY FK_1F8DB349F3F90B30');
+        $this->addSql('ALTER TABLE 
+          vote_result 
+        ADD 
+          CONSTRAINT FK_1F8DB3498BAC62AF FOREIGN KEY (city_id) REFERENCES cities (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE 
+          vote_result 
+        ADD 
+          CONSTRAINT FK_1F8DB349F3F90B30 FOREIGN KEY (vote_place_id) REFERENCES vote_place (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE vote_result DROP FOREIGN KEY FK_1F8DB3498BAC62AF');
+        $this->addSql('ALTER TABLE vote_result DROP FOREIGN KEY FK_1F8DB349F3F90B30');
+        $this->addSql('ALTER TABLE 
+          vote_result 
+        ADD 
+          CONSTRAINT FK_1F8DB3498BAC62AF FOREIGN KEY (city_id) REFERENCES cities (id)');
+        $this->addSql('ALTER TABLE 
+          vote_result 
+        ADD 
+          CONSTRAINT FK_1F8DB349F3F90B30 FOREIGN KEY (vote_place_id) REFERENCES vote_place (id)');
+        $this->addSql('ALTER TABLE vote_result_list DROP FOREIGN KEY FK_677ED502DB567AF4');
+        $this->addSql('ALTER TABLE 
+          vote_result_list 
+        ADD 
+          CONSTRAINT FK_677ED502DB567AF4 FOREIGN KEY (list_collection_id) REFERENCES vote_result_list_collection (id)');
+    }
+}

--- a/src/Entity/Election/CityVoteResult.php
+++ b/src/Entity/Election/CityVoteResult.php
@@ -18,6 +18,7 @@ class CityVoteResult extends BaseWithListCollectionResult
      * @var City
      *
      * @ORM\OneToOne(targetEntity="AppBundle\Entity\City")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $city;
 

--- a/src/Entity/Election/VotePlaceResult.php
+++ b/src/Entity/Election/VotePlaceResult.php
@@ -18,6 +18,7 @@ class VotePlaceResult extends BaseWithListCollectionResult
      * @var VotePlace
      *
      * @ORM\ManyToOne(targetEntity="AppBundle\Entity\VotePlace", inversedBy="voteResults")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $votePlace;
 

--- a/src/Entity/Election/VoteResultList.php
+++ b/src/Entity/Election/VoteResultList.php
@@ -27,6 +27,7 @@ class VoteResultList
      * @var VoteResultListCollection
      *
      * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Election\VoteResultListCollection", inversedBy="lists")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $listCollection;
 

--- a/src/Entity/Election/VoteResultListCollection.php
+++ b/src/Entity/Election/VoteResultListCollection.php
@@ -36,7 +36,6 @@ class VoteResultListCollection
      * @var VoteResultList[]|Collection
      *
      * @ORM\OneToMany(targetEntity="AppBundle\Entity\Election\VoteResultList", mappedBy="listCollection", cascade={"all"}, orphanRemoval=true)
-     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
      *
      * @Assert\Count(min=1)
      */


### PR DESCRIPTION
on database level:
- when deleting a `City`, all related `CityResult` should be delete on cascade

- when deleting a `VotePlace`, all related `VoteResult` should be delete on cascade

- when deleting a `VoteResultListCollection`, all related `VoteResultList` should be delete on cascade