### PR TITLE
Update relationship between zone and referent tag

### DIFF
--- a/migrations/Version20201026115711.php
+++ b/migrations/Version20201026115711.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20201026115711 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE referent_tags ADD zone_id INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE
+          referent_tags
+        ADD
+          CONSTRAINT FK_135D29D99F2C3FAB FOREIGN KEY (zone_id) REFERENCES geo_zone (id)');
+        $this->addSql('CREATE INDEX IDX_135D29D99F2C3FAB ON referent_tags (zone_id)');
+        $this->addSql('ALTER TABLE geo_zone DROP FOREIGN KEY FK_A4CCEF079C262DB3');
+        $this->addSql('DROP INDEX IDX_A4CCEF079C262DB3 ON geo_zone');
+        $this->addSql('ALTER TABLE geo_zone DROP referent_tag_id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE geo_zone ADD referent_tag_id INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE
+          geo_zone
+        ADD
+          CONSTRAINT FK_A4CCEF079C262DB3 FOREIGN KEY (referent_tag_id) REFERENCES referent_tags (id) ON DELETE
+        SET
+          NULL');
+        $this->addSql('CREATE INDEX IDX_A4CCEF079C262DB3 ON geo_zone (referent_tag_id)');
+        $this->addSql('ALTER TABLE referent_tags DROP FOREIGN KEY FK_135D29D99F2C3FAB');
+        $this->addSql('DROP INDEX IDX_135D29D99F2C3FAB ON referent_tags');
+        $this->addSql('ALTER TABLE referent_tags DROP zone_id');
+    }
+}

--- a/src/Entity/Geo/Zone.php
+++ b/src/Entity/Geo/Zone.php
@@ -63,14 +63,6 @@ class Zone implements GeoInterface
      */
     private $children;
 
-    /**
-     * @var ReferentTag|null
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\ReferentTag")
-     * @ORM\JoinColumn(onDelete="SET NULL")
-     */
-    private $referentTag;
-
     public function __construct(string $type, string $code, string $name, ReferentTag $referentTag = null)
     {
         $this->type = $type;
@@ -105,15 +97,5 @@ class Zone implements GeoInterface
     public function getChildren(): array
     {
         return $this->children->toArray();
-    }
-
-    public function getReferentTag(): ?ReferentTag
-    {
-        return $this->referentTag;
-    }
-
-    public function setReferentTag(?ReferentTag $referentTag): void
-    {
-        $this->referentTag = $referentTag;
     }
 }

--- a/src/Entity/ReferentTag.php
+++ b/src/Entity/ReferentTag.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Entity\Geo\Zone;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMSSerializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @UniqueEntity("name")
  * @UniqueEntity("code")
+ *
+ * @deprecated
  */
 class ReferentTag
 {
@@ -79,6 +82,13 @@ class ReferentTag
      * @SymfonySerializer\Groups({"read_api"})
      */
     private $type;
+
+    /**
+     * @var Zone
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Zone")
+     */
+    private $zone;
 
     public function __construct(string $name = null, string $code = null)
     {
@@ -164,5 +174,10 @@ class ReferentTag
     public function getDepartmentCodeFromCirconscriptionName(): ?string
     {
         return $this->isDistrictTag() ? \substr($this->code, 6, 2) : null;
+    }
+
+    public function getZone(): Zone
+    {
+        return $this->zone;
     }
 }

--- a/src/Repository/ReferentTagRepository.php
+++ b/src/Repository/ReferentTagRepository.php
@@ -2,11 +2,15 @@
 
 namespace App\Repository;
 
+use App\Entity\Geo\Zone;
 use App\Entity\ReferentTag;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
+/**
+ * @deprecated
+ */
 class ReferentTagRepository extends ServiceEntityRepository
 {
     public const FRENCH_OUTSIDE_FRANCE_TAG = 'FOF';
@@ -24,6 +28,18 @@ class ReferentTagRepository extends ServiceEntityRepository
     public function findByCodes(array $codes): array
     {
         return $this->findBy(['code' => $codes]);
+    }
+
+    /**
+     * @param Zone[] $zones
+     */
+    public function findByZones(array $zones): array
+    {
+        if (!$zones) {
+            return [];
+        }
+
+        return $this->findBy(['zone' => $zones]);
     }
 
     public function findByPartialName(string $name, int $limit, int $offset): array


### PR DESCRIPTION
Change the relation between  Zone and ReferentTag from `ManyToOne` to unidirectional `OneToOne`.

Changes:
- Remove ReferentTag reference in Zone entity
- Create a `OneToOne` reference to Zone in ReferentTag entity
    - Zone entity is intentionally not aware of its relationship with ReferentTag
- Mark ReferentTag as its repository as deprecated

As consequence, when migrating from ReferentTag to Zone there will be at least one more query to execute, e.g. `TerritorialCouncilRepository::findByMandates()`

---

Note that we need to fill up the new `referent_tags.zone_id` field once it gets deployed.