### PR TITLE
Introduce geo zone into mandate entity

### DIFF
--- a/migrations/Version20201014175014.php
+++ b/migrations/Version20201014175014.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20201014175014 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE elected_representative_mandate ADD geo_zone_id INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE
+          elected_representative_mandate
+        ADD
+          CONSTRAINT FK_38609146283AB2A9 FOREIGN KEY (geo_zone_id) REFERENCES geo_zone (id)');
+        $this->addSql('CREATE INDEX IDX_38609146283AB2A9 ON elected_representative_mandate (geo_zone_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE elected_representative_mandate DROP FOREIGN KEY FK_38609146283AB2A9');
+        $this->addSql('DROP INDEX IDX_38609146283AB2A9 ON elected_representative_mandate');
+        $this->addSql('ALTER TABLE elected_representative_mandate DROP geo_zone_id');
+    }
+}

--- a/src/Entity/ElectedRepresentative/Mandate.php
+++ b/src/Entity/ElectedRepresentative/Mandate.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity\ElectedRepresentative;
 
+use App\Entity\Geo\Zone as GeoZone;
 use App\Exception\BadMandateTypeException;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -49,8 +50,17 @@ class Mandate
      *     "value !== null or (value == null and this.getType() === constant('App\\Entity\\ElectedRepresentative\\MandateTypeEnum::EURO_DEPUTY'))",
      *     message="Le périmètre géographique est obligatoire."
      * )
+     *
+     * @deprecated Will be replace by $geoZone
      */
     private $zone;
+
+    /**
+     * @var GeoZone|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Zone")
+     */
+    private $geoZone;
 
     /**
      * @var bool
@@ -194,14 +204,30 @@ class Mandate
         $this->isElected = $isElected;
     }
 
+    /**
+     * @deprecated Will be replace by getGeoZone()
+     */
     public function getZone(): ?Zone
     {
         return $this->zone;
     }
 
+    /**
+     * @deprecated Will be replace by setGeoZone()
+     */
     public function setZone(Zone $zone): void
     {
         $this->zone = $zone;
+    }
+
+    public function getGeoZone(): ?GeoZone
+    {
+        return $this->geoZone;
+    }
+
+    public function setGeoZone(GeoZone $geoZone): void
+    {
+        $this->geoZone = $geoZone;
     }
 
     public function isOnGoing(): bool


### PR DESCRIPTION
Geo zones will migrate to a new schema.

This PR allows us to keep both relationships in the `Mandate` entity.

- `zone` already exists and will remain until the complete migration
- `geoZone` points to the new mapping

Once this PR is merged:

1. we can populate the new field with the new corresponding id, then
2. make a new PR to turn the new field as `NOT NULL`