### PR TITLE
Do not suggest inactive zone

### DIFF
--- a/src/Form/ElectedRepresentative/ElectedRepresentativeFilterType.php
+++ b/src/Form/ElectedRepresentative/ElectedRepresentativeFilterType.php
@@ -81,6 +81,7 @@ class ElectedRepresentativeFilterType extends AbstractType
             ->add('zones', ZoneAutoCompleteType::class, [
                 'remote_params' => [
                     'space_type' => $options['space_type'],
+                    'active_only' => false,
                 ],
                 'constraints' => [
                     new ManagedZone($options['space_type']),

--- a/src/Repository/Geo/ZoneRepository.php
+++ b/src/Repository/Geo/ZoneRepository.php
@@ -54,6 +54,7 @@ class ZoneRepository extends ServiceEntityRepository
         string $term,
         array $zones,
         array $types,
+        bool $activeOnly,
         int $perType
     ): array {
         if ('' === $term) {
@@ -62,19 +63,31 @@ class ZoneRepository extends ServiceEntityRepository
 
         $grouped = [];
         foreach ($types as $type) {
-            $grouped[] = $this->doSearchByTermManagedZonesAndType($term, $zones, $type, $perType);
+            $grouped[] = $this->doSearchByTermManagedZonesAndType($term, $zones, $type, $activeOnly, $perType);
         }
 
         return array_merge(...$grouped);
     }
 
-    private function doSearchByTermManagedZonesAndType(string $term, array $zones, string $type, int $max): array
-    {
+    private function doSearchByTermManagedZonesAndType(
+        string $term,
+        array $zones,
+        string $type,
+        bool $activeOnly,
+        int $max
+    ): array {
         $qb = $this->createQueryBuilder('zone');
         $qb
             ->andWhere($qb->expr()->eq('zone.type', ':type'))
             ->setParameter(':type', $type)
         ;
+
+        if ($activeOnly) {
+            $qb
+                ->andWhere($qb->expr()->eq('zone.active', ':active'))
+                ->setParameter(':active', $activeOnly)
+            ;
+        }
 
         if ($zones) {
             $qb


### PR DESCRIPTION
This PR makes the application no longer suggest inactive zones in the zone widget on **adherents' search page**.

Note we keep the widget's behavior on the **elected representatives' search page**.