### PR TITLE
Procuration proxies can now accept up to 2 french requests

### DIFF
--- a/src/Entity/ProcurationProxy.php
+++ b/src/Entity/ProcurationProxy.php
@@ -34,6 +34,7 @@ class ProcurationProxy
     private const RELIABILITY_ACTIVIST = 6;
     private const RELIABILITY_REPRESENTATIVE = 8;
 
+    private const MAX_FRENCH_REQUESTS = 2;
     private const MAX_FOREIGN_REQUESTS_FROM_FRANCE = 2;
     private const MAX_FOREIGN_REQUESTS_FROM_FOREIGN_COUNTRY = 3;
 
@@ -686,7 +687,8 @@ class ProcurationProxy
 
     private function processFrenchAvailability(): void
     {
-        $this->frenchRequestAvailable = $this->hasFreeSlots() && !$this->isProxyForFrenchRequest();
+        $this->frenchRequestAvailable = $this->hasFreeSlots()
+            && self::MAX_FRENCH_REQUESTS > $this->countFrenchRequests();
     }
 
     private function processForeignAvailability(): void
@@ -732,15 +734,15 @@ class ProcurationProxy
         return $this->proxiesCount - $this->foundRequests->count();
     }
 
-    private function isProxyForFrenchRequest(): bool
+    private function countFrenchRequests(): int
     {
-        foreach ($this->getFoundRequests() as $request) {
-            if (true === $request->isRequestFromFrance()) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this
+            ->getFoundRequests()
+            ->filter(function (ProcurationRequest $request) {
+                return true === $request->isRequestFromFrance();
+            })
+            ->count()
+        ;
     }
 
     private function countForeignRequests(): int

--- a/tests/Entity/ProcurationRequestTest.php
+++ b/tests/Entity/ProcurationRequestTest.php
@@ -6,6 +6,9 @@ use App\Entity\ProcurationProxy;
 use App\Entity\ProcurationRequest;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group procuration
+ */
 class ProcurationRequestTest extends TestCase
 {
     public function testProcessAndUnprocessWithFrenchProxy()
@@ -39,10 +42,20 @@ class ProcurationRequestTest extends TestCase
         $requestFromForeignCountry->unprocess();
 
         $this->assertCount(1, $proxy->getFoundRequests());
+        $this->assertTrue($proxy->isFrenchRequestAvailable());
+        $this->assertTrue($proxy->isForeignRequestAvailable());
+
+        $requestFromFrance2 = new ProcurationRequest();
+        $requestFromFrance2->setRequestFromFrance(true);
+
+        $requestFromFrance2->process($proxy);
+
+        $this->assertCount(2, $proxy->getFoundRequests());
         $this->assertFalse($proxy->isFrenchRequestAvailable());
-        $this->assertTrue(true, $proxy->isForeignRequestAvailable());
+        $this->assertFalse($proxy->isForeignRequestAvailable());
 
         $requestFromFrance->unprocess();
+        $requestFromFrance2->unprocess();
 
         $this->assertEmpty($proxy->getFoundRequests());
         $this->assertTrue($proxy->isFrenchRequestAvailable());
@@ -65,7 +78,7 @@ class ProcurationRequestTest extends TestCase
         $requestFromFrance->process($proxy);
 
         $this->assertCount(1, $proxy->getFoundRequests());
-        $this->assertFalse($proxy->isFrenchRequestAvailable());
+        $this->assertTrue($proxy->isFrenchRequestAvailable());
         $this->assertTrue($proxy->isForeignRequestAvailable());
 
         $requestFromForeignCountry = new ProcurationRequest();
@@ -74,7 +87,7 @@ class ProcurationRequestTest extends TestCase
         $requestFromForeignCountry->process($proxy);
 
         $this->assertCount(2, $proxy->getFoundRequests());
-        $this->assertFalse($proxy->isFrenchRequestAvailable());
+        $this->assertTrue($proxy->isFrenchRequestAvailable());
         $this->assertTrue($proxy->isForeignRequestAvailable());
 
         $requestFromForeignCountry2 = new ProcurationRequest();
@@ -138,8 +151,8 @@ class ProcurationRequestTest extends TestCase
         yield 'Proxy from france, with 1 slot and only one request not from france: should not be available for french nor foreign extra requests' => [
             'FR', 1, [false], false, false,
         ];
-        yield 'Proxy from france, with 2 slots and only one request from france: should not be available for french extra requests, but is available for foreign extra requests' => [
-            'FR', 2, [true], false, true,
+        yield 'Proxy from france, with 2 slots and only one request from france: should be available for french and foreign extra requests' => [
+            'FR', 2, [true], true, true,
         ];
         yield 'Proxy from france, with 2 slots and only one request from a foreign country: should be available for french extra request, but not foreign extra requests' => [
             'FR', 2, [false], true, true,
@@ -150,6 +163,9 @@ class ProcurationRequestTest extends TestCase
         yield 'Same scenario as above, but changing requests order: should be the same result as above' => [
             'FR', 2, [false, true], false, false,
         ];
+        yield 'Proxy from france, with 2 slots and two requests from france: should not be available for french nor foreign extra requests' => [
+            'FR', 2, [true, true], false, false,
+        ];
         yield 'Proxy from france, with 2 slots and two requests from foreign countries: shouuld not be available for french nor foreign extra requests' => [
             'FR', 2, [false, false], false, false,
         ];
@@ -159,8 +175,8 @@ class ProcurationRequestTest extends TestCase
         yield 'Proxy from foreign country, with 1 slot and only one request from foreign country: should not be available for french nor foreign extra requests' => [
             'GB', 1, [false], false, false,
         ];
-        yield 'Proxy from foreign country, with 2 slots and only one request from france: should not be available for french extra requests, but is available for foreign extra requests' => [
-            'GB', 2, [true], false, true,
+        yield 'Proxy from foreign country, with 2 slots and only one request from france: should be available for french and foreign extra requests' => [
+            'GB', 2, [true], true, true,
         ];
         yield 'Proxy from foreign country, with 2 slots and only one request from foreign country: should be available for french and foreign extra requests' => [
             'GB', 2, [false], true, true,
@@ -171,23 +187,29 @@ class ProcurationRequestTest extends TestCase
         yield 'Same scenario as above, but changing requests order: should be the same result as above..' => [
             'GB', 2, [false, true], false, false,
         ];
+        yield 'Proxy from foreign country, with 2 slots and two requests from france: should not be available for french nor foreign extra requests' => [
+            'GB', 2, [true, true], false, false,
+        ];
         yield 'Proxy from foreign country, with 2 slots and two requests from foreign country: should not be available for french nor foreign extra requests' => [
             'GB', 2, [false, false], false, false,
         ];
-        yield 'Proxy from foreign country, with 3 slots and only one request from france: should not be available for french extra requests, but is available for foreign extra requests' => [
-            'GB', 3, [true], false, true,
+        yield 'Proxy from foreign country, with 3 slots and only one request from france: should be available for french and foreign extra requests' => [
+            'GB', 3, [true], true, true,
         ];
         yield 'Proxy from foreign country, with 3 slots and only one request from foreign country: should be available for french and foreign extra requests' => [
             'GB', 3, [false], true, true,
         ];
-        yield 'Proxy from foreign country, with 3 slots and two requests (one from france and one from foreign country): should not be available for french extra request but should be available for foreign extra requests' => [
-            'GB', 3, [true, false], false, true,
+        yield 'Proxy from foreign country, with 3 slots and two requests (one from france and one from foreign country): should not be available for french and foreign extra request' => [
+            'GB', 3, [true, false], true, true,
         ];
         yield 'Same scenario as above, but changing requests order: should be the same result as above' => [
             'GB', 3, [false, true], false, true,
         ];
         yield 'Proxy from foreign country, with 3 slots and two requests from foreign country: should be available for french and foreign extra requests' => [
             'GB', 3, [false, false], true, true,
+        ];
+        yield 'Proxy from foreign country, with 3 slots and two requests from france: should not be available for french extra request, but is available for foreign extra request' => [
+            'GB', 3, [true, true], false, true,
         ];
         yield 'Proxy from foreign country, with 3 slots and 3 requests (one from france and two from foreign countries): should not be available for french nor foreign extra requests' => [
             'GB', 3, [true, false, false], false, false,


### PR DESCRIPTION
to execute post-deploy:

```

UPDATE procuration_proxies 
SET french_request_available = 1
WHERE id IN (
	SELECT id
	FROM (
		SELECT
			pp.id,
			pp.proxies_count,
			pp.french_request_available,
			pp.foreign_request_available,
			COUNT(DISTINCT(mpr.id)) AS matched_requests,
			COUNT(DISTINCT(frmpr.id)) AS french_matched_requests,
			COUNT(DISTINCT(fompr.id)) AS foreign_matched_requests,
			
			pp.proxies_count - COUNT(DISTINCT(mpr.id)) AS free_slots
		FROM procuration_proxies AS pp
		
		
		INNER JOIN procuration_proxies_to_election_rounds AS pper
			ON pper.procuration_proxy_id = pp.id
		INNER JOIN election_rounds AS er
			ON er.id = pper.election_round_id 
		INNER JOIN elections AS e
			ON e.id = er.election_id
		
		LEFT JOIN procuration_requests AS mpr
			ON mpr.found_proxy_id = pp.id
			
		LEFT JOIN procuration_requests AS frmpr
			ON frmpr.found_proxy_id = pp.id
			AND frmpr.request_from_france = 1
		
		LEFT JOIN procuration_requests AS fompr
			ON fompr.found_proxy_id = pp.id
			AND fompr.request_from_france = 0
		
		WHERE e.name = 'Élections municipales 2020'
		
		GROUP BY pp.id
		HAVING free_slots > 0
		AND french_matched_requests < 2
	) AS temp
)
;
```

(execute only the SELECT before to be sure of what you're updating)