### PR TITLE
Handle PostgreSQL entity manager

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,8 @@ DATABASE_NAME=enmarche
 DATABASE_USER=root
 DATABASE_PASSWORD=root
 
+PGSQL_DSN="postgresql://root:root@pgsql:5432/enmarche?serverVersion=13&charset=utf8"
+
 REDIS_HOST=redis
 
 RABBITMQ_HOST=rabbitmq

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,6 +5,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/tests')
     ->in(__DIR__.'/config')
     ->in(__DIR__.'/migrations')
+    ->in(__DIR__.'/migrations_pgsql')
     ->in(__DIR__.'/features/bootstrap')
 ;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -q && \
         nginx \
         git \
         mysql-client \
+        postgresql-client \
         php7.4 \
         php7.4-bcmath \
         php7.4-common \
@@ -36,6 +37,7 @@ RUN apt-get update -q && \
         php7.4-json \
         php7.4-mbstring \
         php7.4-mysql \
+        php7.4-pgsql \
         php7.4-opcache \
         php7.4-pdo \
         php7.4-phar \

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -11,7 +11,7 @@ default:
                 - Behatch\Context\TableContext
                 - FixtureContext:
                     fixturesLoader: '@Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader'
-                    manager: "@doctrine.orm.default_entity_manager"
+                    managerRegistry: '@Doctrine\Persistence\ManagerRegistry'
                 - RestContext:
                     sslPrivateKey: "%%ssl_private_key%%"
                     entityManager: "@doctrine.orm.default_entity_manager"

--- a/config/migrations/default.yaml
+++ b/config/migrations/default.yaml
@@ -1,0 +1,10 @@
+connection: default
+em: default
+
+migrations_paths:
+    Migrations: '../../migrations'
+
+table_storage:
+    table_name: 'migrations'
+
+transactional: true

--- a/config/migrations/pgsql.yaml
+++ b/config/migrations/pgsql.yaml
@@ -1,0 +1,10 @@
+connection: pgsql
+em: pgsql
+
+migrations_paths:
+  MigrationsPgsql: '../../migrations_pgsql'
+
+table_storage:
+  table_name: 'migrations'
+
+transactional: true

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -2,6 +2,7 @@ api_platform:
     name_converter: serializer.name_converter.camel_case_to_snake_case
     resource_class_directories:
         - '%kernel.project_dir%/src/Entity'
+        - '%kernel.project_dir%/src/EntityPgsql'
     enable_docs: true
     enable_swagger_ui: true
     enable_entrypoint: false

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,17 +1,25 @@
 doctrine:
     dbal:
-        driver:           pdo_mysql
-        charset:          UTF8
-        host:             "%env(DATABASE_HOST)%"
-        port:             "%env(DATABASE_PORT)%"
-        dbname:           "%env(DATABASE_NAME)%"
-        user:             "%env(DATABASE_USER)%"
-        password:         "%env(DATABASE_PASSWORD)%"
-        unix_socket:      "%env(DATABASE_SOCKET)%"
-        server_version:   5.7
-        options:
-            1002: "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
-        schema_filter: '#^(?!rememberme_token)#'
+        default_connection: default
+        connections:
+            default:
+                driver:           pdo_mysql
+                charset:          UTF8
+                host:             "%env(DATABASE_HOST)%"
+                port:             "%env(DATABASE_PORT)%"
+                dbname:           "%env(DATABASE_NAME)%"
+                user:             "%env(DATABASE_USER)%"
+                password:         "%env(DATABASE_PASSWORD)%"
+                unix_socket:      "%env(DATABASE_SOCKET)%"
+                server_version:   5.7
+                options:
+                    1002: "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
+                schema_filter: '#^(?!rememberme_token)#'
+            pgsql:
+                driver: pdo_pgsql
+                url: '%env(resolve:PGSQL_DSN)%'
+                schema_filter:  ~^(?!(public|topology|tiger))~
+
         types:
             uuid:           Ramsey\Uuid\Doctrine\UuidType
             phone_number:   Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType
@@ -19,50 +27,67 @@ doctrine:
             geometry:       CrEOF\Spatial\DBAL\Types\GeometryType
             polygon:        CrEOF\Spatial\DBAL\Types\Geometry\PolygonType
             multipolygon:   CrEOF\Spatial\DBAL\Types\Geometry\PolygonType
+
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
-        naming_strategy: doctrine.orm.naming_strategy.underscore
-        auto_mapping: false
-        mappings:
-            App:
-                is_bundle: false
-                type: annotation
-                dir: '%kernel.project_dir%/src/Entity'
-                prefix: 'App\Entity'
-                alias: App
+        default_entity_manager: default
+        entity_managers:
+            default:
+                connection: default
+                naming_strategy: doctrine.orm.naming_strategy.underscore
+                auto_mapping: false
+                mappings:
+                    App:
+                        is_bundle: false
+                        type: annotation
+                        dir: '%kernel.project_dir%/src/Entity'
+                        prefix: 'App\Entity'
+                        alias: App
 
-        filters:
-            softdeleteable:
-                class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
-                enabled: true
-            enabled:
-                class:   App\Doctrine\Filter\EnabledFilter
-                enabled: true
+                filters:
+                    softdeleteable:
+                        class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
+                        enabled: true
+                    enabled:
+                        class:   App\Doctrine\Filter\EnabledFilter
+                        enabled: true
 
-        dql:
-            datetime_functions:
-                year_month: DoctrineExtensions\Query\Mysql\YearMonth
-                timestampdiff: DoctrineExtensions\Query\Mysql\TimestampDiff
-                convert_tz: DoctrineExtensions\Query\Mysql\ConvertTz
-                now: DoctrineExtensions\Query\Mysql\Now
-                date: DoctrineExtensions\Query\Mysql\Date
-            numeric_functions:
-                acos: DoctrineExtensions\Query\Mysql\Acos
-                cos: DoctrineExtensions\Query\Mysql\Cos
-                radians: DoctrineExtensions\Query\Mysql\Radians
-                sin: DoctrineExtensions\Query\Mysql\Sin
-                st_geomfromtext: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\GeomFromText
-                st_within: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STWithin
-                point: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\Point
-            string_functions:
-                json_contains: App\Query\Mysql\JsonContains
-                find_in_set: DoctrineExtensions\Query\Mysql\FindInSet
-                json_length: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonLength
-                substring_index: DoctrineExtensions\Query\Mysql\SubstringIndex
-                group_concat: DoctrineExtensions\Query\Mysql\GroupConcat
-                concat_ws: DoctrineExtensions\Query\Mysql\ConcatWs
-                replace: DoctrineExtensions\Query\Mysql\Replace
-                if: DoctrineExtensions\Query\Mysql\IfElse
+                dql:
+                    datetime_functions:
+                        year_month: DoctrineExtensions\Query\Mysql\YearMonth
+                        timestampdiff: DoctrineExtensions\Query\Mysql\TimestampDiff
+                        convert_tz: DoctrineExtensions\Query\Mysql\ConvertTz
+                        now: DoctrineExtensions\Query\Mysql\Now
+                        date: DoctrineExtensions\Query\Mysql\Date
+                    numeric_functions:
+                        acos: DoctrineExtensions\Query\Mysql\Acos
+                        cos: DoctrineExtensions\Query\Mysql\Cos
+                        radians: DoctrineExtensions\Query\Mysql\Radians
+                        sin: DoctrineExtensions\Query\Mysql\Sin
+                        st_geomfromtext: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\GeomFromText
+                        st_within: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STWithin
+                        point: CrEOF\Spatial\ORM\Query\AST\Functions\MySql\Point
+                    string_functions:
+                        json_contains: App\Query\Mysql\JsonContains
+                        find_in_set: DoctrineExtensions\Query\Mysql\FindInSet
+                        json_length: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonLength
+                        substring_index: DoctrineExtensions\Query\Mysql\SubstringIndex
+                        group_concat: DoctrineExtensions\Query\Mysql\GroupConcat
+                        concat_ws: DoctrineExtensions\Query\Mysql\ConcatWs
+                        replace: DoctrineExtensions\Query\Mysql\Replace
+                        if: DoctrineExtensions\Query\Mysql\IfElse
 
-        hydrators:
-            EventHydrator: App\Doctrine\Hydrators\EventHydrator
+                hydrators:
+                    EventHydrator: App\Doctrine\Hydrators\EventHydrator
+
+            pgsql:
+                connection: pgsql
+                naming_strategy: doctrine.orm.naming_strategy.underscore
+                auto_mapping: false
+                mappings:
+                    Pgsql:
+                        is_bundle: false
+                        type: annotation
+                        dir: '%kernel.project_dir%/src/EntityPgsql'
+                        prefix: 'App\EntityPgsql'
+                        alias: Pgsql

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,6 +1,0 @@
-doctrine_migrations:
-    migrations_paths:
-        Migrations: '%kernel.project_dir%/migrations'
-    storage:
-        table_storage:
-            table_name: 'migrations'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -102,6 +102,7 @@ services:
             - '../src/Mailchimp'
             - '../src/DependencyInjection'
             - '../src/Entity'
+            - '../src/EntityPgsql'
             - '../src/Security'
             - '../src/Kernel.php'
 

--- a/config/services_dev.yaml
+++ b/config/services_dev.yaml
@@ -8,7 +8,7 @@ services:
         public: false
 
     App\DataFixtures\:
