### PR TITLE
Update SF from 3.4.41 to 3.4.42

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9080,7 +9080,7 @@
         },
         {
             "name": "symfony/asset",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/asset.git",
@@ -9150,16 +9150,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "1c139918b4e93aac8a1afc7785e106c2456c57cc"
+                "reference": "42bd2c563c94eeda0639074e91774505ea557cce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/1c139918b4e93aac8a1afc7785e106c2456c57cc",
-                "reference": "1c139918b4e93aac8a1afc7785e106c2456c57cc",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/42bd2c563c94eeda0639074e91774505ea557cce",
+                "reference": "42bd2c563c94eeda0639074e91774505ea557cce",
                 "shasum": ""
             },
             "require": {
@@ -9230,11 +9230,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-28T07:55:04+00:00"
+            "time": "2020-06-09T14:07:03+00:00"
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -9304,7 +9304,7 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -9382,7 +9382,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -9539,7 +9539,7 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
@@ -9624,16 +9624,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "295d49aee7d85fb68bf572a50bf561040c5ef0bc"
+                "reference": "3617ccfc6dda3c782ce3044fb085e626dd72505b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/295d49aee7d85fb68bf572a50bf561040c5ef0bc",
-                "reference": "295d49aee7d85fb68bf572a50bf561040c5ef0bc",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/3617ccfc6dda3c782ce3044fb085e626dd72505b",
+                "reference": "3617ccfc6dda3c782ce3044fb085e626dd72505b",
                 "shasum": ""
             },
             "require": {
@@ -9715,7 +9715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-28T07:55:04+00:00"
+            "time": "2020-06-09T14:07:03+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -9790,7 +9790,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -9867,7 +9867,7 @@
         },
         {
             "name": "symfony/expression-language",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
@@ -9932,7 +9932,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -9996,7 +9996,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -10041,36 +10041,50 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
             "name": "symfony/flex",
-            "version": "v1.7.1",
+            "version": "v1.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "a53056880aae0ce034ac6c38906e162ee5cfd2df"
+                "reference": "7df5a72c7664baab629ec33de7890e9e3996b51b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/a53056880aae0ce034ac6c38906e162ee5cfd2df",
-                "reference": "a53056880aae0ce034ac6c38906e162ee5cfd2df",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/7df5a72c7664baab629ec33de7890e9e3996b51b",
+                "reference": "7df5a72c7664baab629ec33de7890e9e3996b51b",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
+                "composer-plugin-api": "^1.0|^2.0",
                 "php": ">=7.1"
             },
             "require-dev": {
-                "composer/composer": "^1.0.2",
+                "composer/composer": "^1.0.2|^2.0",
                 "symfony/dotenv": "^4.4|^5.0",
                 "symfony/phpunit-bridge": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0"
+                "symfony/process": "^3.4|^4.4|^5.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -10104,20 +10118,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-28T07:16:35+00:00"
+            "time": "2020-06-16T23:10:41+00:00"
         },
         {
             "name": "symfony/form",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "32ff2e4b864d55072ac09860fd7abca7a402d39f"
+                "reference": "b681a33764f39d3385850bc856d40f438a9cca59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/32ff2e4b864d55072ac09860fd7abca7a402d39f",
-                "reference": "32ff2e4b864d55072ac09860fd7abca7a402d39f",
+                "url": "https://api.github.com/repos/symfony/form/zipball/b681a33764f39d3385850bc856d40f438a9cca59",
+                "reference": "b681a33764f39d3385850bc856d40f438a9cca59",
                 "shasum": ""
             },
             "require": {
@@ -10142,11 +10156,12 @@
                 "symfony/config": "~2.7|~3.0|~4.0",
                 "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
                 "symfony/http-foundation": "~2.8|~3.0|~4.0",
                 "symfony/http-kernel": "^3.3.5|~4.0",
                 "symfony/security-csrf": "^2.8.31|^3.3.13|~4.0",
                 "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/validator": "^3.2.5|~4.0",
+                "symfony/validator": "^3.4.3|^4.0.3",
                 "symfony/var-dumper": "~3.3.11|~3.4|~4.0"
             },
             "suggest": {
@@ -10199,20 +10214,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T18:58:05+00:00"
+            "time": "2020-06-12T07:11:17+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "59cf8c9e8dfcc0761b99add811d7e02620983c71"
+                "reference": "c60957bbff5735490efe30399c5795a5d2415e98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/59cf8c9e8dfcc0761b99add811d7e02620983c71",
-                "reference": "59cf8c9e8dfcc0761b99add811d7e02620983c71",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/c60957bbff5735490efe30399c5795a5d2415e98",
+                "reference": "c60957bbff5735490efe30399c5795a5d2415e98",
                 "shasum": ""
             },
             "require": {
@@ -10328,7 +10343,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-24T15:32:05+00:00"
+            "time": "2020-06-04T10:40:01+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -10451,7 +10466,7 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
@@ -10519,16 +10534,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "e4e4ed6c008c983645b4eee6b67d8f258cde54df"
+                "reference": "6464a0475496040fe1f48428488d53e485be77a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e4e4ed6c008c983645b4eee6b67d8f258cde54df",
-                "reference": "e4e4ed6c008c983645b4eee6b67d8f258cde54df",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6464a0475496040fe1f48428488d53e485be77a0",
+                "reference": "6464a0475496040fe1f48428488d53e485be77a0",
                 "shasum": ""
             },
             "require": {
@@ -10619,11 +10634,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-31T05:14:17+00:00"
+            "time": "2020-06-12T10:57:07+00:00"
         },
         {
             "name": "symfony/inflector",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
@@ -10848,7 +10863,7 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
@@ -10992,7 +11007,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -11060,16 +11075,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd"
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/5e30b2799bc1ad68f7feb62b60a73743589438dd",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4a5b6bba3259902e386eb80dd1956181ee90b5b2",
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2",
                 "shasum": ""
             },
             "require": {
@@ -11079,6 +11094,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -11132,11 +11151,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -11199,7 +11218,7 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
@@ -11281,7 +11300,7 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
@@ -11371,7 +11390,7 @@
         },
         {
             "name": "symfony/proxy-manager-bridge",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/proxy-manager-bridge.git",
@@ -11504,7 +11523,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -11594,7 +11613,7 @@
         },
         {
             "name": "symfony/security",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
@@ -11752,7 +11771,7 @@
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
@@ -11852,7 +11871,7 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
@@ -12081,7 +12100,7 @@
         },
         {
             "name": "symfony/templating",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/templating.git",
@@ -12151,16 +12170,16 @@
         },
         {
             "name": "symfony/thanks",
-            "version": "v1.2.7",
+            "version": "v1.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/thanks.git",
-                "reference": "8bba4410e183ee72ddec1dbd73cf43f4a536485b"
+                "reference": "733cc7b8c09a06c9251bd35d772b453b47d98442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/thanks/zipball/8bba4410e183ee72ddec1dbd73cf43f4a536485b",
-                "reference": "8bba4410e183ee72ddec1dbd73cf43f4a536485b",
+                "url": "https://api.github.com/repos/symfony/thanks/zipball/733cc7b8c09a06c9251bd35d772b453b47d98442",
+                "reference": "733cc7b8c09a06c9251bd35d772b453b47d98442",
                 "shasum": ""
             },
             "require": {
@@ -12204,11 +12223,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T11:13:50+00:00"
+            "time": "2020-06-23T10:36:34+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -12292,7 +12311,7 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
@@ -12397,7 +12416,7 @@
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
@@ -12571,7 +12590,7 @@
         },
         {
             "name": "symfony/workflow",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/workflow.git",
@@ -12652,7 +12671,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -16249,7 +16268,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
@@ -16320,7 +16339,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -16387,7 +16406,7 @@
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
@@ -16509,16 +16528,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "f926812c6b3d456dfbd13c706293f49e9a10bc2a"
+                "reference": "ac355e1e9ebde4cf6ef5187f5cf4b43001f9a29f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/f926812c6b3d456dfbd13c706293f49e9a10bc2a",
-                "reference": "f926812c6b3d456dfbd13c706293f49e9a10bc2a",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/ac355e1e9ebde4cf6ef5187f5cf4b43001f9a29f",
+                "reference": "ac355e1e9ebde4cf6ef5187f5cf4b43001f9a29f",
                 "shasum": ""
             },
             "require": {
@@ -16584,7 +16603,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-21T18:33:26+00:00"
+            "time": "2020-06-04T15:36:03+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -16679,16 +16698,16 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "2f4566e22a67bbd33757265559da147a1738531b"
+                "reference": "41db5bcf33dce9b15bb1cdea3888cc392bddb3f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/2f4566e22a67bbd33757265559da147a1738531b",
-                "reference": "2f4566e22a67bbd33757265559da147a1738531b",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/41db5bcf33dce9b15bb1cdea3888cc392bddb3f1",
+                "reference": "41db5bcf33dce9b15bb1cdea3888cc392bddb3f1",
                 "shasum": ""
             },
             "require": {
@@ -16757,7 +16776,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-04T13:18:19+00:00"
+            "time": "2020-06-09T08:25:18+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
```
❯ dc exec app entrypoint.sh composer update "symfony/*"
Loading composer repositories with package information
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "3.4.*"
Package operations: 0 installs, 40 updates, 0 removals
  - Updating symfony/flex (v1.7.1 => v1.8.4): As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
Installing 'unzip' may remediate them.
Loading from cache
  - Updating symfony/thanks (v1.2.7 => v1.2.9): Loading from cache
  - Updating symfony/asset (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/doctrine-bridge (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/cache (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/expression-language (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/http-foundation (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/event-dispatcher (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/polyfill-php80 (v1.17.0 => v1.17.1): Loading from cache
  - Updating symfony/http-kernel (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/monolog-bridge (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/inflector (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/property-info (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/dependency-injection (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/proxy-manager-bridge (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/property-access (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/security (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/filesystem (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/config (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/security-bundle (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/serializer (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/templating (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/translation (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/workflow (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/yaml (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/twig-bridge (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/debug-bundle (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/phpunit-bridge (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/twig-bundle (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/routing (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/web-profiler-bundle (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/options-resolver (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/form (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/finder (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/class-loader (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/framework-bundle (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/console (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/css-selector (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/browser-kit (v3.4.41 => v3.4.42): Loading from cache
  - Updating symfony/process (v3.4.41 => v3.4.42): Loading from cache
Package algolia/algolia-search-bundle is abandoned, you should avoid using it. Use algolia/search-bundle instead.
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package egeloen/http-adapter is abandoned, you should avoid using it. Use php-http/httplug instead.
Package http-interop/http-factory is abandoned, you should avoid using it. Use psr/http-factory instead.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Package syslogic/doctrine-json-functions is abandoned, you should avoid using it. Use scienta/doctrine-json-functions instead.
Package zendframework/zend-code is abandoned, you should avoid using it. Use laminas/laminas-code instead.
Package zendframework/zend-diactoros is abandoned, you should avoid using it. Use laminas/laminas-diactoros instead.
Package zendframework/zend-eventmanager is abandoned, you should avoid using it. Use laminas/laminas-eventmanager instead.
Writing lock file
Generating autoload files
45 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Endroid Installer was disabled

What about running composer thanks now?
This will spread some 💖  by sending a ★  to 261 GitHub repositories of your fellow package maintainers.
You can also run composer fund to discover how you can sponsor their work with some 💵

ocramius/package-versions:  Generating version class...
ocramius/package-versions: ...done generating version class
> Fuz\Symfony\Collection\ScriptHandler::postUpdate
*** ninsuo/symfony-collection: Installing Twig form theme... 	Directory '/app/vendor/../app/Resources/views' doesn't exist.
SUCCESS: You can now use {% form_theme form 'jquery.collection.html.twig' %}
*** ninsuo/symfony-collection: Installing jQuery plugin... 	Directory '/app/vendor/../web' doesn't exist.
SUCCESS: You can now use <script type="text/javascript" src={{ asset('js/jquery.collection.js') }} />
Executing script cache:clear [OK]
Executing script assets:install public [OK]
Executing script security-checker security:check [OK]

```