### PR TITLE
French geo entities

### DIFF
--- a/migrations/Version20200825130502.php
+++ b/migrations/Version20200825130502.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20200825130502 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE geo_region (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          country_id INT UNSIGNED NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_A4B3C80877153098 (code),
+          INDEX IDX_A4B3C808F92F3E70 (country_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_canton (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          department_id INT UNSIGNED NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_F04FC05F77153098 (code),
+          INDEX IDX_F04FC05FAE80F5DF (department_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_department (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          region_id INT UNSIGNED NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_B460660477153098 (code),
+          INDEX IDX_B460660498260155 (region_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_district (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          department_id INT UNSIGNED NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_DF78232677153098 (code),
+          INDEX IDX_DF782326AE80F5DF (department_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_city (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          department_id INT UNSIGNED DEFAULT NULL,
+          city_community_id INT UNSIGNED DEFAULT NULL,
+          district_id INT UNSIGNED DEFAULT NULL,
+          postal_code LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:simple_array)\',
+          population INT DEFAULT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_297C2D3477153098 (code),
+          INDEX IDX_297C2D34AE80F5DF (department_id),
+          INDEX IDX_297C2D346D3B1930 (city_community_id),
+          INDEX IDX_297C2D34B08FA272 (district_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_city_canton (
+          city_id INT UNSIGNED NOT NULL,
+          canton_id INT UNSIGNED NOT NULL,
+          INDEX IDX_A4AB64718BAC62AF (city_id),
+          INDEX IDX_A4AB64718D070D0B (canton_id),
+          PRIMARY KEY(city_id, canton_id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_country (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_E465446477153098 (code),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE geo_city_community (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          department_id INT UNSIGNED NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_E5805E0877153098 (code),
+          INDEX IDX_E5805E08AE80F5DF (department_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE
+          geo_region
+        ADD
+          CONSTRAINT FK_A4B3C808F92F3E70 FOREIGN KEY (country_id) REFERENCES geo_country (id)');
+        $this->addSql('ALTER TABLE
+          geo_canton
+        ADD
+          CONSTRAINT FK_F04FC05FAE80F5DF FOREIGN KEY (department_id) REFERENCES geo_department (id)');
+        $this->addSql('ALTER TABLE
+          geo_department
+        ADD
+          CONSTRAINT FK_B460660498260155 FOREIGN KEY (region_id) REFERENCES geo_region (id)');
+        $this->addSql('ALTER TABLE
+          geo_district
+        ADD
+          CONSTRAINT FK_DF782326AE80F5DF FOREIGN KEY (department_id) REFERENCES geo_department (id)');
+        $this->addSql('ALTER TABLE
+          geo_city
+        ADD
+          CONSTRAINT FK_297C2D34AE80F5DF FOREIGN KEY (department_id) REFERENCES geo_department (id)');
+        $this->addSql('ALTER TABLE
+          geo_city
+        ADD
+          CONSTRAINT FK_297C2D346D3B1930 FOREIGN KEY (city_community_id) REFERENCES geo_city_community (id)');
+        $this->addSql('ALTER TABLE
+          geo_city
+        ADD
+          CONSTRAINT FK_297C2D34B08FA272 FOREIGN KEY (district_id) REFERENCES geo_district (id)');
+        $this->addSql('ALTER TABLE
+          geo_city_canton
+        ADD
+          CONSTRAINT FK_A4AB64718BAC62AF FOREIGN KEY (city_id) REFERENCES geo_city (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE
+          geo_city_canton
+        ADD
+          CONSTRAINT FK_A4AB64718D070D0B FOREIGN KEY (canton_id) REFERENCES geo_canton (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE
+          geo_city_community
+        ADD
+          CONSTRAINT FK_E5805E08AE80F5DF FOREIGN KEY (department_id) REFERENCES geo_department (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE geo_department DROP FOREIGN KEY FK_B460660498260155');
+        $this->addSql('ALTER TABLE geo_city_canton DROP FOREIGN KEY FK_A4AB64718D070D0B');
+        $this->addSql('ALTER TABLE geo_canton DROP FOREIGN KEY FK_F04FC05FAE80F5DF');
+        $this->addSql('ALTER TABLE geo_district DROP FOREIGN KEY FK_DF782326AE80F5DF');
+        $this->addSql('ALTER TABLE geo_city DROP FOREIGN KEY FK_297C2D34AE80F5DF');
+        $this->addSql('ALTER TABLE geo_city_community DROP FOREIGN KEY FK_E5805E08AE80F5DF');
+        $this->addSql('ALTER TABLE geo_city DROP FOREIGN KEY FK_297C2D34B08FA272');
+        $this->addSql('ALTER TABLE geo_city_canton DROP FOREIGN KEY FK_A4AB64718BAC62AF');
+        $this->addSql('ALTER TABLE geo_region DROP FOREIGN KEY FK_A4B3C808F92F3E70');
+        $this->addSql('ALTER TABLE geo_city DROP FOREIGN KEY FK_297C2D346D3B1930');
+        $this->addSql('DROP TABLE geo_region');
+        $this->addSql('DROP TABLE geo_canton');
+        $this->addSql('DROP TABLE geo_department');
+        $this->addSql('DROP TABLE geo_district');
+        $this->addSql('DROP TABLE geo_city');
+        $this->addSql('DROP TABLE geo_city_canton');
+        $this->addSql('DROP TABLE geo_country');
+        $this->addSql('DROP TABLE geo_city_community');
+    }
+}

--- a/src/Entity/Geo/Canton.php
+++ b/src/Entity/Geo/Canton.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_canton")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class Canton implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var Department
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Department")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $department;
+
+    /**
+     * @var City[]|Collection
+     *
+     * @ORM\ManyToMany(targetEntity="App\Entity\Geo\City", mappedBy="cantons")
+     */
+    private $cities;
+
+    public function __construct(string $code, string $name, Department $department)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->department = $department;
+        $this->cities = new ArrayCollection();
+    }
+
+    public function getDepartment(): Department
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(Department $department): void
+    {
+        $this->department = $department;
+    }
+
+    /**
+     * @return City[]|Collection
+     */
+    public function getCities(): Collection
+    {
+        return $this->cities;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $department = $this->getDepartment();
+        if ($department) {
+            $parents = array_merge($parents, $department->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}

--- a/src/Entity/Geo/City.php
+++ b/src/Entity/Geo/City.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_city")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class City implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var string[]|null
+     *
+     * @ORM\Column(type="simple_array", nullable=true)
+     */
+    private $postalCode;
+
+    /**
+     * @var int|null
+     *
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $population;
+
+    /**
+     * @var Department|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Department")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $department;
+
+    /**
+     * @var Canton[]|Collection
+     *
+     * @ORM\ManyToMany(targetEntity="App\Entity\Geo\Canton", inversedBy="cities")
+     * @ORM\JoinTable(name="geo_city_canton")
+     */
+    private $cantons;
+
+    /**
+     * @var CityCommunity|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\CityCommunity")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $cityCommunity;
+
+    /**
+     * @var District|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\District")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $district;
+
+    public function __construct(string $code, string $name)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->cantons = new ArrayCollection();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPostalCode(): array
+    {
+        return $this->postalCode ?: [];
+    }
+
+    /**
+     * @param string[] $postalCode
+     */
+    public function setPostalCode(array $postalCode): void
+    {
+        $this->postalCode = $postalCode;
+    }
+
+    public function getPopulation(): ?int
+    {
+        return $this->population;
+    }
+
+    public function setPopulation(?int $population): void
+    {
+        $this->population = $population;
+    }
+
+    public function getDepartment(): ?Department
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(?Department $department): void
+    {
+        $this->department = $department;
+    }
+
+    /**
+     * @return Canton[]|Collection
+     */
+    public function getCantons(): Collection
+    {
+        return $this->cantons;
+    }
+
+    public function getCityCommunity(): ?CityCommunity
+    {
+        return $this->cityCommunity;
+    }
+
+    public function setCityCommunity(?CityCommunity $cityCommunity): void
+    {
+        $this->cityCommunity = $cityCommunity;
+    }
+
+    public function getDistrict(): ?District
+    {
+        return $this->district;
+    }
+
+    public function setDistrict(?District $district): void
+    {
+        $this->district = $district;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $department = $this->getDepartment();
+        if ($department) {
+            $parents = array_merge($parents, $department->getParents());
+        }
+
+        $cantons = $this->getCantons();
+        foreach ($cantons as $canton) {
+            $parents[] = $canton;
+            $parents = array_merge($parents, $canton->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}

--- a/src/Entity/Geo/CityCommunity.php
+++ b/src/Entity/Geo/CityCommunity.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_city_community")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class CityCommunity implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var Department
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Department")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $department;
+
+    public function __construct(string $code, string $name, Department $department)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->department = $department;
+    }
+
+    public function getDepartment(): Department
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(Department $department): void
+    {
+        $this->department = $department;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $department = $this->getDepartment();
+        if ($department) {
+            $parents = array_merge($parents, $department->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}

--- a/src/Entity/Geo/CollectivityInterface.php
+++ b/src/Entity/Geo/CollectivityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Entity\Geo;
+
+interface CollectivityInterface
+{
+    public function getId(): ?int;
+
+    public function getCode(): ?string;
+
+    public function setCode(string $code): void;
+
+    public function getName(): ?string;
+
+    public function setName(string $name): void;
+
+    public function isActive(): bool;
+
+    public function activate(bool $active = true): void;
+
+    /**
+     * @return CollectivityInterface[]
+     */
+    public function getParents(): array;
+}

--- a/src/Entity/Geo/Country.php
+++ b/src/Entity/Geo/Country.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_country")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class Country implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    public function __construct(string $code, string $name)
+    {
+        $this->code = $code;
+        $this->name = $name;
+    }
+
+    public function getParents(): array
+    {
+        return [];
+    }
+}

--- a/src/Entity/Geo/Department.php
+++ b/src/Entity/Geo/Department.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_department")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class Department implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var Region
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Region")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $region;
+
+    public function __construct(string $code, string $name, Region $region)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->region = $region;
+    }
+
+    public function getRegion(): Region
+    {
+        return $this->region;
+    }
+
+    public function setRegion(Region $region): void
+    {
+        $this->region = $region;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $region = $this->getRegion();
+        if ($region) {
+            $parents = array_merge($parents, $region->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}

--- a/src/Entity/Geo/District.php
+++ b/src/Entity/Geo/District.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_district")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class District implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var Department
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Department")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $department;
+
+    public function __construct(string $code, string $name, Department $department)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->department = $department;
+    }
+
+    public function getDepartment(): Department
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(Department $department): void
+    {
+        $this->department = $department;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $department = $this->getDepartment();
+        if ($department) {
+            $parents = array_merge($parents, $department->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}

--- a/src/Entity/Geo/GeoTrait.php
+++ b/src/Entity/Geo/GeoTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait GeoTrait
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(unique=true)
+     */
+    private $code;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column
+     */
+    private $name;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $active = true;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function activate(bool $active = true): void
+    {
+        $this->active = $active;
+    }
+
+    private function sanitizeEntityList(array $entities): array
+    {
+        $unique = [];
+        foreach (array_filter($entities) as $entity) {
+            if (!\in_array($entity, $unique, true)) {
+                $unique[] = $entity;
+            }
+        }
+
+        return $unique;
+    }
+}

--- a/src/Entity/Geo/Region.php
+++ b/src/Entity/Geo/Region.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="geo_region")
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class Region implements CollectivityInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    /**
+     * @var Country|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Country")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $country;
+
+    public function __construct(string $code, string $name, Country $country)
+    {
+        $this->code = $code;
+        $this->name = $name;
+        $this->country = $country;
+    }
+
+    public function getCountry(): ?Country
+    {
+        return $this->country;
+    }
+
+    public function setCountry(Country $country): void
+    {
+        $this->country = $country;
+    }
+
+    public function getParents(): array
+    {
+        $parents = [];
+
+        $parents[] = $country = $this->getCountry();
+        if ($country) {
+            $parents = array_merge($parents, $country->getParents());
+        }
+
+        return $this->sanitizeEntityList($parents);
+    }
+}


### PR DESCRIPTION
This PR create basis entities for new zone engine.

Tables:

- `geo_country`
- `geo_region`
- `geo_department`
- `geo_canton`
- `geo_district`
- `geo_city_community`
- `geo_city`
    - `geo_city_canton`

Relations are declared in acendenting way, because:

- Populating will run in descending: country, then region, and so on
- Flat zones will be catched from the zone node to its parents, and so on