### PR TITLE
Fix filtering by zone

### DIFF
--- a/src/ElectedRepresentative/Filter/ListFilter.php
+++ b/src/ElectedRepresentative/Filter/ListFilter.php
@@ -191,7 +191,7 @@ class ListFilter
     /**
      * @return Zone[]
      */
-    public function getManagesZones(): array
+    public function getManagedZones(): array
     {
         return $this->managedZones;
     }

--- a/src/Repository/ElectedRepresentative/ElectedRepresentativeRepository.php
+++ b/src/Repository/ElectedRepresentative/ElectedRepresentativeRepository.php
@@ -109,8 +109,12 @@ class ElectedRepresentativeRepository extends ServiceEntityRepository
 
         $this->withActiveMandatesCondition($qb);
 
-        if ($filter->getManagesZones()) {
-            $this->withZoneCondition($qb, $filter->getManagesZones());
+        $zones = $filter->getZones() ?: $filter->getManagedZones();
+        if ($zones) {
+            $this->withZoneCondition($qb, $zones);
+        }
+
+        if ($filter->getManagedZones()) {
             $qb
                 ->orderBy('er.'.$filter->getSort(), 'd' === $filter->getOrder() ? 'DESC' : 'ASC')
                 ->addOrderBy('mandate.number', 'ASC')
@@ -183,10 +187,6 @@ class ElectedRepresentativeRepository extends ServiceEntityRepository
                 ->andWhere('politicalFunction.finishAt IS NULL')
                 ->setParameter('politicalFunctions', $politicalFunctions)
             ;
-        }
-
-        if ($zones = $filter->getZones()) {
-            $this->withZoneCondition($qb, $zones);
         }
 
         if ($userListDefinitions = $filter->getUserListDefinitions()) {

--- a/src/Repository/Projection/ManagedUserRepository.php
+++ b/src/Repository/Projection/ManagedUserRepository.php
@@ -56,9 +56,8 @@ class ManagedUserRepository extends ServiceEntityRepository
             ->orderBy('u.'.$filter->getSort(), 'd' === $filter->getOrder() ? 'DESC' : 'ASC')
         ;
 
-        $this->withZoneCondition($qb, $filter->getManagedZones());
-
-        $this->withZoneCondition($qb, $filter->getZones());
+        $zones = $filter->getZones() ?: $filter->getManagedZones();
+        $this->withZoneCondition($qb, $zones);
 
         if ($queryAreaCode = $filter->getCityAsArray()) {
             $areaCodeExpression = $qb->expr()->orX();


### PR DESCRIPTION
This PR is an attempt to fix filtering by zones widely in the application.

**The symptom**: when filtering users by managed zones *AND* given zones, there is no match

**The problem**: the application applies the second filter (given zones) over those entities already filtered, as a result, we have only zones linked directly to the given zones, but not their children

**THE FIX** present in this PR: the application discards the "managed zones" if a "given zone" is present, the "managed zone" is taken into account otherwise

**Discarded fix**: apply both at once with `OR` filtering directly in the `JOIN` operation

(there is also a typo fix embedded)