### PR TITLE
Allow to remove a relation parent/child in app:geo:sync-zones command

### DIFF
--- a/src/Command/Geo/SyncZonesCommand.php
+++ b/src/Command/Geo/SyncZonesCommand.php
@@ -155,6 +155,7 @@ final class SyncZonesCommand extends Command
         $zone = $this->zoneRepository->zoneableAsZone($zoneable);
         $this->entities->set($key, $zone);
 
+        $zone->clearParents();
         foreach ($zoneable->getParents() as $zoneableParent) {
             $zone->addParent($this->zoneableAsZone($zoneableParent));
         }


### PR DESCRIPTION
Fix `app:geo:sync-zones`, allow it to remove no more existing relation between two zones.