### PR TITLE
Fix getParents() in Country

### DIFF
--- a/src/Entity/Geo/Country.php
+++ b/src/Entity/Geo/Country.php
@@ -39,12 +39,14 @@ class Country implements ZoneableInterface
 
     public function getParents(): array
     {
-        $toMerge = [
-            [$this->foreignDistrict],
-            $this->foreignDistrict->getParents(),
-        ];
+        $toMerge = [];
 
-        return array_values(array_unique(array_merge(...$toMerge)));
+        if ($this->foreignDistrict) {
+            $toMerge[] = [$this->foreignDistrict];
+            $toMerge[] = $this->foreignDistrict->getParents();
+        }
+
+        return $toMerge ? array_values(array_unique(array_merge(...$toMerge))) : [];
     }
 
     public function getZoneType(): string


### PR DESCRIPTION
The foreign district is not always present, so `getParents()` is broken.

This PR fixes it.