-        resource: '../src/DataFixtures/'
+        resource: '%kernel.project_dir%/src/DataFixtures/'
 
     Tests\App\Test\Geocoder\DummyGeocoder: ~
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -64,6 +64,10 @@ version: "3.9"
 #        ports:
 #            - "3306:3306"
 
+#    pgsql:
+#        ports:
+#            - "5432:5432"
+
 #    blackfire:
 #        image: blackfire/blackfire
 #        environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         build: docker/dev
         depends_on:
             - db
+            - pgsql
             - redis
             - rabbitmq
         volumes:
@@ -23,6 +24,13 @@ services:
             - ./docker/dev/my.cnf:/etc/mysql/conf.d/my.cnf
         environment:
             MYSQL_ROOT_PASSWORD: root
+
+    pgsql:
+        image: mdillon/postgis:11
+        environment:
+            POSTGRES_DB: enmarche
+            POSTGRES_USER: root
+            POSTGRES_PASSWORD: root
 
     redis:
         image: redis:3.2

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -q && \
         git \
         graphviz \
         mysql-client \
+        postgresql-client \
         php7.4 \
         php7.4-bcmath \
         php7.4-common \
@@ -41,6 +42,7 @@ RUN apt-get update -q && \
         php7.4-json \
         php7.4-mbstring \
         php7.4-mysql \
+        php7.4-pgsql \
         php7.4-pdo \
         php7.4-phar \
         php7.4-sqlite \

--- a/migrations_pgsql/Version20211013021350.php
+++ b/migrations_pgsql/Version20211013021350.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MigrationsPgsql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20211013021350 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SEQUENCE address_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE address (
+          id BIGINT NOT NULL,
+          number VARCHAR(255) NOT NULL,
+          street VARCHAR(255) NOT NULL,
+          PRIMARY KEY(id)
+        )');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP SEQUENCE address_id_seq CASCADE');
+        $this->addSql('DROP TABLE address');
+    }
+}

--- a/src/DataFixtures/ORM/AbstractFixtures.php
+++ b/src/DataFixtures/ORM/AbstractFixtures.php
@@ -4,12 +4,18 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Geo\Zone;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\ORM\EntityManagerInterface;
 
-abstract class AbstractFixtures extends Fixture
+abstract class AbstractFixtures extends Fixture implements FixtureGroupInterface
 {
     protected function getZoneEntity(EntityManagerInterface $manager, int $id): Zone
     {
         return $manager->getPartialReference(Zone::class, $id);
+    }
+
+    public static function getGroups(): array
+    {
+        return ['default'];
     }
 }

--- a/src/DataFixtures/ORM/LoadAdherentData.php
+++ b/src/DataFixtures/ORM/LoadAdherentData.php
@@ -29,13 +29,12 @@ use App\Jecoute\GenderEnum;
 use App\Membership\ActivityPositions;
 use App\Membership\AdherentFactory;
 use App\Subscription\SubscriptionTypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadAdherentData extends Fixture implements DependentFixtureInterface
+class LoadAdherentData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const ADHERENT_1_UUID = '313bd28f-efc8-57c9-8ab7-2106c8be9697';
     public const ADHERENT_2_UUID = 'e6977a4d-2646-5f6c-9c82-88e58dca8458';

--- a/src/DataFixtures/ORM/LoadAdherentEmailSubscribeTokenData.php
+++ b/src/DataFixtures/ORM/LoadAdherentEmailSubscribeTokenData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\AdherentEmailSubscribeToken;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAdherentEmailSubscribeTokenData extends Fixture implements DependentFixtureInterface
+class LoadAdherentEmailSubscribeTokenData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadAdherentInstanceQualityData.php
+++ b/src/DataFixtures/ORM/LoadAdherentInstanceQualityData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Instance\AdherentInstanceQuality;
 use App\Instance\InstanceQualityEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAdherentInstanceQualityData extends Fixture implements DependentFixtureInterface
+class LoadAdherentInstanceQualityData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadAdherentMessageData.php
+++ b/src/DataFixtures/ORM/LoadAdherentMessageData.php
@@ -12,13 +12,12 @@ use App\Entity\AdherentMessage\Filter\CommitteeFilter;
 use App\Entity\AdherentMessage\Filter\ReferentUserFilter;
 use App\Entity\AdherentMessage\MailchimpCampaign;
 use App\Entity\AdherentMessage\ReferentAdherentMessage;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use Ramsey\Uuid\Uuid;
 
-class LoadAdherentMessageData extends Fixture implements DependentFixtureInterface
+class LoadAdherentMessageData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const MESSAGE_01_UUID = '969b1f08-53ec-4a7d-8d6e-7654a001b13f';
 

--- a/src/DataFixtures/ORM/LoadAdherentSegmentData.php
+++ b/src/DataFixtures/ORM/LoadAdherentSegmentData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\AdherentSegment;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAdherentSegmentData extends Fixture implements DependentFixtureInterface
+class LoadAdherentSegmentData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadAdherentTagData.php
+++ b/src/DataFixtures/ORM/LoadAdherentTagData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\AdherentTag;
 use App\Entity\AdherentTagEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAdherentTagData extends Fixture
