### PR TITLE
Links deprecated zones to the new zones

### DIFF
--- a/migrations/Version20201028145944.php
+++ b/migrations/Version20201028145944.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20201028145944 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE elected_representative_zone ADD geo_zone_id INT UNSIGNED DEFAULT NULL');
+        $this->addSql('ALTER TABLE
+          elected_representative_zone
+        ADD
+          CONSTRAINT FK_C52FC4A7283AB2A9 FOREIGN KEY (geo_zone_id) REFERENCES geo_zone (id)');
+        $this->addSql('CREATE INDEX IDX_C52FC4A7283AB2A9 ON elected_representative_zone (geo_zone_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE elected_representative_zone DROP FOREIGN KEY FK_C52FC4A7283AB2A9');
+        $this->addSql('DROP INDEX IDX_C52FC4A7283AB2A9 ON elected_representative_zone');
+        $this->addSql('ALTER TABLE elected_representative_zone DROP geo_zone_id');
+    }
+}

--- a/src/Entity/ElectedRepresentative/Mandate.php
+++ b/src/Entity/ElectedRepresentative/Mandate.php
@@ -160,6 +160,7 @@ class Mandate
         $this->type = $type;
         $this->isElected = $isElected;
         $this->zone = $zone;
+        $this->geoZone = $zone ? $zone->getGeoZone() : null;
         $this->electedRepresentative = $electedRepresentative;
         $this->laREMSupport = $laREMSupport;
         $this->politicalAffiliation = $politicalAffiliation;
@@ -218,6 +219,7 @@ class Mandate
     public function setZone(Zone $zone): void
     {
         $this->zone = $zone;
+        $this->geoZone = $zone->getGeoZone();
     }
 
     public function getGeoZone(): ?GeoZone

--- a/src/Entity/ElectedRepresentative/Zone.php
+++ b/src/Entity/ElectedRepresentative/Zone.php
@@ -3,6 +3,7 @@
 namespace App\Entity\ElectedRepresentative;
 
 use App\Entity\EntityReferentTagTrait;
+use App\Entity\Geo\Zone as GeoZone;
 use App\Entity\ReferentTag;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -94,6 +95,13 @@ class Zone
      */
     private $children;
 
+    /**
+     * @var GeoZone|null
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Geo\Zone")
+     */
+    private $geoZone;
+
     public function __construct(ZoneCategory $category = null, string $name = null)
     {
         $this->category = $category;
@@ -158,5 +166,15 @@ class Zone
         if (!$this->children->contains($zone)) {
             $this->children->add($zone);
         }
+    }
+
+    public function setGeoZone(GeoZone $geoZone): void
+    {
+        $this->geoZone = $geoZone;
+    }
+
+    public function getGeoZone(): ?GeoZone
+    {
+        return $this->geoZone;
     }
 }


### PR DESCRIPTION
This PR allows smooth migration to the new zone table,
by creating a relation n-1 between `ElectedRepresentative\Zone` and `Geo\Zone`.

Every time an entity receives an old zone object, the new one becomes available instantly.