### PR TITLE
Inject mocked zone in mocked referent tags

### DIFF
--- a/src/Entity/Geo/Zone.php
+++ b/src/Entity/Geo/Zone.php
@@ -3,7 +3,6 @@
 namespace App\Entity\Geo;
 
 use App\Entity\EntityTimestampableTrait;
-use App\Entity\ReferentTag;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -63,12 +62,11 @@ class Zone implements GeoInterface
      */
     private $children;
 
-    public function __construct(string $type, string $code, string $name, ReferentTag $referentTag = null)
+    public function __construct(string $type, string $code, string $name)
     {
         $this->type = $type;
         $this->code = $code;
         $this->name = $name;
-        $this->referentTag = $referentTag;
         $this->parents = new ArrayCollection();
         $this->children = new ArrayCollection();
     }

--- a/src/Entity/ReferentTag.php
+++ b/src/Entity/ReferentTag.php
@@ -90,10 +90,11 @@ class ReferentTag
      */
     private $zone;
 
-    public function __construct(string $name = null, string $code = null)
+    public function __construct(string $name = null, string $code = null, Zone $zone = null)
     {
         $this->name = $name;
         $this->code = $code;
+        $this->zone = $zone;
     }
 
     public function __toString(): string

--- a/tests/AdherentMessage/Handler/AdherentMessageChangeCommandHandlerTest.php
+++ b/tests/AdherentMessage/Handler/AdherentMessageChangeCommandHandlerTest.php
@@ -24,6 +24,7 @@ use App\Entity\AdherentMessage\SenatorAdherentMessage;
 use App\Entity\CitizenProject;
 use App\Entity\Committee;
 use App\Entity\District;
+use App\Entity\Geo\Zone;
 use App\Entity\MunicipalChiefManagedArea;
 use App\Entity\ReferentTag;
 use App\Mailchimp\Campaign\CampaignContentRequestBuilder;
@@ -140,8 +141,8 @@ class AdherentMessageChangeCommandHandlerTest extends TestCase
         $message = $this->preparedMessage(ReferentAdherentMessage::class);
 
         $message->setFilter($filter = new ReferentUserFilter([
-            $tag1 = new ReferentTag('Tag1', 'code1'),
-            $tag2 = new ReferentTag('Tag2', 'code2'),
+            $tag1 = new ReferentTag('Tag1', 'code1', new Zone('mock', 'code1', 'Tag1')),
+            $tag2 = new ReferentTag('Tag2', 'code2', new Zone('mock', 'code1', 'Tag2')),
         ]));
         $tag1->setExternalId(123);
         $tag2->setExternalId(456);
