### PR TITLE
Permissive Zone name matching

### DIFF
--- a/src/Repository/Geo/ZoneRepository.php
+++ b/src/Repository/Geo/ZoneRepository.php
@@ -92,11 +92,12 @@ final class ZoneRepository extends ServiceEntityRepository
             $qb
                 ->andWhere(
                     $qb->expr()->orX(
-                        $qb->expr()->like('zone.name', ':term'),
-                        $qb->expr()->like('zone.code', ':term'),
+                        $qb->expr()->like("REPLACE(zone.name, '-', ' ')", ':term_name'),
+                        $qb->expr()->like('zone.code', ':term_code'),
                     )
                 )
-                ->setParameter(':term', "%$term%")
+                ->setParameter(':term_name', '%'.str_replace('-', ' ', $term).'%')
+                ->setParameter(':term_code', "%$term%")
             ;
         }
 


### PR DESCRIPTION
This PR allows matching the input `Hauts de` with the text `Hauts-de-France` when searching for the zone widget in the filter form.