+class LoadAdherentTagData extends AbstractFixtures
 {
     public const ADHERENT_TAG = [
         'AT001' => AdherentTagEnum::ELECTED,

--- a/src/DataFixtures/ORM/LoadAdminData.php
+++ b/src/DataFixtures/ORM/LoadAdminData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Admin\AdministratorFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadAdminData extends Fixture
+class LoadAdminData extends AbstractFixtures
 {
     private $administratorFactory;
 

--- a/src/DataFixtures/ORM/LoadApplicationRequestRunningMateRequestData.php
+++ b/src/DataFixtures/ORM/LoadApplicationRequestRunningMateRequestData.php
@@ -4,14 +4,13 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\ApplicationRequest\RunningMateRequest;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use libphonenumber\PhoneNumberUtil;
 use Ramsey\Uuid\Uuid;
 
-class LoadApplicationRequestRunningMateRequestData extends Fixture implements DependentFixtureInterface
+class LoadApplicationRequestRunningMateRequestData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const UUID_1 = '23db4b50-dbe3-4b7f-9bd8-f3eaba8367de';
     private const UUID_2 = '64bae83d-0d29-42a7-a394-fb31648131f2';

--- a/src/DataFixtures/ORM/LoadApplicationRequestTagData.php
+++ b/src/DataFixtures/ORM/LoadApplicationRequestTagData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ApplicationRequest\ApplicationRequestTag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApplicationRequestTagData extends Fixture
+class LoadApplicationRequestTagData extends AbstractFixtures
 {
     private const TAGS = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
 

--- a/src/DataFixtures/ORM/LoadApplicationRequestTechnicalSkillData.php
+++ b/src/DataFixtures/ORM/LoadApplicationRequestTechnicalSkillData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ApplicationRequest\TechnicalSkill;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApplicationRequestTechnicalSkillData extends Fixture
+class LoadApplicationRequestTechnicalSkillData extends AbstractFixtures
 {
     private const SKILLS = [
         'application-skill-01' => 'Communication',

--- a/src/DataFixtures/ORM/LoadApplicationRequestThemeData.php
+++ b/src/DataFixtures/ORM/LoadApplicationRequestThemeData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ApplicationRequest\Theme;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApplicationRequestThemeData extends Fixture
+class LoadApplicationRequestThemeData extends AbstractFixtures
 {
     private const THEMES = [
         'application-theme-01' => 'Urbanisme',

--- a/src/DataFixtures/ORM/LoadApplicationRequestVolunteerRequestData.php
+++ b/src/DataFixtures/ORM/LoadApplicationRequestVolunteerRequestData.php
@@ -4,13 +4,12 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\ApplicationRequest\VolunteerRequest;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use libphonenumber\PhoneNumberUtil;
 use Ramsey\Uuid\Uuid;
 
-class LoadApplicationRequestVolunteerRequestData extends Fixture implements DependentFixtureInterface
+class LoadApplicationRequestVolunteerRequestData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const UUID_1 = '214ef0d4-8923-48a6-99e1-e50eeefaeaf4';
     private const UUID_2 = 'a6ac8cc7-776f-4f4f-854e-f6b0a1bd7c62';

--- a/src/DataFixtures/ORM/LoadApproachData.php
+++ b/src/DataFixtures/ORM/LoadApproachData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ProgrammaticFoundation\Approach;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApproachData extends Fixture implements DependentFixtureInterface
+class LoadApproachData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadApproachMeasureData.php
+++ b/src/DataFixtures/ORM/LoadApproachMeasureData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ProgrammaticFoundation\Measure;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApproachMeasureData extends Fixture implements DependentFixtureInterface
+class LoadApproachMeasureData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const CONTENTS = [
         '<p>Ut tortor mi, ullamcorper sed elit at, fringilla molestie leo. In efficitur arcu dui, id posuere nulla ultricies quis. Sed fringilla lac<a href="#">us sed enim vestibul</a>um, at ornare metus scelerisque. Phasellus id sagittis neque. In justo quam, placerat a pretium a, mattis et nibh. Duis consequat ac metus aliquam fermentum.</p>

--- a/src/DataFixtures/ORM/LoadApproachProjectData.php
+++ b/src/DataFixtures/ORM/LoadApproachProjectData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ProgrammaticFoundation\Project;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadApproachProjectData extends Fixture implements DependentFixtureInterface
+class LoadApproachProjectData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const CITIES = [
         'Lyon',

--- a/src/DataFixtures/ORM/LoadArticleData.php
+++ b/src/DataFixtures/ORM/LoadArticleData.php
@@ -5,14 +5,13 @@ namespace App\DataFixtures\ORM;
 use App\Content\ArticleFactory;
 use App\Content\MediaFactory;
 use App\Entity\ArticleCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use Gedmo\Sluggable\Util\Urlizer;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadArticleData extends Fixture
+class LoadArticleData extends AbstractFixtures
 {
     private $articleFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadAssessorRequestData.php
+++ b/src/DataFixtures/ORM/LoadAssessorRequestData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Assessor\AssessorRequestFactory;
 use App\Entity\AssessorOfficeEnum;
 use App\Entity\VotePlace;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadAssessorRequestData extends Fixture implements DependentFixtureInterface
+class LoadAssessorRequestData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const ASSESSOR_REQUEST_1_UUID = 'be61ba07-c8e7-4533-97e1-0ab215cd752c';
     private const ASSESSOR_REQUEST_2_UUID = '91b8d3a3-6757-4cf6-becc-5e3786bbbf5a';

--- a/src/DataFixtures/ORM/LoadAudienceData.php
+++ b/src/DataFixtures/ORM/LoadAudienceData.php
@@ -6,12 +6,11 @@ use App\Entity\Audience\Audience;
 use App\Entity\Geo\Zone;
 use App\Scope\ScopeEnum;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadAudienceData extends Fixture implements DependentFixtureInterface
+class LoadAudienceData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const AUDIENCE_1_UUID = '4fe24658-000c-4223-87be-d09129c1e191';
     public const AUDIENCE_2_UUID = 'bd298079-f763-4c7a-9a8a-a243d01d0e31';

--- a/src/DataFixtures/ORM/LoadAudienceSegmentData.php
+++ b/src/DataFixtures/ORM/LoadAudienceSegmentData.php
@@ -8,12 +8,11 @@ use App\Entity\AdherentMessage\Segment\AudienceSegment;
 use App\Entity\Geo\Zone;
 use App\Scope\ScopeEnum;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadAudienceSegmentData extends Fixture implements DependentFixtureInterface
+class LoadAudienceSegmentData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const SEGMENT_1_UUID = '830d230f-67fb-4217-9986-1a3ed7d3d5e7';
     public const SEGMENT_2_UUID = 'f6c36dd7-0517-4caf-ba6f-ec6822f2ec12';

--- a/src/DataFixtures/ORM/LoadBannedAdherentData.php
+++ b/src/DataFixtures/ORM/LoadBannedAdherentData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\BannedAdherent;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadBannedAdherentData extends Fixture
+class LoadBannedAdherentData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadBoardMemberRoleData.php
+++ b/src/DataFixtures/ORM/LoadBoardMemberRoleData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\BoardMember\Role;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadBoardMemberRoleData extends Fixture
+class LoadBoardMemberRoleData extends AbstractFixtures
 {
     public const BOARD_MEMBER_ROLES = [
         'adherent' => 'Adhérent(e) membre de la société civile',

--- a/src/DataFixtures/ORM/LoadCauseData.php
+++ b/src/DataFixtures/ORM/LoadCauseData.php
@@ -9,13 +9,12 @@ use App\Entity\Coalition\Coalition;
 use App\Entity\FollowerInterface;
 use App\Entity\Geo\Zone;
 use App\Image\ImageManagerInterface;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadCauseData extends Fixture implements DependentFixtureInterface
+class LoadCauseData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const CAUSE_1_UUID = '55056e7c-2b5f-4ef6-880e-cde0511f79b2';
     public const CAUSE_2_UUID = '017491f9-1953-482e-b491-20418235af1f';

--- a/src/DataFixtures/ORM/LoadCauseEventData.php
+++ b/src/DataFixtures/ORM/LoadCauseEventData.php
@@ -11,12 +11,11 @@ use App\Event\EventFactory;
 use App\Event\EventRegistrationCommand;
 use App\Event\EventRegistrationFactory;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadCauseEventData extends Fixture implements DependentFixtureInterface
+class LoadCauseEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const EVENT_1_UUID = 'ef62870c-6d42-47b6-91ea-f454d473adf8';
     public const EVENT_2_UUID = '19242011-7fbe-47b7-b459-0ca724d4fca2';

--- a/src/DataFixtures/ORM/LoadCertificationData.php
+++ b/src/DataFixtures/ORM/LoadCertificationData.php
@@ -9,12 +9,11 @@ use App\Entity\Adherent;
 use App\Entity\Administrator;
 use App\Entity\CertificationRequest;
 use App\Entity\Reporting\AdherentCertificationHistory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadCertificationData extends Fixture implements DependentFixtureInterface
+class LoadCertificationData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $certificationManager;
 

--- a/src/DataFixtures/ORM/LoadChezVousData.php
+++ b/src/DataFixtures/ORM/LoadChezVousData.php
@@ -12,11 +12,10 @@ use App\Entity\ChezVous\Marker;
 use App\Entity\ChezVous\Measure;
 use App\Entity\ChezVous\Region;
 use Cocur\Slugify\Slugify;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadChezVousData extends Fixture implements DependentFixtureInterface
+class LoadChezVousData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const REGIONS = [
         '1' => 'Guadeloupe',

--- a/src/DataFixtures/ORM/LoadChezVousMeasureTypeData.php
+++ b/src/DataFixtures/ORM/LoadChezVousMeasureTypeData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ChezVous\MeasureType;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadChezVousMeasureTypeData extends Fixture
+class LoadChezVousMeasureTypeData extends AbstractFixtures
 {
     private const TYPES = [
         [

--- a/src/DataFixtures/ORM/LoadCityData.php
+++ b/src/DataFixtures/ORM/LoadCityData.php
@@ -6,10 +6,9 @@ use App\Entity\City;
 use App\Entity\Department;
 use App\Entity\Region;
 use App\Utils\AreaUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCityData extends Fixture
+class LoadCityData extends AbstractFixtures
 {
     private const REGIONS = [
         '1' => 'Guadeloupe',

--- a/src/DataFixtures/ORM/LoadClarificationData.php
+++ b/src/DataFixtures/ORM/LoadClarificationData.php
@@ -4,13 +4,12 @@ namespace App\DataFixtures\ORM;
 
 use App\Content\ClarificationFactory;
 use App\Content\MediaFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadClarificationData extends Fixture
+class LoadClarificationData extends AbstractFixtures
 {
     private $clarificationFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadClientData.php
+++ b/src/DataFixtures/ORM/LoadClientData.php
@@ -6,11 +6,10 @@ use App\Entity\OAuth\Client;
 use App\OAuth\Model\GrantTypeEnum;
 use App\OAuth\Model\Scope;
 use App\Security\Voter\DataCornerVoter;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadClientData extends Fixture
+class LoadClientData extends AbstractFixtures
 {
     public const CLIENT_01_UUID = 'f80ce2df-af6d-4ce4-8239-04cfcefd5a19';
     public const CLIENT_02_UUID = '661cc3b7-322d-4441-a510-ab04eda71737';

--- a/src/DataFixtures/ORM/LoadCmsBlockData.php
+++ b/src/DataFixtures/ORM/LoadCmsBlockData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\AdherentCharter\AdherentCharterTypeEnum;
 use App\Entity\CmsBlock;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCmsBlockData extends Fixture
+class LoadCmsBlockData extends AbstractFixtures
 {
     private const MARKDOWN_CONTENT = <<<MARKDOWN
 # Lorem ipsum

--- a/src/DataFixtures/ORM/LoadCoalitionData.php
+++ b/src/DataFixtures/ORM/LoadCoalitionData.php
@@ -4,13 +4,12 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Coalition\Coalition;
 use App\Image\ImageManagerInterface;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadCoalitionData extends Fixture implements DependentFixtureInterface
+class LoadCoalitionData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const COALITION_1_UUID = 'd5289058-2a35-4cf0-8f2f-a683d97d8315';
     public const COALITION_2_UUID = '09d700f8-8813-4c3c-9bee-ff18d2051bba';

--- a/src/DataFixtures/ORM/LoadCoalitionEventData.php
+++ b/src/DataFixtures/ORM/LoadCoalitionEventData.php
@@ -11,12 +11,11 @@ use App\Event\EventFactory;
 use App\Event\EventRegistrationCommand;
 use App\Event\EventRegistrationFactory;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadCoalitionEventData extends Fixture implements DependentFixtureInterface
+class LoadCoalitionEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const EVENT_1_UUID = '472d1f86-6522-4122-a0f4-abd69d17bb2d';
     public const EVENT_2_UUID = '8d706ed2-0312-4c21-9923-c573005b338e';

--- a/src/DataFixtures/ORM/LoadCommitteeAdherentMandateData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeAdherentMandateData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\AdherentMandate\CommitteeAdherentMandate;
 use App\Entity\AdherentMandate\CommitteeMandateQualityEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCommitteeAdherentMandateData extends Fixture implements DependentFixtureInterface
+class LoadCommitteeAdherentMandateData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadCommitteeCandidacyData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeCandidacyData.php
@@ -7,12 +7,11 @@ use App\Entity\Committee;
 use App\Entity\CommitteeCandidacy;
 use App\Entity\CommitteeCandidacyInvitation;
 use App\Image\ImageManager;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadCommitteeCandidacyData extends Fixture implements DependentFixtureInterface
+class LoadCommitteeCandidacyData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $imageManager;
 

--- a/src/DataFixtures/ORM/LoadCommitteeData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeData.php
@@ -6,11 +6,10 @@ use App\Committee\CommitteeFactory;
 use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\CommitteeElection;
 use App\Entity\PostAddress;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCommitteeData extends Fixture implements DependentFixtureInterface
+class LoadCommitteeData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const COMMITTEE_1_UUID = '515a56c0-bde8-56ef-b90c-4745b1c93818';
     public const COMMITTEE_2_UUID = '182d8586-8b05-4b70-a727-704fa701e816';

--- a/src/DataFixtures/ORM/LoadCommitteeEventData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeEventData.php
@@ -14,11 +14,10 @@ use App\Event\EventFactory;
 use App\Event\EventRegistrationCommand;
 use App\Event\EventRegistrationFactory;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCommitteeEventData extends Fixture implements DependentFixtureInterface
+class LoadCommitteeEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const EVENT_1_UUID = '1fc69fd0-2b34-4bd4-a0cc-834480480934';
     public const EVENT_2_UUID = 'defd812f-265c-4196-bd33-72fe39e5a2a1';

--- a/src/DataFixtures/ORM/LoadCommitteeMembershipHistoryData.php
+++ b/src/DataFixtures/ORM/LoadCommitteeMembershipHistoryData.php
@@ -8,11 +8,10 @@ use App\Entity\CommitteeMembership;
 use App\Entity\Reporting\CommitteeMembershipAction;
 use App\Entity\Reporting\CommitteeMembershipHistory;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadCommitteeMembershipHistoryData extends Fixture implements DependentFixtureInterface
+class LoadCommitteeMembershipHistoryData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadCustomSearchData.php
+++ b/src/DataFixtures/ORM/LoadCustomSearchData.php
@@ -4,12 +4,11 @@ namespace App\DataFixtures\ORM;
 
 use App\Content\CustomSearchResultFactory;
 use App\Content\MediaFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadCustomSearchData extends Fixture
+class LoadCustomSearchData extends AbstractFixtures
 {
     private $customSearchResultFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadDefaultEventData.php
+++ b/src/DataFixtures/ORM/LoadDefaultEventData.php
@@ -6,12 +6,11 @@ use App\Entity\Event\BaseEvent;
 use App\Entity\Event\DefaultEvent;
 use App\Event\EventRegistrationCommand;
 use App\Event\EventRegistrationFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadDefaultEventData extends Fixture implements DependentFixtureInterface
+class LoadDefaultEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const EVENT_1_UUID = '5cab27a7-dbb3-4347-9781-566dad1b9eb5';
     private const EVENT_2_UUID = '2b7238f9-10ca-4a39-b8a4-ad7f438aa95f';

--- a/src/DataFixtures/ORM/LoadDelegatedAccessData.php
+++ b/src/DataFixtures/ORM/LoadDelegatedAccessData.php
@@ -3,12 +3,11 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\MyTeam\DelegatedAccess;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadDelegatedAccessData extends Fixture implements DependentFixtureInterface
+class LoadDelegatedAccessData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const ACCESS_UUID_1 = '2e80d106-4bcb-4b28-97c9-3856fc235b27';
     private const ACCESS_UUID_2 = 'f4ce89da-1272-4a01-a47e-4ce5248ce018';

--- a/src/DataFixtures/ORM/LoadDesignationData.php
+++ b/src/DataFixtures/ORM/LoadDesignationData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Entity\VotingPlatform\Designation\Designation;
 use App\VotingPlatform\Designation\DesignationTypeEnum;
 use App\VotingPlatform\Designation\DesignationZoneEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadDesignationData extends Fixture implements DependentFixtureInterface
+class LoadDesignationData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadDeviceData.php
+++ b/src/DataFixtures/ORM/LoadDeviceData.php
@@ -3,12 +3,11 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Device;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadDeviceData extends Fixture implements DependentFixtureInterface
+class LoadDeviceData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const DEVICE_1_UUID = '64a85323-fade-4d05-9db0-e06825fc5e61';
     public const DEVICE_2_UUID = '2d5f91ce-547f-44e0-b5f2-037c7a5a99ec';

--- a/src/DataFixtures/ORM/LoadDistrictData.php
+++ b/src/DataFixtures/ORM/LoadDistrictData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Deputy\LightFileDistrictLoader;
 use App\Entity\District;
 use App\Entity\ReferentTag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadDistrictData extends Fixture implements DependentFixtureInterface
+class LoadDistrictData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $districtLoader;
 

--- a/src/DataFixtures/ORM/LoadDonationData.php
+++ b/src/DataFixtures/ORM/LoadDonationData.php
@@ -9,12 +9,11 @@ use App\Entity\Donation;
 use App\Entity\Donator;
 use App\Entity\Transaction;
 use Cocur\Slugify\SlugifyInterface;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadDonationData extends Fixture implements DependentFixtureInterface
+class LoadDonationData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $slugify;
 

--- a/src/DataFixtures/ORM/LoadDonationTagData.php
+++ b/src/DataFixtures/ORM/LoadDonationTagData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\DonationTag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadDonationTagData extends Fixture
+class LoadDonationTagData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadDonatorIdentifierData.php
+++ b/src/DataFixtures/ORM/LoadDonatorIdentifierData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\DonatorIdentifier;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadDonatorIdentifierData extends Fixture
+class LoadDonatorIdentifierData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadDonatorTagData.php
+++ b/src/DataFixtures/ORM/LoadDonatorTagData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\DonatorTag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadDonatorTagData extends Fixture
+class LoadDonatorTagData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadElectedRepresentativeData.php
+++ b/src/DataFixtures/ORM/LoadElectedRepresentativeData.php
@@ -16,12 +16,11 @@ use App\Entity\ElectedRepresentative\PoliticalFunctionNameEnum;
 use App\Entity\ElectedRepresentative\SocialLinkTypeEnum;
 use App\Entity\ElectedRepresentative\SocialNetworkLink;
 use App\Utils\PhoneNumberUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadElectedRepresentativeData extends Fixture implements DependentFixtureInterface
+class LoadElectedRepresentativeData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const ELECTED_REPRESENTATIVE_1_UUID = '34b0b236-b72e-4161-8f9f-7f23f935758f';
     public const ELECTED_REPRESENTATIVE_2_UUID = '4b8bb9fd-0645-47fd-bb9a-3515bf46618a';

--- a/src/DataFixtures/ORM/LoadElectionCityCardData.php
+++ b/src/DataFixtures/ORM/LoadElectionCityCardData.php
@@ -9,11 +9,10 @@ use App\Entity\Election\CityManager;
 use App\Entity\Election\CityPartner;
 use App\Entity\Election\CityPrevision;
 use App\Utils\PhoneNumberUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadElectionCityCardData extends Fixture implements DependentFixtureInterface
+class LoadElectionCityCardData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ORM/LoadElectionData.php
+++ b/src/DataFixtures/ORM/LoadElectionData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Election;
 use App\Entity\ElectionRound;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadElectionData extends Fixture
+class LoadElectionData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadEmailSubscriptionHistoryData.php
+++ b/src/DataFixtures/ORM/LoadEmailSubscriptionHistoryData.php
@@ -8,11 +8,10 @@ use App\Entity\Reporting\EmailSubscriptionHistoryAction;
 use App\Repository\AdherentRepository;
 use App\Subscription\SubscriptionTypeEnum;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadEmailSubscriptionHistoryData extends Fixture implements DependentFixtureInterface
+class LoadEmailSubscriptionHistoryData extends AbstractFixtures implements DependentFixtureInterface
 {
     /**
      * @var AdherentRepository

--- a/src/DataFixtures/ORM/LoadEmailTemplateData.php
+++ b/src/DataFixtures/ORM/LoadEmailTemplateData.php
@@ -4,12 +4,11 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Adherent;
 use App\Entity\EmailTemplate\EmailTemplate;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadEmailTemplateData extends Fixture implements DependentFixtureInterface
+class LoadEmailTemplateData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const EMAIL_TEMPLATE_1_UUID = 'ba5a7294-f7a6-4710-88c8-9ceb67ad61ce';
     public const EMAIL_TEMPLATE_2_UUID = '825c3c30-f4bd-42b5-8adf-29926a02a4af';

--- a/src/DataFixtures/ORM/LoadEventCategoryData.php
+++ b/src/DataFixtures/ORM/LoadEventCategoryData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\Event\BaseEventCategory;
 use App\Entity\Event\EventCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadEventCategoryData extends Fixture implements DependentFixtureInterface
+class LoadEventCategoryData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const LEGACY_EVENT_CATEGORIES = [
         'CE001' => 'Kiosque',

--- a/src/DataFixtures/ORM/LoadEventGroupCategoryData.php
+++ b/src/DataFixtures/ORM/LoadEventGroupCategoryData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Event\EventCategory;
 use App\Entity\Event\EventGroupCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadEventGroupCategoryData extends Fixture
+class LoadEventGroupCategoryData extends AbstractFixtures
 {
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ORM/LoadExecutiveOfficeMemberData.php
+++ b/src/DataFixtures/ORM/LoadExecutiveOfficeMemberData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Biography\ExecutiveOfficeMember;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadExecutiveOfficeMemberData extends Fixture
+class LoadExecutiveOfficeMemberData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadFacebookVideoData.php
+++ b/src/DataFixtures/ORM/LoadFacebookVideoData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\FacebookVideo;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 
-class LoadFacebookVideoData extends Fixture
+class LoadFacebookVideoData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadFileData.php
+++ b/src/DataFixtures/ORM/LoadFileData.php
@@ -7,11 +7,10 @@ use App\Entity\Filesystem\File;
 use App\Entity\Filesystem\FilePermission;
 use App\Entity\Filesystem\FilePermissionEnum;
 use App\Entity\Filesystem\FileTypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadFileData extends Fixture implements DependentFixtureInterface
+class LoadFileData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadFormationData.php
+++ b/src/DataFixtures/ORM/LoadFormationData.php
@@ -7,13 +7,12 @@ use App\Entity\Formation\Axe;
 use App\Entity\Formation\Module;
 use App\Entity\Formation\Path;
 use App\Entity\Media;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadFormationData extends Fixture
+class LoadFormationData extends AbstractFixtures
 {
     private $faker;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadGeoZoneData.php
+++ b/src/DataFixtures/ORM/LoadGeoZoneData.php
@@ -3,12 +3,11 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Geo\Zone;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadGeoZoneData extends Fixture
+class LoadGeoZoneData extends AbstractFixtures
 {
     public static $zoneCache;
 

--- a/src/DataFixtures/ORM/LoadHomeBlockData.php
+++ b/src/DataFixtures/ORM/LoadHomeBlockData.php
@@ -6,12 +6,11 @@ use App\Content\HomeBlockFactory;
 use App\Content\MediaFactory;
 use App\Entity\HomeBlock;
 use App\Entity\Media;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadHomeBlockData extends Fixture
+class LoadHomeBlockData extends AbstractFixtures
 {
     private $mediaFactory;
     private $homeBlockFactory;

--- a/src/DataFixtures/ORM/LoadInstanceQualityData.php
+++ b/src/DataFixtures/ORM/LoadInstanceQualityData.php
@@ -5,10 +5,9 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Instance\InstanceQuality;
 use App\Instance\InstanceQualityEnum;
 use App\Instance\InstanceQualityScopeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadInstanceQualityData extends Fixture
+class LoadInstanceQualityData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadInstitutionalEventCategoryData.php
+++ b/src/DataFixtures/ORM/LoadInstitutionalEventCategoryData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Event\InstitutionalEventCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadInstitutionalEventCategoryData extends Fixture
+class LoadInstitutionalEventCategoryData extends AbstractFixtures
 {
     public const INSTITUTIONAL_EVENT_CATEGORIES = [
         'category-1' => 'Comité politique',

--- a/src/DataFixtures/ORM/LoadInstitutionalEventData.php
+++ b/src/DataFixtures/ORM/LoadInstitutionalEventData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Entity\PostAddress;
 use App\Event\EventFactory;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadInstitutionalEventData extends Fixture implements DependentFixtureInterface
+class LoadInstitutionalEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const INSTITUTIONAL_EVENT_1_UUID = '3f46976e-e76a-476e-86d7-575c6d3bc15e';
 

--- a/src/DataFixtures/ORM/LoadInternalApiApplicationData.php
+++ b/src/DataFixtures/ORM/LoadInternalApiApplicationData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\InternalApiApplication;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadInternalApiApplicationData extends Fixture
+class LoadInternalApiApplicationData extends AbstractFixtures
 {
     public const INTERNAL_API_APPLICATION_01_UUID = '50594332-7766-47de-b1f1-72d4328d8ec0';
     public const INTERNAL_API_APPLICATION_02_UUID = '3e50211c-ce07-487d-86ce-f5118acdbdad';

--- a/src/DataFixtures/ORM/LoadJecouteDataAnswerData.php
+++ b/src/DataFixtures/ORM/LoadJecouteDataAnswerData.php
@@ -6,11 +6,10 @@ use App\Entity\Jecoute\Choice;
 use App\Entity\Jecoute\DataAnswer;
 use App\Entity\Jecoute\DataSurvey;
 use App\Entity\Jecoute\SurveyQuestion;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadJecouteDataAnswerData extends Fixture implements DependentFixtureInterface
+class LoadJecouteDataAnswerData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadJecouteNewsData.php
+++ b/src/DataFixtures/ORM/LoadJecouteNewsData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Geo\Zone;
 use App\Entity\Jecoute\News;
 use App\Jecoute\JecouteSpaceEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadJecouteNewsData extends Fixture implements DependentFixtureInterface
+class LoadJecouteNewsData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const NEWS_1_UUID = '16373659-fed1-443c-a956-a257e2c2bae4';
     public const NEWS_2_UUID = '0bc3f920-da90-4773-80e1-a388005926fc';

--- a/src/DataFixtures/ORM/LoadJecouteQuestionData.php
+++ b/src/DataFixtures/ORM/LoadJecouteQuestionData.php
@@ -6,10 +6,9 @@ use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\Jecoute\Choice;
 use App\Entity\Jecoute\Question;
 use App\Jecoute\SurveyQuestionTypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadJecouteQuestionData extends Fixture
+class LoadJecouteQuestionData extends AbstractFixtures
 {
     public const QUESTIONS = [
         'question-1' => [

--- a/src/DataFixtures/ORM/LoadJecouteRiposteData.php
+++ b/src/DataFixtures/ORM/LoadJecouteRiposteData.php
@@ -6,12 +6,11 @@ use App\Entity\Adherent;
 use App\Entity\Administrator;
 use App\Entity\Jecoute\Riposte;
 use App\Riposte\RiposteOpenGraphHandler;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadJecouteRiposteData extends Fixture implements DependentFixtureInterface
+class LoadJecouteRiposteData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const RIPOSTE_1_UUID = '220bd36e-4ac4-488a-8473-8e99a71efba4';
     public const RIPOSTE_2_UUID = 'ff4a352e-9762-4da7-b9f3-a8bfdbce63c1';

--- a/src/DataFixtures/ORM/LoadJecouteSuggestedQuestionData.php
+++ b/src/DataFixtures/ORM/LoadJecouteSuggestedQuestionData.php
@@ -6,10 +6,9 @@ use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\Jecoute\Choice;
 use App\Entity\Jecoute\SuggestedQuestion;
 use App\Jecoute\SurveyQuestionTypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadJecouteSuggestedQuestionData extends Fixture
+class LoadJecouteSuggestedQuestionData extends AbstractFixtures
 {
     public const SUGGESTED_QUESTIONS = [
         'suggested-question-1' => [

--- a/src/DataFixtures/ORM/LoadJecouteSurveyData.php
+++ b/src/DataFixtures/ORM/LoadJecouteSurveyData.php
@@ -9,12 +9,11 @@ use App\Entity\Jecoute\LocalSurvey;
 use App\Entity\Jecoute\NationalSurvey;
 use App\Entity\Jecoute\Question;
 use App\Entity\Jecoute\SurveyQuestion;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadJecouteSurveyData extends Fixture implements DependentFixtureInterface
+class LoadJecouteSurveyData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const SURVEY_NATIONAL_1 = '13814039-1dd2-11b2-9bfd-78ea3dcdf0d9';
     public const SURVEY_NATIONAL_2 = '1f07832c-2a69-1e80-a33a-d5f9460e838f';

--- a/src/DataFixtures/ORM/LoadJemarcheDataSurveyData.php
+++ b/src/DataFixtures/ORM/LoadJemarcheDataSurveyData.php
@@ -8,12 +8,11 @@ use App\Entity\Jecoute\JemarcheDataSurvey;
 use App\Entity\Jecoute\NationalSurvey;
 use App\Entity\Jecoute\Survey;
 use App\Jecoute\GenderEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadJemarcheDataSurveyData extends Fixture implements DependentFixtureInterface
+class LoadJemarcheDataSurveyData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const JEMARCHE_DATA_SURVEY_1_UUID = '5191f388-ccb0-4a93-b7f9-a15f107287fb';
 

--- a/src/DataFixtures/ORM/LoadLegislativesData.php
+++ b/src/DataFixtures/ORM/LoadLegislativesData.php
@@ -5,13 +5,12 @@ namespace App\DataFixtures\ORM;
 use App\Entity\LegislativeCandidate;
 use App\Entity\LegislativeDistrictZone;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
 /**
  * @see https://fr.wikipedia.org/wiki/Liste_des_circonscriptions_l%C3%A9gislatives_de_la_France
  */
-class LoadLegislativesData extends Fixture
+class LoadLegislativesData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadLiveLinkData.php
+++ b/src/DataFixtures/ORM/LoadLiveLinkData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Content\LiveLinkFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadLiveLinkData extends Fixture
+class LoadLiveLinkData extends AbstractFixtures
 {
     private $factory;
 

--- a/src/DataFixtures/ORM/LoadManagedUserData.php
+++ b/src/DataFixtures/ORM/LoadManagedUserData.php
@@ -6,11 +6,10 @@ use App\Entity\Projection\ManagedUser;
 use App\Entity\Projection\ManagedUserFactory;
 use App\Subscription\SubscriptionTypeEnum;
 use App\Utils\PhoneNumberUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadManagedUserData extends Fixture implements DependentFixtureInterface
+class LoadManagedUserData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMinistryVoteResultData.php
+++ b/src/DataFixtures/ORM/LoadMinistryVoteResultData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Election\VoteListNuanceEnum;
 use App\Entity\Election\MinistryListTotalResult;
 use App\Entity\Election\MinistryVoteResult;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMinistryVoteResultData extends Fixture implements DependentFixtureInterface
+class LoadMinistryVoteResultData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ORM/LoadMoocChapterData.php
+++ b/src/DataFixtures/ORM/LoadMoocChapterData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Mooc\Chapter;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMoocChapterData extends Fixture implements DependentFixtureInterface
+class LoadMoocChapterData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMoocData.php
+++ b/src/DataFixtures/ORM/LoadMoocData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Image;
 use App\Entity\Mooc\Mooc;
 use Cake\Chronos\MutableDateTime;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadMoocData extends Fixture implements DependentFixtureInterface
+class LoadMoocData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMoocQuizData.php
+++ b/src/DataFixtures/ORM/LoadMoocQuizData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Mooc\MoocQuizElement;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMoocQuizData extends Fixture
+class LoadMoocQuizData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMoocVideoData.php
+++ b/src/DataFixtures/ORM/LoadMoocVideoData.php
@@ -5,10 +5,9 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Mooc\AttachmentLink;
 use App\Entity\Mooc\MoocVideoElement;
 use Cake\Chronos\MutableDateTime;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadMoocVideoData extends Fixture
+class LoadMoocVideoData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMunicipalEventData.php
+++ b/src/DataFixtures/ORM/LoadMunicipalEventData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Event\MunicipalEvent;
 use App\Entity\PostAddress;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadMunicipalEventData extends Fixture implements DependentFixtureInterface
+class LoadMunicipalEventData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadMyEuropeData.php
+++ b/src/DataFixtures/ORM/LoadMyEuropeData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\MyEuropeChoice;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadMyEuropeData extends Fixture
+class LoadMyEuropeData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadNationalCouncilAdherentMandateData.php
+++ b/src/DataFixtures/ORM/LoadNationalCouncilAdherentMandateData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\AdherentMandate\NationalCouncilAdherentMandate;
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadNationalCouncilAdherentMandateData extends Fixture implements DependentFixtureInterface
+class LoadNationalCouncilAdherentMandateData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadNationalCouncilElectionData.php
+++ b/src/DataFixtures/ORM/LoadNationalCouncilElectionData.php
@@ -8,12 +8,11 @@ use App\Entity\Instance\NationalCouncil\Candidacy;
 use App\Entity\Instance\NationalCouncil\Election;
 use App\Image\ImageManager;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadNationalCouncilElectionData extends Fixture implements DependentFixtureInterface
+class LoadNationalCouncilElectionData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const AVATARS = [
         Genders::MALE => [

--- a/src/DataFixtures/ORM/LoadNewsletterSubscriptionData.php
+++ b/src/DataFixtures/ORM/LoadNewsletterSubscriptionData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Newsletter\NewsletterSubscriptionFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadNewsletterSubscriptionData extends Fixture implements OrderedFixtureInterface
+class LoadNewsletterSubscriptionData extends AbstractFixtures implements OrderedFixtureInterface
 {
     private $newsletterSubscriptionFactory;
 

--- a/src/DataFixtures/ORM/LoadOAuthTokenData.php
+++ b/src/DataFixtures/ORM/LoadOAuthTokenData.php
@@ -9,12 +9,11 @@ use App\Entity\OAuth\Client;
 use App\Entity\OAuth\RefreshToken;
 use App\Repository\AdherentRepository;
 use App\Repository\OAuth\ClientRepository;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadOAuthTokenData extends Fixture implements DependentFixtureInterface
+class LoadOAuthTokenData extends AbstractFixtures implements DependentFixtureInterface
 {
     /**
      * @var AdherentRepository

--- a/src/DataFixtures/ORM/LoadOfficialReportData.php
+++ b/src/DataFixtures/ORM/LoadOfficialReportData.php
@@ -6,11 +6,10 @@ use App\Entity\Adherent;
 use App\Entity\TerritorialCouncil\OfficialReport;
 use App\Entity\TerritorialCouncil\OfficialReportDocument;
 use App\Entity\TerritorialCouncil\PoliticalCommittee;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadOfficialReportData extends Fixture implements DependentFixtureInterface
+class LoadOfficialReportData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadOrderArticleData.php
+++ b/src/DataFixtures/ORM/LoadOrderArticleData.php
@@ -4,14 +4,13 @@ namespace App\DataFixtures\ORM;
 
 use App\Content\MediaFactory;
 use App\Content\OrderArticleFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadOrderArticleData extends Fixture implements DependentFixtureInterface
+class LoadOrderArticleData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $orderArticleFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadOrderSectionData.php
+++ b/src/DataFixtures/ORM/LoadOrderSectionData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\OrderSection;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadOrderSectionData extends Fixture
+class LoadOrderSectionData extends AbstractFixtures
 {
     public const ORDER_SECTION = [
         'OS001' => 'Articles',

--- a/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
+++ b/src/DataFixtures/ORM/LoadOrganizationalChartItemData.php
@@ -6,11 +6,10 @@ use App\Entity\ReferentOrganizationalChart\AbstractOrganizationalChartItem;
 use App\Entity\ReferentOrganizationalChart\GroupOrganizationalChartItem;
 use App\Entity\ReferentOrganizationalChart\PersonOrganizationalChartItem;
 use App\Entity\ReferentOrganizationalChart\ReferentPersonLink;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadOrganizationalChartItemData extends Fixture implements DependentFixtureInterface
+class LoadOrganizationalChartItemData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const MAPPING = [
         'referent' => [

--- a/src/DataFixtures/ORM/LoadPageData.php
+++ b/src/DataFixtures/ORM/LoadPageData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Content\MediaFactory;
 use App\Content\PageFactory;
 use App\Entity\Page;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadPageData extends Fixture
+class LoadPageData extends AbstractFixtures
 {
     private $pageFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadPhoningCampaignData.php
+++ b/src/DataFixtures/ORM/LoadPhoningCampaignData.php
@@ -8,12 +8,11 @@ use App\Entity\Phoning\Campaign;
 use App\Entity\Team\Team;
 use App\ValueObject\Genders;
 use Cake\Chronos\Chronos;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadPhoningCampaignData extends Fixture implements DependentFixtureInterface
+class LoadPhoningCampaignData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const CAMPAIGN_1_UUID = '4ebb184c-24d9-4aeb-bb36-afe44f294387';
     public const CAMPAIGN_2_UUID = '4d91b94c-4b39-43c7-9c88-f4be7e2fe0bc';

--- a/src/DataFixtures/ORM/LoadPhoningCampaignHistoryData.php
+++ b/src/DataFixtures/ORM/LoadPhoningCampaignHistoryData.php
@@ -9,12 +9,11 @@ use App\Entity\Jecoute\Survey;
 use App\Entity\Phoning\Campaign;
 use App\Entity\Phoning\CampaignHistory;
 use App\Phoning\CampaignHistoryStatusEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadPhoningCampaignHistoryData extends Fixture implements DependentFixtureInterface
+class LoadPhoningCampaignHistoryData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const HISTORY_1_UUID = '47bf09fb-db03-40c3-b951-6fe6bbe1f055';
     public const HISTORY_2_UUID = 'a80248ff-384a-4f80-972a-177c3d0a77c4';

--- a/src/DataFixtures/ORM/LoadPoliticalCommitteeData.php
+++ b/src/DataFixtures/ORM/LoadPoliticalCommitteeData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\TerritorialCouncil\PoliticalCommittee;
 use App\Repository\ReferentTagRepository;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadPoliticalCommitteeData extends Fixture implements DependentFixtureInterface
+class LoadPoliticalCommitteeData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadPoliticalCommitteeFeedItemData.php
+++ b/src/DataFixtures/ORM/LoadPoliticalCommitteeFeedItemData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\TerritorialCouncil\PoliticalCommittee;
 use App\Entity\TerritorialCouncil\PoliticalCommitteeFeedItem;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadPoliticalCommitteeFeedItemData extends Fixture implements DependentFixtureInterface
+class LoadPoliticalCommitteeFeedItemData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadPoliticalCommitteeMembershipData.php
+++ b/src/DataFixtures/ORM/LoadPoliticalCommitteeMembershipData.php
@@ -6,11 +6,10 @@ use App\Entity\TerritorialCouncil\PoliticalCommittee;
 use App\Entity\TerritorialCouncil\PoliticalCommitteeMembership;
 use App\Entity\TerritorialCouncil\PoliticalCommitteeQuality;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQualityEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadPoliticalCommitteeMembershipData extends Fixture implements DependentFixtureInterface
+class LoadPoliticalCommitteeMembershipData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadPollData.php
+++ b/src/DataFixtures/ORM/LoadPollData.php
@@ -10,12 +10,11 @@ use App\Entity\Poll\LocalPoll;
 use App\Entity\Poll\NationalPoll;
 use App\Entity\Poll\Poll;
 use App\Entity\Poll\Vote;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadPollData extends Fixture implements DependentFixtureInterface
+class LoadPollData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const NATIONAL_POLL_01_UUID = '8adca369-938c-450b-92e9-9c2b1f206fa3';
     public const LOCAL_POLL_01_UUID = '655d7534-9592-4aed-83e6-cad8fbb3668f';

--- a/src/DataFixtures/ORM/LoadProcurationData.php
+++ b/src/DataFixtures/ORM/LoadProcurationData.php
@@ -6,11 +6,10 @@ use App\Entity\Adherent;
 use App\Entity\ProcurationProxy;
 use App\Entity\ProcurationRequest;
 use App\Utils\PhoneNumberUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadProcurationData extends Fixture implements DependentFixtureInterface
+class LoadProcurationData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadProgrammaticFoundationTagData.php
+++ b/src/DataFixtures/ORM/LoadProgrammaticFoundationTagData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ProgrammaticFoundation\Tag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadProgrammaticFoundationTagData extends Fixture
+class LoadProgrammaticFoundationTagData extends AbstractFixtures
 {
     private const TAG_LABELS = [
         'Écologie',

--- a/src/DataFixtures/ORM/LoadProposalData.php
+++ b/src/DataFixtures/ORM/LoadProposalData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Content\MediaFactory;
 use App\Content\ProposalFactory;
 use App\Entity\ProposalTheme;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadProposalData extends Fixture
+class LoadProposalData extends AbstractFixtures
 {
     private $proposalFactory;
     private $mediaFactory;

--- a/src/DataFixtures/ORM/LoadPushTokenData.php
+++ b/src/DataFixtures/ORM/LoadPushTokenData.php
@@ -6,12 +6,11 @@ use App\Entity\Adherent;
 use App\Entity\Device;
 use App\Entity\PushToken;
 use App\PushToken\PushTokenSourceEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadPushTokenData extends Fixture implements DependentFixtureInterface
+class LoadPushTokenData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const PUSH_TOKEN_1_UUID = '5a650f97-2100-4800-913e-17d82f69b7a3';
     public const PUSH_TOKEN_2_UUID = 'aa429e50-f55a-4da7-b1e6-3c12a55e031a';

--- a/src/DataFixtures/ORM/LoadQrCodeData.php
+++ b/src/DataFixtures/ORM/LoadQrCodeData.php
@@ -4,12 +4,11 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Administrator;
 use App\Entity\QrCode;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadQrCodeData extends Fixture implements DependentFixtureInterface
+class LoadQrCodeData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const QR_CODE_1_UUID = '5d54f136-dce3-41fd-9a19-f8274f1cc2a9';
     public const QR_CODE_2_UUID = '9324d566-5f5a-449a-873e-e204154ff939';

--- a/src/DataFixtures/ORM/LoadQuickActionData.php
+++ b/src/DataFixtures/ORM/LoadQuickActionData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\Coalition\QuickAction;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadQuickActionData extends Fixture implements DependentFixtureInterface
+class LoadQuickActionData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadRedirectionData.php
+++ b/src/DataFixtures/ORM/LoadRedirectionData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\Redirection;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\Response;
 
-class LoadRedirectionData extends Fixture
+class LoadRedirectionData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadReferentData.php
+++ b/src/DataFixtures/ORM/LoadReferentData.php
@@ -5,10 +5,9 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Referent;
 use App\Entity\ReferentArea;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadReferentData extends Fixture
+class LoadReferentData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadReferentTagData.php
+++ b/src/DataFixtures/ORM/LoadReferentTagData.php
@@ -5,10 +5,9 @@ namespace App\DataFixtures\ORM;
 use App\Entity\ReferentTag;
 use App\Intl\UnitedNationsBundle;
 use App\Repository\ReferentTagRepository;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadReferentTagData extends Fixture
+class LoadReferentTagData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadReferentTagsZonesLinksData.php
+++ b/src/DataFixtures/ORM/LoadReferentTagsZonesLinksData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ReferentTag;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadReferentTagsZonesLinksData extends Fixture implements DependentFixtureInterface
+class LoadReferentTagsZonesLinksData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ORM/LoadReportData.php
+++ b/src/DataFixtures/ORM/LoadReportData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Report\CommitteeReport;
 use App\Entity\Report\ReportReasonEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadReportData extends Fixture implements DependentFixtureInterface
+class LoadReportData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadRepublicanSilenceData.php
+++ b/src/DataFixtures/ORM/LoadRepublicanSilenceData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\RepublicanSilence;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadRepublicanSilenceData extends Fixture implements DependentFixtureInterface
+class LoadRepublicanSilenceData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadScopeData.php
+++ b/src/DataFixtures/ORM/LoadScopeData.php
@@ -6,10 +6,9 @@ use App\Entity\Scope;
 use App\Scope\AppEnum;
 use App\Scope\FeatureEnum;
 use App\Scope\ScopeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadScopeData extends Fixture
+class LoadScopeData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadSmsCampaignData.php
+++ b/src/DataFixtures/ORM/LoadSmsCampaignData.php
@@ -6,12 +6,11 @@ use App\Entity\Audience\AudienceSnapshot;
 use App\Entity\SmsCampaign;
 use App\SmsCampaign\SmsCampaignStatusEnum;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadSmsCampaignData extends Fixture implements DependentFixtureInterface
+class LoadSmsCampaignData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const UUID_1 = '0950cc74-eb81-49c6-9989-8500530feaa6';
     public const UUID_2 = 'a8a9b003-a05c-40b9-bc78-8184a2a4ac71';

--- a/src/DataFixtures/ORM/LoadSocialShareData.php
+++ b/src/DataFixtures/ORM/LoadSocialShareData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Content\MediaFactory;
 use App\Entity\SocialShare;
 use App\Entity\SocialShareCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-class LoadSocialShareData extends Fixture
+class LoadSocialShareData extends AbstractFixtures
 {
     private $mediaFactory;
     private $storage;

--- a/src/DataFixtures/ORM/LoadSubApproachData.php
+++ b/src/DataFixtures/ORM/LoadSubApproachData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ProgrammaticFoundation\SubApproach;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSubApproachData extends Fixture implements DependentFixtureInterface
+class LoadSubApproachData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const DESCRIPTIONS = [
         "En ce qui concerne la baisse de confiance conjoncturelle, on se doit d'analyser systématiquement les ouvertures imaginables, avec toute la prudence requise.",

--- a/src/DataFixtures/ORM/LoadSubscriptionTypeData.php
+++ b/src/DataFixtures/ORM/LoadSubscriptionTypeData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\SubscriptionType;
 use App\Subscription\SubscriptionTypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadSubscriptionTypeData extends Fixture
+class LoadSubscriptionTypeData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadTeamData.php
+++ b/src/DataFixtures/ORM/LoadTeamData.php
@@ -6,12 +6,11 @@ use App\Entity\Adherent;
 use App\Entity\Team\Member;
 use App\Entity\Team\Team;
 use App\Team\TypeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadTeamData extends Fixture implements DependentFixtureInterface
+class LoadTeamData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const TEAM_1_UUID = '3deeb1f5-819e-4629-85a1-eb75c916ce2f';
     public const TEAM_2_UUID = '6434f2ac-edd0-412a-9c4b-99ab4b039146';

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilAdherentMandateData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilAdherentMandateData.php
@@ -6,11 +6,10 @@ use App\Entity\AdherentMandate\TerritorialCouncilAdherentMandate;
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQualityEnum;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilAdherentMandateData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilAdherentMandateData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilCandidacyData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilCandidacyData.php
@@ -8,12 +8,11 @@ use App\Entity\TerritorialCouncil\CandidacyInvitation;
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQualityEnum;
 use App\Image\ImageManager;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class LoadTerritorialCouncilCandidacyData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilCandidacyData extends AbstractFixtures implements DependentFixtureInterface
 {
     private $imageManager;
 

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\Repository\ReferentTagRepository;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const NAME_CORSE = 'Conseil territorial de la Corse';
 

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilElectionData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilElectionData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Entity\TerritorialCouncil\Election;
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\TerritorialCouncil\Designation\DesignationVoteModeEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilElectionData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilElectionData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilElectionPollData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilElectionPollData.php
@@ -7,11 +7,10 @@ use App\Entity\TerritorialCouncil\ElectionPoll\Poll;
 use App\Entity\TerritorialCouncil\ElectionPoll\PollChoice;
 use App\Entity\TerritorialCouncil\ElectionPoll\Vote;
 use App\ValueObject\Genders;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilElectionPollData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilElectionPollData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilFeedItemData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilFeedItemData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\Entity\TerritorialCouncil\TerritorialCouncilFeedItem;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilFeedItemData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilFeedItemData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilMembershipData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilMembershipData.php
@@ -6,12 +6,11 @@ use App\Entity\TerritorialCouncil\TerritorialCouncil;
 use App\Entity\TerritorialCouncil\TerritorialCouncilMembership;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQuality;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQualityEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadTerritorialCouncilMembershipData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilMembershipData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const MEMBERSHIP_UUID1 = 'ad3780fe-d607-4d01-bc1a-d537fe351908';
 

--- a/src/DataFixtures/ORM/LoadTerritorialCouncilMembershipLogData.php
+++ b/src/DataFixtures/ORM/LoadTerritorialCouncilMembershipLogData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\TerritorialCouncil\TerritorialCouncilMembershipLog;
 use App\Entity\TerritorialCouncil\TerritorialCouncilQualityEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTerritorialCouncilMembershipLogData extends Fixture implements DependentFixtureInterface
+class LoadTerritorialCouncilMembershipLogData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadThematicCommunityContactData.php
+++ b/src/DataFixtures/ORM/LoadThematicCommunityContactData.php
@@ -7,10 +7,9 @@ use App\Entity\JobEnum;
 use App\Entity\ThematicCommunity\Contact;
 use App\Jecoute\GenderEnum;
 use App\Utils\PhoneNumberUtils;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadThematicCommunityContactData extends Fixture
+class LoadThematicCommunityContactData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadThematicCommunityData.php
+++ b/src/DataFixtures/ORM/LoadThematicCommunityData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ThematicCommunity\ThematicCommunity;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadThematicCommunityData extends Fixture
+class LoadThematicCommunityData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadThematicCommunityMembershipData.php
+++ b/src/DataFixtures/ORM/LoadThematicCommunityMembershipData.php
@@ -5,12 +5,11 @@ namespace App\DataFixtures\ORM;
 use App\Entity\ThematicCommunity\AdherentMembership;
 use App\Entity\ThematicCommunity\ContactMembership;
 use App\Entity\ThematicCommunity\ThematicCommunityMembership;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadThematicCommunityMembershipData extends Fixture implements DependentFixtureInterface
+class LoadThematicCommunityMembershipData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const MEMBERSHIP_UUID_1 = 'b168d99c-f3ff-4701-948f-be180c8d2af6';
     private const MEMBERSHIP_UUID_2 = '2420524f-f52e-46af-a945-327c48788d37';

--- a/src/DataFixtures/ORM/LoadTimelineData.php
+++ b/src/DataFixtures/ORM/LoadTimelineData.php
@@ -6,10 +6,9 @@ use App\Entity\Timeline\Manifesto;
 use App\Entity\Timeline\Measure;
 use App\Entity\Timeline\Profile;
 use App\Entity\Timeline\Theme;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadTimelineData extends Fixture
+class LoadTimelineData extends AbstractFixtures
 {
     public const PROFILES = [
         'TP001' => [

--- a/src/DataFixtures/ORM/LoadTonMacronData.php
+++ b/src/DataFixtures/ORM/LoadTonMacronData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\TonMacronChoice;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadTonMacronData extends Fixture
+class LoadTonMacronData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadUserData.php
+++ b/src/DataFixtures/ORM/LoadUserData.php
@@ -7,10 +7,9 @@ use App\Entity\AdherentActivationToken;
 use App\Entity\AdherentResetPasswordToken;
 use App\Entity\PostAddress;
 use App\Membership\AdherentFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadUserData extends Fixture
+class LoadUserData extends AbstractFixtures
 {
     public const USER_1_UUID = '313bd28f-efc8-57c9-8ab7-2106c8be9699';
     public const USER_2_UUID = '413bd28f-57c9-efc8-8ab7-2106c8be9690';

--- a/src/DataFixtures/ORM/LoadUserDocumentData.php
+++ b/src/DataFixtures/ORM/LoadUserDocumentData.php
@@ -3,11 +3,10 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\UserDocument;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Ramsey\Uuid\Uuid;
 
-class LoadUserDocumentData extends Fixture
+class LoadUserDocumentData extends AbstractFixtures
 {
     public const USER_DOCUMENT_1_UUID = '5f279d90-712c-4335-a83b-a82851b43dfe';
     public const USER_DOCUMENT_2_UUID = 'd2abac78-6004-41cd-a88d-e3e1e83a6f65';

--- a/src/DataFixtures/ORM/LoadUserListDefinitionData.php
+++ b/src/DataFixtures/ORM/LoadUserListDefinitionData.php
@@ -4,10 +4,9 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\UserListDefinition;
 use App\Entity\UserListDefinitionEnum;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadUserListDefinitionData extends Fixture
+class LoadUserListDefinitionData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadVotePlaceData.php
+++ b/src/DataFixtures/ORM/LoadVotePlaceData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\VotePlace\VotePlaceFactory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadVotePlaceData extends Fixture
+class LoadVotePlaceData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadVotePlaceResultData.php
+++ b/src/DataFixtures/ORM/LoadVotePlaceResultData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Entity\Election\VotePlaceResult;
 use App\Entity\ElectionRound;
 use App\Entity\VotePlace;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadVotePlaceResultData extends Fixture implements DependentFixtureInterface
+class LoadVotePlaceResultData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/src/DataFixtures/ORM/LoadVoteResultListCollectionData.php
+++ b/src/DataFixtures/ORM/LoadVoteResultListCollectionData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\Entity\Election\VoteResultList;
 use App\Entity\Election\VoteResultListCollection;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadVoteResultListCollectionData extends Fixture implements DependentFixtureInterface
+class LoadVoteResultListCollectionData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadVotingPlatformElectionData.php
+++ b/src/DataFixtures/ORM/LoadVotingPlatformElectionData.php
@@ -21,13 +21,12 @@ use App\Entity\VotingPlatform\VotersList;
 use App\ValueObject\Genders;
 use App\VotingPlatform\Designation\MajorityVoteMentionEnum;
 use App\VotingPlatform\Election\ResultCalculator;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use Ramsey\Uuid\Uuid;
 
-class LoadVotingPlatformElectionData extends Fixture implements DependentFixtureInterface
+class LoadVotingPlatformElectionData extends AbstractFixtures implements DependentFixtureInterface
 {
     public const ELECTION_UUID1 = 'd678c30a-a94b-4ecf-8cfc-0e06d1fb16df';
     public const ELECTION_UUID2 = '278ec098-e5f2-45e3-9faf-a9b2cb9305fd';

--- a/src/DataFixtures/ORM/LoadWebHookData.php
+++ b/src/DataFixtures/ORM/LoadWebHookData.php
@@ -5,11 +5,10 @@ namespace App\DataFixtures\ORM;
 use App\Entity\WebHook\WebHook;
 use App\WebHook\Event;
 use App\WebHook\Service;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadWebHookData extends Fixture implements DependentFixtureInterface
+class LoadWebHookData extends AbstractFixtures implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadZoneCategoryData.php
+++ b/src/DataFixtures/ORM/LoadZoneCategoryData.php
@@ -3,10 +3,9 @@
 namespace App\DataFixtures\ORM;
 
 use App\Entity\ElectedRepresentative\ZoneCategory;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadZoneCategoryData extends Fixture
+class LoadZoneCategoryData extends AbstractFixtures
 {
     public function load(ObjectManager $manager)
     {

--- a/src/DataFixtures/ORM/LoadZoneData.php
+++ b/src/DataFixtures/ORM/LoadZoneData.php
@@ -4,11 +4,10 @@ namespace App\DataFixtures\ORM;
 
 use App\DataFixtures\AutoIncrementResetter;
 use App\Entity\ElectedRepresentative\Zone;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class LoadZoneData extends Fixture implements DependentFixtureInterface
+class LoadZoneData extends AbstractFixtures implements DependentFixtureInterface
 {
     private const CITIES = [
         '06000' => 'Nice (06000,06100,06200,06300)',

--- a/src/DataFixturesPgsql/AbstractPgsqlFixtures.php
+++ b/src/DataFixturesPgsql/AbstractPgsqlFixtures.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\DataFixturesPgsql;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+
+abstract class AbstractPgsqlFixtures extends Fixture implements FixtureGroupInterface
+{
+    public static function getGroups(): array
+    {
+        return ['pgsql'];
+    }
+}

--- a/src/DataFixturesPgsql/AddressFixtures.php
+++ b/src/DataFixturesPgsql/AddressFixtures.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\DataFixturesPgsql;
+
+use App\EntityPgsql\Address;
+use Doctrine\Persistence\ObjectManager;
+
+class AddressFixtures extends AbstractPgsqlFixtures
+{
+    public function load(ObjectManager $manager)
+    {
+        $manager->persist($this->create('2', 'Rue de la Paix'));
+        $manager->persist($this->create('2 bis', 'Rue de la Paix'));
+
+        $manager->flush();
+    }
+
+    private function create(string $number, string $street): Address
+    {
+        $address = new Address();
+        $address->setNumber($number);
+        $address->setStreet($street);
+
+        return $address;
+    }
+}

--- a/src/EntityPgsql/Address.php
+++ b/src/EntityPgsql/Address.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\EntityPgsql;
+
+use App\EntityPgsql\Traits\IdTrait;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Address
+{
+    use IdTrait;
+
+    /**
+     * @ORM\Column
+     */
+    private ?string $number = null;
+
+    /**
+     * @ORM\Column
+     */
+    private ?string $street = null;
+
+    public function getNumber(): ?string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(?string $number): void
+    {
+        $this->number = $number;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): void
+    {
+        $this->street = $street;
+    }
+}

--- a/src/EntityPgsql/Traits/IdTrait.php
+++ b/src/EntityPgsql/Traits/IdTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\EntityPgsql\Traits;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait IdTrait
+{
+    /**
+     * @ORM\Column(type="bigint")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Notes:
- the **default** EntityManager handles entities in the `src/Entity `namespace only
- the **pgsql** EntityManager handles entites in the `src/EntityPgsql `namespace only
- commands regarding the databases now need additional arguments; check the **Makefile** for examples
- *default fixtures* now needs to extend `src/DataFixtures/ORM/AbstractFixtures` (or be tagged with the `default` fixtures group)
- *pgsql fixtures* needs to extend `src/DataFixturesPgsql/AbstractFixtures` (or be tagged with the `pgsql` fixtures group)
- new Behat step to handle *pgsql fixtures* has been added, check the `FixtureContext`
- the dummy entity`App\EntityPgsql\Address` has been created for the proof of concept only