### PR TITLE
Use geo zones to display elected in referent page

### DIFF
--- a/migrations/Version20201023160621.php
+++ b/migrations/Version20201023160621.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20201023160621 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE referent_managed_area_zone (
+          referent_managed_area_id INT NOT NULL,
+          zone_id INT UNSIGNED NOT NULL,
+          INDEX IDX_B3A7E3746B99CC25 (referent_managed_area_id),
+          INDEX IDX_B3A7E3749F2C3FAB (zone_id),
+          PRIMARY KEY(
+            referent_managed_area_id, zone_id
+          )
+        ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE
+          referent_managed_area_zone
+        ADD
+          CONSTRAINT FK_B3A7E3746B99CC25 FOREIGN KEY (referent_managed_area_id) REFERENCES referent_managed_areas (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE
+          referent_managed_area_zone
+        ADD
+          CONSTRAINT FK_B3A7E3749F2C3FAB FOREIGN KEY (zone_id) REFERENCES geo_zone (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE referent_managed_area_zone');
+    }
+}

--- a/src/Entity/EntityReferentTagTrait.php
+++ b/src/Entity/EntityReferentTagTrait.php
@@ -6,6 +6,9 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 
+/**
+ * @deprecated
+ */
 trait EntityReferentTagTrait
 {
     /**
@@ -25,6 +28,11 @@ trait EntityReferentTagTrait
 
     public function addReferentTag(ReferentTag $referentTag): void
     {
+        // Tries to keep zone synchronised with referent tag (both will coexist during the migration)
+        if (method_exists($this, 'addZone')) {
+            $this->addZone($referentTag->getZone());
+        }
+
         if (!$this->referentTags->contains($referentTag)) {
             $this->referentTags->add($referentTag);
         }
@@ -32,11 +40,21 @@ trait EntityReferentTagTrait
 
     public function removeReferentTag(ReferentTag $referentTag): void
     {
+        // Tries to keep zone synchronised with referent tag (both will coexist during the migration)
+        if (method_exists($this, 'removeZone')) {
+            $this->removeZone($referentTag->getZone());
+        }
+
         $this->referentTags->remove($referentTag);
     }
 
     public function clearReferentTags(): void
     {
+        // Tries to keep zone synchronised with referent tag (both will coexist during the migration)
+        if (method_exists($this, 'clearZones')) {
+            $this->clearZones();
+        }
+
         $this->referentTags->clear();
     }
 

--- a/src/Entity/EntityZoneTrait.php
+++ b/src/Entity/EntityZoneTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Geo\Zone;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+trait EntityZoneTrait
+{
+    /**
+     * @var Collection|Zone[]
+     *
+     * @ORM\ManyToMany(targetEntity="App\Entity\Geo\Zone")
+     */
+    protected $zones;
+
+    /**
+     * @return Collection|Zone[]
+     */
+    public function getZones(): Collection
+    {
+        return $this->zones;
+    }
+
+    public function addZone(Zone $Zone): void
+    {
+        if (!$this->zones->contains($Zone)) {
+            $this->zones->add($Zone);
+        }
+    }
+
+    public function removeZone(Zone $Zone): void
+    {
+        $this->zones->remove($Zone);
+    }
+
+    public function clearZones(): void
+    {
+        $this->zones->clear();
+    }
+}

--- a/src/Entity/ReferentTag.php
+++ b/src/Entity/ReferentTag.php
@@ -185,4 +185,9 @@ class ReferentTag
     {
         return $this->zone;
     }
+
+    public function setZone(Zone $zone): void
+    {
+        $this->zone = $zone;
+    }
 }

--- a/src/Form/AbstractConnectedUserFormType.php
+++ b/src/Form/AbstractConnectedUserFormType.php
@@ -36,6 +36,9 @@ abstract class AbstractConnectedUserFormType extends AbstractType
         return $user;
     }
 
