### PR TITLE
Fix insee codes with leading zeros

### DIFF
--- a/src/Entity/ProcurationProxy.php
+++ b/src/Entity/ProcurationProxy.php
@@ -576,6 +576,9 @@ class ProcurationProxy implements RecaptchaChallengeInterface
 
         if ($cityCode && false !== strpos($cityCode, '-')) {
             list($postalCode, $inseeCode) = explode('-', $cityCode);
+            $inseeCode = str_pad($inseeCode, 5, '0', \STR_PAD_LEFT);
+
+            $this->city = "$postalCode-$inseeCode";
             $this->voteCityName = (string) FranceCitiesBundle::getCity($postalCode, $inseeCode);
         }
     }

--- a/src/Entity/ProcurationProxy.php
+++ b/src/Entity/ProcurationProxy.php
@@ -578,7 +578,7 @@ class ProcurationProxy implements RecaptchaChallengeInterface
             list($postalCode, $inseeCode) = explode('-', $cityCode);
             $inseeCode = str_pad($inseeCode, 5, '0', \STR_PAD_LEFT);
 
-            $this->city = "$postalCode-$inseeCode";
+            $this->voteCity = "$postalCode-$inseeCode";
             $this->voteCityName = (string) FranceCitiesBundle::getCity($postalCode, $inseeCode);
         }
     }

--- a/src/Entity/ProcurationRequest.php
+++ b/src/Entity/ProcurationRequest.php
@@ -566,6 +566,9 @@ class ProcurationRequest implements RecaptchaChallengeInterface
 
         if ($cityCode && false !== strpos($cityCode, '-')) {
             list($postalCode, $inseeCode) = explode('-', $cityCode);
+            $inseeCode = str_pad($inseeCode, 5, '0', \STR_PAD_LEFT);
+
+            $this->city = "$postalCode-$inseeCode";
             $this->voteCityName = (string) FranceCitiesBundle::getCity($postalCode, $inseeCode);
         }
     }

--- a/src/Entity/ProcurationRequest.php
+++ b/src/Entity/ProcurationRequest.php
@@ -568,7 +568,7 @@ class ProcurationRequest implements RecaptchaChallengeInterface
             list($postalCode, $inseeCode) = explode('-', $cityCode);
             $inseeCode = str_pad($inseeCode, 5, '0', \STR_PAD_LEFT);
 
-            $this->city = "$postalCode-$inseeCode";
+            $this->voteCity = "$postalCode-$inseeCode";
             $this->voteCityName = (string) FranceCitiesBundle::getCity($postalCode, $inseeCode);
         }
     }


### PR DESCRIPTION
post-deploy :
```
UPDATE procuration_requests
SET vote_city_insee = REPLACE(vote_city_insee, '-', '-0')
WHERE LENGTH(
	SUBSTR(
		vote_city_insee,
		POSITION('-' IN vote_city_insee) + 1,
		5
	)
) = 4
;

UPDATE procuration_proxies
SET vote_city_insee = REPLACE(vote_city_insee, '-', '-0')
WHERE LENGTH(
	SUBSTR(
		vote_city_insee,
		POSITION('-' IN vote_city_insee) + 1,
		5
	)
) = 4
;
```