@@ -265,7 +266,7 @@ class AdherentMessageChangeCommandHandlerTest extends TestCase
     public function testDeputyMessageGeneratesGoodPayloads(): void
     {
         $message = $this->preparedMessage(DeputyAdherentMessage::class);
-        $message->setFilter($filter = new AdherentZoneFilter($tag = new ReferentTag('Tag1', 'code1')));
+        $message->setFilter($filter = new AdherentZoneFilter($tag = new ReferentTag('Tag1', 'code1', new Zone('mock', 'code1', 'Tag1'))));
         $tag->setExternalId(123);
 
         (new AdherentZoneMailchimpCampaignHandler())->handle($message);
@@ -334,7 +335,7 @@ class AdherentMessageChangeCommandHandlerTest extends TestCase
     public function testSenatorMessageGeneratesGoodPayloads(): void
     {
         $message = $this->preparedMessage(SenatorAdherentMessage::class);
-        $filter = new AdherentZoneFilter($tag = new ReferentTag('Tag1', 'code1')); // 5 and 6 are included by default
+        $filter = new AdherentZoneFilter($tag = new ReferentTag('Tag1', 'code1', new Zone('mock', 'code1', 'Tag1'))); // 5 and 6 are included by default
         $filter->setIncludeCitizenProjectHosts(false); // exclude 2
         $filter->setIncludeCommitteeSupervisors(false); // exclude 3
         $filter->setIncludeCommitteeHosts(true); // include 4

--- a/tests/Deputy/Subscriber/BindAdherentDistrictSubscriberTest.php
+++ b/tests/Deputy/Subscriber/BindAdherentDistrictSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Tests\App\Deputy\Subscriber;
 use App\Deputy\Subscriber\BindAdherentDistrictSubscriber;
 use App\Entity\Adherent;
 use App\Entity\District;
+use App\Entity\Geo\Zone;
 use App\Entity\GeoData;
 use App\Entity\PostAddress;
 use App\Entity\ReferentTag;
@@ -85,8 +86,8 @@ class BindAdherentDistrictSubscriberTest extends TestCase
         /** @var GeoData $geoData */
         $geoData = $this->createMock(GeoData::class);
 
-        $tag1 = new ReferentTag('1ère circonscription, Paris', 'CIRCO_75001');
-        $tag2 = new ReferentTag('Alpes-Maritimes, 1ère circonscription (06-01)', 'CIRCO_06001');
+        $tag1 = new ReferentTag('1ère circonscription, Paris', 'CIRCO_75001', new Zone('district', 'CIRCO_75001', '1ère circonscription, Paris'));
+        $tag2 = new ReferentTag('Alpes-Maritimes, 1ère circonscription (06-01)', 'CIRCO_06001', new Zone('district', 'CIRCO_06001', 'Alpes-Maritimes, 1ère circonscription (06-01)'));
         $district1 = new District(
             ['FR'], 'Ain', '01001', 1, 01, $geoData, $tag1
         );

--- a/tests/Entity/AdherentTest.php
+++ b/tests/Entity/AdherentTest.php
@@ -8,6 +8,7 @@ use App\Entity\BoardMember\BoardMember;
 use App\Entity\CitizenProject;
 use App\Entity\CitizenProjectMembership;
 use App\Entity\CommitteeMembership;
+use App\Entity\Geo\Zone;
 use App\Entity\PostAddress;
 use App\Entity\ReferentTag;
 use App\Geocoder\Coordinates;
@@ -145,7 +146,7 @@ class AdherentTest extends TestCase
 
         // Referent
         $adherent = $this->createAdherent();
-        $adherent->setReferent([new ReferentTag('06')], -1.6743, 48.112);
+        $adherent->setReferent([new ReferentTag('06', null, new Zone('', '', '06'))], -1.6743, 48.112);
 
         $this->assertFalse($adherent->isBasicAdherent());
 

--- a/tests/RepublicanSilence/TagExtractor/ReferentTagExtractorTest.php
+++ b/tests/RepublicanSilence/TagExtractor/ReferentTagExtractorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\App\RepublicanSilence\TagExtractor;
 
 use App\Entity\Adherent;
+use App\Entity\Geo\Zone;
 use App\Entity\ReferentManagedArea;
 use App\Entity\ReferentTag;
 use App\RepublicanSilence\TagExtractor\ReferentTagExtractor;
@@ -16,8 +17,8 @@ class ReferentTagExtractorTest extends TestCase
 
         $adherentMock = $this->createConfiguredMock(Adherent::class, [
             'getManagedArea' => new ReferentManagedArea([
-                new ReferentTag(null, 'tag1'),
-                new ReferentTag(null, 'tag2'),
+                new ReferentTag(null, 'tag1', new Zone('mock', 'tag1', '')),
+                new ReferentTag(null, 'tag2', new Zone('mock', 'tag2', '')),
             ]),
         ]);
 

--- a/tests/Security/Voter/ManageUserListDefinitionElectedRepresentativeVoterTest.php
+++ b/tests/Security/Voter/ManageUserListDefinitionElectedRepresentativeVoterTest.php
@@ -4,6 +4,7 @@ namespace Tests\App\Security\Voter;
 
 use App\Entity\Adherent;
 use App\Entity\ElectedRepresentative\ElectedRepresentative;
+use App\Entity\Geo\Zone;
 use App\Entity\ReferentManagedArea;
 use App\Entity\ReferentTag;
 use App\Repository\ElectedRepresentative\ElectedRepresentativeRepository;
@@ -70,7 +71,7 @@ class ManageUserListDefinitionElectedRepresentativeVoterTest extends AbstractAdh
 
     public function testAdherentIsNotGrantedIfNotInReferentArea()
     {
-        $tags = [new ReferentTag()];
+        $tags = [new ReferentTag(null, null, new Zone('', '', ''))];
         $adherent = $this->getAdherentMock(true, true, $tags);
         $electedRepresentative = $this->createMock(ElectedRepresentative::class);
 
@@ -91,7 +92,7 @@ class ManageUserListDefinitionElectedRepresentativeVoterTest extends AbstractAdh
 
     public function testAdherentIsGrantedIfReferent()
     {
-        $tags = [new ReferentTag()];
+        $tags = [new ReferentTag(null, null, new Zone('', '', ''))];
         $adherent = $this->getAdherentMock(true, true, $tags);
         $electedRepresentative = $this->createMock(ElectedRepresentative::class);
 


### PR DESCRIPTION
`ReferentTag` has a like-readonly relation with `Geo\Zone`, this PR fix tests that want to create mocked `ReferentTag` allowing injecting `Geo\Zone`.