### PR TITLE
Add FDE level as an entity in the new geo mapping

### DIFF
--- a/migrations/Version20201013145634.php
+++ b/migrations/Version20201013145634.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20201013145634 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE geo_custom_zone (
+          id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+          code VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          active TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          updated_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_ABE4DB5A77153098 (code),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE geo_foreign_district ADD custom_zone_id INT UNSIGNED');
+        $this->addSql('ALTER TABLE
+          geo_foreign_district
+        ADD
+          CONSTRAINT FK_973BE1F198755666 FOREIGN KEY (custom_zone_id) REFERENCES geo_custom_zone (id)');
+        $this->addSql('CREATE INDEX IDX_973BE1F198755666 ON geo_foreign_district (custom_zone_id)');
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        $this->connection->insert('geo_custom_zone', [
+            'code' => 'FDE',
+            'name' => "Français de l'Étranger",
+            'active' => true,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->update('geo_foreign_district', [
+            'custom_zone_id' => $this->connection->lastInsertId(),
+        ], [true]);
+
+        $this->connection->executeQuery('ALTER TABLE geo_foreign_district CHANGE custom_zone_id custom_zone_id INT UNSIGNED NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE geo_foreign_district DROP FOREIGN KEY FK_973BE1F198755666');
+        $this->addSql('DROP TABLE geo_custom_zone');
+        $this->addSql('DROP INDEX IDX_973BE1F198755666 ON geo_foreign_district');
+        $this->addSql('ALTER TABLE geo_foreign_district DROP custom_zone_id');
+    }
+}

--- a/src/Command/Geo/SyncZonesCommand.php
+++ b/src/Command/Geo/SyncZonesCommand.php
@@ -10,6 +10,7 @@ use App\Entity\Geo\City;
 use App\Entity\Geo\CityCommunity;
 use App\Entity\Geo\ConsularDistrict;
 use App\Entity\Geo\Country;
+use App\Entity\Geo\CustomZone;
 use App\Entity\Geo\Department;
 use App\Entity\Geo\District;
 use App\Entity\Geo\ForeignDistrict;
@@ -37,6 +38,7 @@ final class SyncZonesCommand extends Command
         CityCommunity::class,
         City::class,
         Borough::class,
+        CustomZone::class,
         ForeignDistrict::class,
         ConsularDistrict::class,
     ];

--- a/src/Entity/Geo/Country.php
+++ b/src/Entity/Geo/Country.php
@@ -39,7 +39,12 @@ class Country implements ZoneableInterface
 
     public function getParents(): array
     {
-        return $this->foreignDistrict ? [$this->foreignDistrict] : [];
+        $toMerge = [
+            [$this->foreignDistrict],
+            $this->foreignDistrict->getParents(),
+        ];
+
+        return array_values(array_unique(array_merge(...$toMerge)));
     }
 
     public function getZoneType(): string

--- a/src/Entity/Geo/CustomZone.php
+++ b/src/Entity/Geo/CustomZone.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Entity\Geo;
+
+use App\Entity\EntityTimestampableTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(readOnly=true)
+ * @ORM\Table(name="geo_custom_zone")
+ */
+class CustomZone implements ZoneableInterface
+{
+    use GeoTrait;
+    use EntityTimestampableTrait;
+
+    public function getParents(): array
+    {
+        return [];
+    }
+
+    public function getZoneType(): string
+    {
+        return Zone::CUSTOM;
+    }
+}

--- a/src/Entity/Geo/ForeignDistrict.php
+++ b/src/Entity/Geo/ForeignDistrict.php
@@ -24,17 +24,26 @@ class ForeignDistrict implements ZoneableInterface
     private $number;
 
     /**
+     * @var CustomZone
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\CustomZone")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $customZone;
+
+    /**
      * @var Collection|Country[]
      *
      * @ORM\OneToMany(targetEntity="App\Entity\Geo\Country", mappedBy="foreignDistrict")
      */
     private $countries;
 
-    public function __construct(string $code, string $name, int $number)
+    public function __construct(string $code, string $name, int $number, CustomZone $customZone)
     {
         $this->code = $code;
         $this->name = $name;
         $this->number = $number;
+        $this->customZone = $customZone;
         $this->countries = new ArrayCollection();
     }
 
@@ -63,7 +72,12 @@ class ForeignDistrict implements ZoneableInterface
 
     public function getParents(): array
     {
-        return [];
+        $toMerge = [
+            [$this->customZone],
+            $this->customZone->getParents(),
+        ];
+
+        return array_values(array_unique(array_merge(...$toMerge)));
     }
 
     public function getZoneType(): string

--- a/src/Entity/Geo/Zone.php
+++ b/src/Entity/Geo/Zone.php
@@ -24,6 +24,7 @@ class Zone implements GeoInterface
     use GeoTrait;
     use EntityTimestampableTrait;
 
+    public const CUSTOM = 'custom';
     public const COUNTRY = 'country';
     public const REGION = 'region';
     public const DEPARTMENT = 'department';


### PR DESCRIPTION
The "Abroad" level is the parent of "Foreign Districts", therefore "Consular Districts" and "Countries".

This change allows us to group these levels into the FDE one as "Zones" entities.