+    /**
+     * @deprecated
+     */
     protected function getReferentTags(): array
     {
         if (!$user = $this->getUser()) {

--- a/src/Form/ManagedUsers/ManagedUsersFilterType.php
+++ b/src/Form/ManagedUsers/ManagedUsersFilterType.php
@@ -2,13 +2,13 @@
 
 namespace App\Form\ManagedUsers;
 
-use App\Entity\ReferentTag;
+use App\Entity\Geo\Zone;
 use App\Form\DatePickerType;
 use App\Form\EventListener\IncludeExcludeFilterRoleListener;
 use App\Form\FilterRoleType;
 use App\Form\GenderType;
 use App\Form\MemberInterestsChoiceType;
-use App\Form\MyReferentTagChoiceType;
+use App\Form\MyZoneChoiceType;
 use App\ManagedUsers\ManagedUsersFilter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -77,13 +77,13 @@ class ManagedUsersFilterType extends AbstractType
         ;
 
         if (false === $options['single_zone']) {
-            $builder->add('referentTags', MyReferentTagChoiceType::class, [
+            $builder->add('zones', MyZoneChoiceType::class, [
                 'placeholder' => 'Tous',
                 'required' => false,
                 'by_reference' => false,
             ]);
 
-            $referentTagsField = $builder->get('referentTags');
+            $referentTagsField = $builder->get('zones');
 
             $referentTagsField->addModelTransformer(new CallbackTransformer(
                 static function ($value) use ($referentTagsField) {
@@ -98,7 +98,7 @@ class ManagedUsersFilterType extends AbstractType
                         return  $referentTagsField->getOption('choices');
                     }
 
-                    if ($value instanceof ReferentTag) {
+                    if ($value instanceof Zone) {
                         return [$value];
                     }
 

--- a/src/Form/MyZoneChoiceType.php
+++ b/src/Form/MyZoneChoiceType.php
@@ -6,15 +6,12 @@ use App\Entity\ReferentTag;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-/**
- * @deprecated
- */
-class MyReferentTagChoiceType extends AbstractConnectedUserFormType
+class MyZoneChoiceType extends AbstractConnectedUserFormType
 {
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'choices' => $this->getReferentTags(),
+            'choices' => $this->getZones(),
             'class' => ReferentTag::class,
             'choice_label' => 'name',
         ]);
@@ -23,5 +20,22 @@ class MyReferentTagChoiceType extends AbstractConnectedUserFormType
     public function getParent()
     {
         return EntityType::class;
+    }
+
+    private function getZones(): array
+    {
+        if (!$user = $this->getUser()) {
+            return [];
+        }
+
+        if (!$user->isReferent()) {
+            return [];
+        }
+
+        if (!$managedArea = $user->getManagedArea()) {
+            return [];
+        }
+
+        return $managedArea->getZones()->toArray();
     }
 }

--- a/src/ManagedUsers/ManagedUsersFilter.php
+++ b/src/ManagedUsers/ManagedUsersFilter.php
@@ -3,6 +3,7 @@
 namespace App\ManagedUsers;
 
 use App\Entity\Committee;
+use App\Entity\Geo\Zone;
 use App\Entity\ReferentTag;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -88,11 +89,20 @@ class ManagedUsersFilter
     private $includeCitizenProjectHosts;
 
     /**
+     * @deprecated
+     *
      * @var ReferentTag[]
      *
      * @Assert\NotNull
      */
     private $referentTags;
+
+    /**
+     * @var Zone[]
+     *
+     * @Assert\NotNull
+     */
+    private $zones;
 
     /**
      * @var bool|null
@@ -151,9 +161,14 @@ class ManagedUsersFilter
         }
 
         $this->subscriptionType = $subscriptionType;
-        $this->referentTags = $referentTags;
+        $this->referentTags = [];
+        $this->zones = [];
         $this->committeeUuids = $committeeUuids;
         $this->cities = $cities;
+
+        foreach ($referentTags as $referentTag) {
+            $this->addReferentTag($referentTag);
+        }
     }
 
     public function getGender(): ?string
@@ -302,6 +317,8 @@ class ManagedUsersFilter
     }
 
     /**
+     * @deprecated
+     *
      * @return ReferentTag[]
      */
     public function getReferentTags(): array
@@ -309,11 +326,19 @@ class ManagedUsersFilter
         return $this->referentTags;
     }
 
+    /**
+     * @deprecated
+     */
     public function addReferentTag(ReferentTag $referentTag): void
     {
+        $this->addZone($referentTag->getZone());
+
         $this->referentTags[] = $referentTag;
     }
 
+    /**
+     * @deprecated
+     */
     public function removeReferentTag(ReferentTag $referentTag): void
     {
         foreach ($this->referentTags as $key => $tag) {
@@ -323,6 +348,30 @@ class ManagedUsersFilter
         }
 
         $this->referentTags = array_values($this->referentTags);
+    }
+
+    /**
+     * @return Zone[]
+     */
+    public function getZones(): array
+    {
+        return $this->zones;
+    }
+
+    public function addZone(Zone $zone): void
+    {
+        $this->zones[] = $zone;
+    }
+
+    public function removeZone(Zone $zone): void
+    {
+        foreach ($this->zones as $key => $value) {
+            if ($value->getId() === $zone->getId()) {
+                unset($this->zones[$key]);
+            }
+        }
+
+        $this->zones = array_values($this->zones);
     }
 
     public function getEmailSubscription(): ?bool

--- a/src/Repository/Geo/ZoneRepository.php
+++ b/src/Repository/Geo/ZoneRepository.php
@@ -2,15 +2,6 @@
 
 namespace App\Repository\Geo;
 
-use App\Entity\Geo\Canton;
-use App\Entity\Geo\City;
-use App\Entity\Geo\CityCommunity;
-use App\Entity\Geo\ConsularDistrict;
-use App\Entity\Geo\Country;
-use App\Entity\Geo\Department;
-use App\Entity\Geo\District;
-use App\Entity\Geo\ForeignDistrict;
-use App\Entity\Geo\Region;
 use App\Entity\Geo\Zone;
 use App\Entity\Geo\ZoneableInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -18,18 +9,6 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 
 final class ZoneRepository extends ServiceEntityRepository
 {
-    private const TYPES = [
-        Country::class => Zone::COUNTRY,
-        Region::class => Zone::REGION,
-        Department::class => Zone::DEPARTMENT,
-        District::class => Zone::DISTRICT,
-        Canton::class => Zone::CANTON,
-        CityCommunity::class => Zone::CITY_COMMUNITY,
-        City::class => Zone::CITY,
-        ForeignDistrict::class => Zone::FOREIGN_DISTRICT,
-        ConsularDistrict::class => Zone::CONSULAR_DISTRICT,
-    ];
-
     public function __construct(RegistryInterface $registry)
     {
         parent::__construct($registry, Zone::class);

--- a/templates/managed_users/filter_form.html.twig
+++ b/templates/managed_users/filter_form.html.twig
@@ -9,11 +9,11 @@
         <div class="manager__filters__row">
             <div class="manager__filters__section">
                 <div class="manager__filters__group">
-                    {% if form.referentTags is defined %}
+                    {% if form.zones is defined %}
                         <div class="filter__row">
                             <label class="filter__label">Zones gérées</label>
-                            {{ form_widget(form.referentTags, {attr: {class: 'filter__field'}}) }}
-                            {{ form_errors(form.referentTags) }}
+                            {{ form_widget(form.zones, {attr: {class: 'filter__field'}}) }}
+                            {{ form_errors(form.zones) }}
                         </div>
                     {% endif %}
 


### PR DESCRIPTION
- [x] Merge #4948
- [x] Build `ReferentTag` fixtures from `Geo\ Zone` to mimic production behavior (each tag points to a zone)
- [x] Update `EntityReferentTagTrait` syncing entities to geo zone when referent tag is changed
- [x] Replace `MyReferentTagChoiceType` (marked as deprecated) with `MyZoneChoiceType` in `ManagedUsersFilterType`
- [ ] Update fixtures, make sure each `ReferentTag` points to a `Geo\Zone`
- [ ] Update `\App\Repository\ElectedRepresentative\ElectedRepresentativeRepository::createFilterQueryBuilder()`
- [ ] Replace `$referentTags` with `$zones` in App\ElectedRepresentative\Filter\ListFilter
- [ ] Replace `getManagedTags()` with `getZones()` in `App\Controller\EnMarche\ElectedRepresentative\ReferentElectedRepresentativeController`